### PR TITLE
Use better method for libffi version retrieval

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -65,9 +65,7 @@ NOSCRIPTSTUB=
 #############################################################################
 
 # libffi --> use pkg(5) to determine what we're running:
-FFIVERS=`pkg list libffi | grep libffi | awk '{print $2}' | \
-	awk -F- '{print $1}'`
-
+FFIVERS=`pkg list -H libffi | awk '{print $(NF-1)}' | cut -d- -f1`
 
 #############################################################################
 # Perl stuff


### PR DESCRIPTION
The current method for retrieving the version of the installed libffi package fails if omnios is not the first publisher in the list since there's an extra column in the output showing the publisher name.

```
bloody% pkg publisher
PUBLISHER                   TYPE     STATUS P LOCATION
citrus                      origin   online F https://ips.example.com/
omnios                      origin   online F https://pkg.omniti.com/omnios/bloody/

bloody% pkg list libffi
NAME (PUBLISHER)                                  VERSION                    IFO
library/libffi (omnios)                           3.2.1-0.151023             i--
```
The updated method works regardless:

```
bloody% pkg list -H libffi | awk '{print $(NF-1)}' | cut -d- -f1
3.2.1
```
