### PR TITLE
Add some missing dependencies and fix line which had run-together

### DIFF
--- a/build/omnios-build-tools/omnios-build-tools.p5m
+++ b/build/omnios-build-tools/omnios-build-tools.p5m
@@ -3,12 +3,14 @@ set name=pkg.depend.install-hold value=core-os.omnios
 set name=pkg.summary value="Single meta-package containing required tools to build omnios."
 set name=pkg.description value="Single meta-package containing required tools to build omnios."
 
+depend fmri=developer/gcc51 type=require
+depend fmri=developer/gcc51/libgmp-gcc51 type=require
+depend fmri=developer/build/gnu-make type=require
 depend fmri=archiver/gnu-tar type=require
 depend fmri=compatibility/ucb type=require
 depend fmri=compress/xz type=require
 depend fmri=developer/build/autoconf type=require
 depend fmri=developer/build/automake type=require
-depend fmri=developer/build/gnu-make type=require
 depend fmri=developer/build/libtool type=require
 depend fmri=developer/dtrace type=require
 depend fmri=developer/illumos-tools type=require
@@ -29,7 +31,7 @@ depend fmri=library/libffi type=require
 depend fmri=library/libidn type=require
 depend fmri=library/nspr/header-nspr type=require
 depend fmri=library/security/openssl type=require
-depend fmri=library/security/opensslweb/ca-bundle type=require
+depend fmri=web/ca-bundle type=require
 depend fmri=library/zlib type=require
 depend fmri=network/rsync type=require
 depend fmri=runtime/java type=require
@@ -38,12 +40,14 @@ depend fmri=runtime/perl-64 type=require
 depend fmri=runtime/perl/manual type=require
 depend fmri=runtime/python-27 type=require
 depend fmri=service/network/tftp type=require
-depend fmri=sunstudio12.1 type=require
-depend fmri=swig type=require
+depend fmri=developer/swig type=require
 depend fmri=system/header/header-audio type=require
 depend fmri=system/library type=require
 depend fmri=system/library/gcc-5-runtime type=require
 depend fmri=system/library/math type=require
 depend fmri=system/zones/internal type=require
 depend fmri=text/gnu-sed type=require
+depend fmri=text/intltool type=require
+depend fmri=library/idnkit/header-idnkit type=require
+depend fmri=system/pciutils/pci.ids type=require
 


### PR DESCRIPTION
This is an update to the `omnios-build-tools` package to add some more dependencies for building `omnios-build` and to fix one line which had conflated openssl and ca-bundle