### PR TITLE
Disable lint for library/zlib

### DIFF
--- a/build/zlib/build.sh
+++ b/build/zlib/build.sh
@@ -61,6 +61,7 @@ move_libs() {
     popd>/dev/null
 }
 
+SKIP_PKGLINT=1
 init
 download_source $PROG $PROG $VER
 patch_source


### PR DESCRIPTION
Temporarily disable lint for `library/zlib` pending proper fix.

See: https://github.com/omniosorg/omnios-build/issues/46