### PR TITLE
openssl: update to 1.0.2l

### DIFF
--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=openssl
-VER=1.0.2k
+VER=1.0.2l
 VERHUMAN=$VER
 PKG=library/security/openssl # Package name (without prefix)
 SUMMARY="$PROG - A toolkit for Secure Sockets Layer (SSL v2/v3) and Transport Layer (TLS v1) protocols and general purpose cryptographic library"


### PR DESCRIPTION
No security changes in this version but keeping openssl up-to-date in stable makes this a good candidate for backporting.