### PR TITLE
Replace references to OmniTI code repositories

### DIFF
--- a/build/g11n/build.sh
+++ b/build/g11n/build.sh
@@ -43,7 +43,7 @@ VER=$PVER
 BUILDNUM=$RELVER
 if [[ -z "$PKGPUBLISHER" ]]; then
     logerr "No PKGPUBLISHER specified in config.sh"
-    exit # Force it, we're fucked here.
+    exit
 fi
 
 GIT=/usr/bin/git
@@ -58,7 +58,7 @@ clone_source(){
     logcmd mkdir -p $TMPDIR/$BUILDDIR
     pushd $TMPDIR/$BUILDDIR > /dev/null 
     if [[ ! -d g11n ]]; then
-        logcmd  $GIT clone -b omni anon@src.omniti.com:~omnios/core/g11n
+        logcmd  $GIT clone -b omni https://github.com/omniosorg/g11n.git
     fi
     logcmd  cd g11n || logerr "g11n inaccessible"
     SRC=$TMPDIR/$BUILDDIR/g11n

--- a/build/gcc44/build.sh
+++ b/build/gcc44/build.sh
@@ -32,8 +32,8 @@ VER=4.4.4
 #
 # The ILLUMOSVER is the suffix of the tag gcc-4.4.4-<ILLUMOSVER>.
 # It takes the form "il-N" for some number N.  These are announced to the
-# illumos developer's list, and it is expected that OmniTI will keep a
-# copy at mirrors.omniti.com, or local maintainers keep it whereever they
+# illumos developer's list, and it is expected that OmniOSce will keep a
+# copy at mirrors.omniosce.org, or local maintainers keep it whereever they
 # keep their local mirrors.
 #
 ILLUMOSVER=il-4

--- a/build/illumos/build.sh
+++ b/build/illumos/build.sh
@@ -57,8 +57,7 @@ CODEMGR_WS=$TMPDIR/$BUILDDIR/illumos-omnios
 #Since these variables are used in a sed statment make sure to escape properly
 ILLUMOS_NO="NIGHTLY\_OPTIONS=\'\-nDCmpr\'"
 ILLUMOS_CODEMGR_WS="CODEMGR\_WS=/code/$BUILDDIR/illumos\-omnios"
-#ILLUMOS_CLONE_WS="CLONE\_WS=\'ssh://anonhg@hg.illumos.org/illumos\-gate\'"
-ILLUMOS_CLONE_WS="CLONE\_WS=\'anon@src.omniti.com:~omnios/core/illumos\-omnios\'"
+ILLUMOS_CLONE_WS="CLONE\_WS=\'https:\/\/github.com\/omniosorg/illumos\-omnios'"
 
 ILLUMOS_PKG_REDIST="PKGPUBLISHER\_REDIST=\'omnios\'"
 
@@ -94,7 +93,7 @@ clone_source(){
         logmsg "OMNI Illumos Source in place. Using existing workspace."
     else
         logmsg "Cloning OMNI Illumos Source..."
-        logcmd  $GIT clone anon@src.omniti.com:~omnios/core/illumos-omnios || \
+        logcmd  $GIT clone https://github.com/omniosorg/illumos-omnios.git || \
             logerr "--- Failed to clone source"
     fi
     pushd illumos-omnios 
@@ -152,7 +151,7 @@ closed_bins() {
     logmsg "Getting Closed Source Bins..."
     for bin in on-closed-bins.i386.tar.bz2 on-closed-bins-nd.i386.tar.bz2 ; do
 	if [[ ! -f $bin ]]; then
-            logcmd curl -s -O http://mirrors.omniti.com/illumos-gate/$bin
+            logcmd curl -s -O $MIRROR/illumos-gate/$bin
 	fi
     	logcmd tar xvpf $bin
     done

--- a/build/kayak-kernel/build.sh
+++ b/build/kayak-kernel/build.sh
@@ -84,7 +84,7 @@ clone_source() {
         logmsg "--- old checkout found, removing it."
         logcmd rm -rf kayak
     fi
-    logcmd $GIT clone https://github.com/omniti-labs/kayak
+    logcmd $GIT clone https://github.com/omniosorg/kayak
     pushd kayak > /dev/null
     logcmd $GIT checkout r$RELVER || logmsg "No r$RELVER branch, using master."
     GITREV=`$GIT log -1  --format=format:%at`

--- a/build/kayak/build.sh
+++ b/build/kayak/build.sh
@@ -39,7 +39,7 @@ clone_source() {
         logmsg "--- old checkout found, removing it."
         logcmd rm -rf kayak
     fi
-    logcmd $GIT clone https://github.com/omniti-labs/kayak
+    logcmd $GIT clone https://github.com/omniosorg/kayak
     pushd kayak > /dev/null
     logcmd $GIT checkout r$RELVER || logmsg "No r$RELVER branch, using master."
     GITREV=`$GIT log -1  --format=format:%at`

--- a/build/pci.ids/build.sh
+++ b/build/pci.ids/build.sh
@@ -33,7 +33,7 @@ FORMAT=2.2
 PCIIDS_PATH=usr/src/data/hwdata/${PROG}
 LOCAL_PCIIDS=${PREBUILT_ILLUMOS}/${PCIIDS_PATH}
 BRANCH=$(git branch | fgrep \* | awk '{print $2}')
-GITHUB_PREFIX=https://github.com/omniti-labs/illumos-omnios/raw
+GITHUB_PREFIX=https://github.com/omniosorg/illumos-omnios/raw
 GITHUB_PCIIDS=${GITHUB_PREFIX}/${BRANCH}/${PCIIDS_PATH}
 
 # We should grab the pci.ids from $PREBUILT_ILLUMOS so we match the illumos

--- a/build/perl/build.sh
+++ b/build/perl/build.sh
@@ -65,7 +65,7 @@ PERL_BUILD_OPTS_COMMON="-des \
         -Umydomain \
         -Umyuname \
         -Dcf_by=omnios-builder \
-        -Dcf_email=omnios-builder@omniti.com \
+        -Dcf_email=omnios-builder@omniosce.org \
         -Dcc=gcc \
         -Dld=/usr/ccs/bin/ld \
         -Doptimize=-O3"

--- a/build/pkg/build.sh
+++ b/build/pkg/build.sh
@@ -39,7 +39,7 @@ VER=omni
 BUILDNUM=$RELVER
 if [[ -z "$PKGPUBLISHER" ]]; then
     logerr "No PKGPUBLISHER specified. Check lib/site.sh?"
-    exit # Force it, we're fucked here.
+    exit
 fi
 
 GIT=/usr/bin/git
@@ -67,7 +67,7 @@ crib_headers(){
 }
 
 # Respect an environmental override on this, for development's sake.
-PKG_SOURCE_REPO=${PKG_SOURCE_REPO:-https://github.com/omniti-labs/pkg5}
+PKG_SOURCE_REPO=${PKG_SOURCE_REPO:-https://github.com/omniosorg/pkg5}
 
 clone_source(){
     logmsg "pkg -> $TMPDIR/$BUILDDIR/pkg"

--- a/build/studio/sunstudio12.1.p5m
+++ b/build/studio/sunstudio12.1.p5m
@@ -1,7 +1,7 @@
 set name=pkg.fmri value=pkg://@PKGPUBLISHER@/developer/sunstudio12.1@12.1,5.11-@PVER@:20110928T020752Z
 set name=pkg.summary value="sunstudio - Sun Studio"
 set name=pkg.descr value="sunstudio - Sun Studio (12.1)"
-set name=publisher value=sa@omniti.com
+set name=publisher value=sa@omniosce.org
 dir  path=opt/sunstudio12.1 owner=root group=bin mode=0755
 dir  path=opt/sunstudio12.1/LEGAL owner=root group=bin mode=0755
 file opt/sunstudio12.1/LEGAL/Copyright.html path=opt/sunstudio12.1/LEGAL/Copyright.html owner=root group=bin mode=0644

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -33,7 +33,7 @@ PVER=0.$RELVER
 
 # Which server to fetch files from.
 # If $MIRROR begins with a '/', it is treated as a local directory.
-MIRROR=mirrors.omniosce.org
+MIRROR=https://mirrors.omniosce.org
 
 # Default prefix for packages (may be overridden)
 PREFIX=/usr

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -33,7 +33,7 @@ PVER=0.$RELVER
 
 # Which server to fetch files from.
 # If $MIRROR begins with a '/', it is treated as a local directory.
-MIRROR=mirrors.omniti.com
+MIRROR=mirrors.omniosce.org
 
 # Default prefix for packages (may be overridden)
 PREFIX=/usr

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -505,7 +505,7 @@ get_resource() {
 #
 # E.g.
 #       download_source myprog myprog 1.2.3 will try:
-#       http://mirrors.omniti.com/myprog/myprog-1.2.3.tar.gz
+#       http://mirrors.omniosce.org/myprog/myprog-1.2.3.tar.gz
 download_source() {
     local DLDIR=$1
     local PROG=$2
@@ -680,7 +680,7 @@ make_package() {
     fi
     echo "set name=pkg.summary value=\"$SUMMARY\"" >> $MY_MOG_FILE
     echo "set name=pkg.descr value=\"$DESCSTR\"" >> $MY_MOG_FILE
-    echo "set name=publisher value=\"sa@omniti.com\"" >> $MY_MOG_FILE
+    echo "set name=publisher value=\"sa@omniosce.org\"" >> $MY_MOG_FILE
     if [[ -f $SRCDIR/local.mog ]]; then
         LOCAL_MOG_FILE=$SRCDIR/local.mog
     fi


### PR DESCRIPTION
This PR swaps in new omniosce code repositories for places where code is currently pulled directly from OmniTI servers or their Github area.
It also updates the default for package publishers