### PR TITLE
Build in deterministic order and show more progress information

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -243,10 +243,11 @@ case "$1" in
 		batch_flag="-b"
 
 		mapfile -d '' sorted < \
-		    <( printf '%s\n' ${!fulltargets[@]} | sort)
+		    <( printf '%s\n' ${!fulltargets[@]} | sort | \
+		       grep -v kayak-kernel)
 		pkgcount=${#fulltargets[@]}
 		pkgnum=0
-		for tgt in ${sorted[@]}; do
+		for tgt in ${sorted[@]} system/install/kayak-kernel; do
 			((pkgnum = pkgnum + 1))
                         # Uncomment the echo line if you want to see a
                         # one-package-per-line status of what's building in

--- a/build/buildctl
+++ b/build/buildctl
@@ -241,11 +241,21 @@ case "$1" in
 	tobuild=$*
 	if [ -z "$tobuild" ] || [ "$tobuild" == "all" ]; then
 		batch_flag="-b"
-		for tgt in "${!fulltargets[@]}"; do
+
+		mapfile -d '' sorted < \
+		    <( printf '%s\n' ${!fulltargets[@]} | sort)
+		pkgcount=${#fulltargets[@]}
+		pkgnum=0
+		for tgt in ${sorted[@]}; do
+			((pkgnum = pkgnum + 1))
                         # Uncomment the echo line if you want to see a
                         # one-package-per-line status of what's building in
                         # /tmp/debug.<PID>.
                         # echo "Target = $tgt" >> /tmp/debug.$$
+			echo "\n"
+			echo "***********"
+			echo "*********** ($pkgnum/$pkgcount) Building $tgt"
+			echo "***********\n"
 			build $tgt
 		done
 	else


### PR DESCRIPTION
At present, running an entire OmniOS build via `buildctl build all` builds the packages in effectively a random order as it iterates the keys in an associative bash array.

This PR changes that so that builds are done in alphabetical order and also adds extra output showing which package number is being built alongside the total:

```
***********
*********** (17/199) Building developer/gcc44
***********

===== Build started at Sat Jul  8 08:20:45 UTC 2017 =====
Package name: developer/gcc44
Selected flavor: None (use -f to specify a flavor)
```