### PR TITLE
Allow skipping the kayak-kernel package build

### DIFF
--- a/build/kayak-kernel/build.sh
+++ b/build/kayak-kernel/build.sh
@@ -23,6 +23,11 @@ KAYAK_CLOBBER=${KAYAK_CLOBBER:=0}
 # Load support functions
 . ../../lib/functions.sh
 
+if [ -n "$SKIP_KAYAK_KERNEL" ]; then
+    logmsg "Skipping kayak-kernel build"
+    exit 0
+fi
+
 # Reality check.
 if [[ "$UID" == 0 ]]; then
     SUDO=""
@@ -31,7 +36,7 @@ elif [[ ! -z $KAYAK_SUDO_BUILD ]]; then
     SUDO="sudo -n"
     OLDUSER=`whoami`
 else
-    logerr "--- You must be root or set KAYAK_SUDO_BUILD and have no-password sudo enabled"
+    logerr "--- You must be root or set KAYAK_SUDO_BUILD, and be in the global zone"
     logmsg "Proceeding as if KAYAK_SUDO_BUILD was set to 1."
     KAYAK_SUDO_BUILD=1
     SUDO="sudo -n"


### PR DESCRIPTION
Building the `kayak-kernel` package has a number of pre-requisites.

* The build must be performed in the global zone;
* The build must be done by root or a by a user with non-password `sudo` rights.

This change allows setting the SKIP_KAYAK_KERNEL environment variable (possibly in `site.sh`) to skip attempting to build this package which is useful if performing test builds in a zone.