### PR TITLE
Skip pkglint for gcc51/gmp

### DIFF
--- a/build/gcc51/build-libgmp.sh
+++ b/build/gcc51/build-libgmp.sh
@@ -61,5 +61,5 @@ download_source $PROG $PROG $VER
 prep_build
 build
 make_isa_stub
-make_package libgmp.mog
+SKIP_PKGLINT=1 make_package libgmp.mog
 clean_up


### PR DESCRIPTION
See https://github.com/omniosorg/omnios-build/issues/10

pkglint fails for this package due to a duplicate dependency. This is a workaround for now but I'll leave the issue open to try and fix the underlying cause.