### PR TITLE
p7zip: Add patch for CVE 2016-9296

### DIFF
--- a/build/p7zip/patches/CVE-2016-9296.patch
+++ b/build/p7zip/patches/CVE-2016-9296.patch
@@ -1,0 +1,12 @@
+--- p7zip_16.02.distrib/CPP/7zip/Archive/7z/7zIn.cpp	Fri May 20 08:20:03 2016
++++ p7zip_16.02/CPP/7zip/Archive/7z/7zIn.cpp	Wed Jun 14 08:01:01 2017
+@@ -1097,7 +1097,8 @@
+       if (CrcCalc(data, unpackSize) != folders.FolderCRCs.Vals[i])
+         ThrowIncorrect();
+   }
+-  HeadersSize += folders.PackPositions[folders.NumPackStreams];
++  if (folders.PackPositions)
++    HeadersSize += folders.PackPositions[folders.NumPackStreams];
+   return S_OK;
+ }
+ 

--- a/build/p7zip/patches/series
+++ b/build/p7zip/patches/series
@@ -1,2 +1,3 @@
 makefile.patch
 bash.patch -p0
+CVE-2016-9296.patch -p1


### PR DESCRIPTION
This adds a patch for CVE 2016-9296 to p7zip. The same patch is already present in OI.