### PR TITLE
Omnios build tools

### DIFF
--- a/build/omnios-build-tools/omnios-build-tools.p5m
+++ b/build/omnios-build-tools/omnios-build-tools.p5m
@@ -2,12 +2,15 @@ set name=pkg.fmri value=pkg://@PKGPUBLISHER@/developer/omnios-build-tools@11,5.1
 set name=pkg.depend.install-hold value=core-os.omnios
 set name=pkg.summary value="Single meta-package containing required tools to build omnios."
 set name=pkg.description value="Single meta-package containing required tools to build omnios."
+
 depend fmri=archiver/gnu-tar type=require
 depend fmri=compatibility/ucb type=require
 depend fmri=compress/xz type=require
 depend fmri=developer/build/autoconf type=require
 depend fmri=developer/build/automake type=require
+depend fmri=developer/build/gnu-make type=require
 depend fmri=developer/build/libtool type=require
+depend fmri=developer/dtrace type=require
 depend fmri=developer/illumos-tools type=require
 depend fmri=developer/lexer/flex type=require
 depend fmri=developer/macro/gnu-m4 type=require
@@ -18,16 +21,29 @@ depend fmri=developer/versioning/git type=require
 depend fmri=developer/versioning/mercurial type=require
 depend fmri=driver/ipmi type=require
 depend fmri=file/gnu-coreutils type=require
+depend fmri=library/expat type=require
+depend fmri=library/glib2 type=require
+depend fmri=library/gmp type=require
 depend fmri=library/idnkit type=require
+depend fmri=library/libffi type=require
+depend fmri=library/libidn type=require
 depend fmri=library/nspr/header-nspr type=require
+depend fmri=library/security/openssl type=require
+depend fmri=library/security/opensslweb/ca-bundle type=require
+depend fmri=library/zlib type=require
 depend fmri=network/rsync type=require
 depend fmri=runtime/java type=require
 depend fmri=runtime/perl type=require
 depend fmri=runtime/perl-64 type=require
 depend fmri=runtime/perl/manual type=require
 depend fmri=runtime/python-27 type=require
+depend fmri=service/network/tftp type=require
 depend fmri=sunstudio12.1 type=require
 depend fmri=swig type=require
 depend fmri=system/header/header-audio type=require
+depend fmri=system/library type=require
+depend fmri=system/library/gcc-5-runtime type=require
+depend fmri=system/library/math type=require
 depend fmri=system/zones/internal type=require
 depend fmri=text/gnu-sed type=require
+

--- a/build/omnios-build-tools/omnios-build-tools.p5m
+++ b/build/omnios-build-tools/omnios-build-tools.p5m
@@ -1,0 +1,33 @@
+set name=pkg.fmri value=pkg://@PKGPUBLISHER@/developer/omnios-build-tools@11,5.11-@PVER@
+set name=pkg.depend.install-hold value=core-os.omnios
+set name=pkg.summary value="Single meta-package containing required tools to build omnios."
+set name=pkg.description value="Single meta-package containing required tools to build omnios."
+depend fmri=archiver/gnu-tar type=require
+depend fmri=compatibility/ucb type=require
+depend fmri=compress/xz type=require
+depend fmri=developer/build/autoconf type=require
+depend fmri=developer/build/automake type=require
+depend fmri=developer/build/libtool type=require
+depend fmri=developer/illumos-tools type=require
+depend fmri=developer/lexer/flex type=require
+depend fmri=developer/macro/gnu-m4 type=require
+depend fmri=developer/parser/bison type=require
+depend fmri=developer/pkg-config type=require
+depend fmri=developer/sunstudio12.1 type=require
+depend fmri=developer/versioning/git type=require
+depend fmri=developer/versioning/mercurial type=require
+depend fmri=driver/ipmi type=require
+depend fmri=file/gnu-coreutils type=require
+depend fmri=library/idnkit type=require
+depend fmri=library/nspr/header-nspr type=require
+depend fmri=network/rsync type=require
+depend fmri=runtime/java type=require
+depend fmri=runtime/perl type=require
+depend fmri=runtime/perl-64 type=require
+depend fmri=runtime/perl/manual type=require
+depend fmri=runtime/python-27 type=require
+depend fmri=sunstudio12.1 type=require
+depend fmri=swig type=require
+depend fmri=system/header/header-audio type=require
+depend fmri=system/zones/internal type=require
+depend fmri=text/gnu-sed type=require

--- a/tools/omnios-build-deps.sh
+++ b/tools/omnios-build-deps.sh
@@ -11,8 +11,8 @@ if [ ! -x "$dir/buildctl" ]; then
 	exit 1
 fi
 
-find $dir -type f -name \*build\*.sh -exec grep -h BUILD_DEPENDS_IPS {} + | \
-    sed -n '
+find $dir -type f -name \*build\*.sh \
+    -exec ggrep -A1 -h BUILD_DEPENDS_IPS {} + | sed -n '
 	/=/ {
 		# Remove quotes
 		s/["'"'"']//g
@@ -22,6 +22,8 @@ find $dir -type f -name \*build\*.sh -exec grep -h BUILD_DEPENDS_IPS {} + | \
 		s/\$[^ ]* *//g
 		# Remove comments
 		s/^ *#.*//
+		# Remove specific versions
+		s/@[^ ]* *//
 		# Swap whitespace for = (tr will switch to newline)
 		s/  */=/g
 		# Skip lines now blank
@@ -29,7 +31,10 @@ find $dir -type f -name \*build\*.sh -exec grep -h BUILD_DEPENDS_IPS {} + | \
 		p
 	}
 ' | tr '=' '\n' | sort | uniq | sed '
+	/^\//d
+	/SUNWcs/d
 	/^gcc[0-9]*$/d
+	/^[0-9]/d
 	/^auto/d
 	/^omniti/d
 	/^developer\/gcc44/d

--- a/tools/omnios-build-deps.sh
+++ b/tools/omnios-build-deps.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This script generates a list of the dependencies for a full OmniOS
+# build which can be used to update the omnios-build-tools meta package
+# manifest.
+
+dir=${1:-build}
+
+if [ ! -x "$dir/buildctl" ]; then
+	echo "Syntax: $0 <path to omnios-build tree>"
+	exit 1
+fi
+
+find $dir -type f -name \*build\*.sh -exec grep -h BUILD_DEPENDS_IPS {} + | \
+    sed -n '
+	/=/ {
+		# Remove quotes
+		s/["'"'"']//g
+		# Remove initial variable name
+		s/.*=//
+		# Remove variables from RHS
+		s/\$[^ ]* *//g
+		# Remove comments
+		s/^ *#.*//
+		# Swap whitespace for = (tr will switch to newline)
+		s/  */=/g
+		# Skip lines now blank
+		/^$/d
+		p
+	}
+' | tr '=' '\n' | sort | uniq | sed '
+	/^gcc[0-9]*$/d
+	/^auto/d
+	/^omniti/d
+	/^developer\/gcc44/d
+	s/.*/depend fmri=& type=require/
+'
+


### PR DESCRIPTION
This PR adds a new meta package, similar to `illumos-tools`, that makes it easy to install of the dependencies required for building `omnios-build`.
