### PR TITLE
Add options for resuming builds after fixing problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+built.cache
 build.log
 build.log.1
 tmp.repo/

--- a/build/buildctl
+++ b/build/buildctl
@@ -69,18 +69,34 @@ do
     done
 done
 
+: ${BUILT_CACHE:="`pwd`/built.cache"}
+
 usage() {
     echo $0
-    echo "    list [grep pattern]  (sorted alphabetically)"
+    echo "    list [grep pattern]       (sorted alphabetically)"
     echo "    list-build [grep pattern] (sorted in build order)"
-    echo "    licenses"
-    echo "    build <pkg> | all"
+    echo "    licenses                  (audit licenses)"
+    echo "    build <pkg>"
+    echo "    build all"
+    echo "    build continue            (continue interrupted build)"
+    echo "    build from <pkg>          (build <pkg> then those after)"
     exit
 }
 
 bail() {
     echo $*
     exit
+}
+
+# Dependencies are limited at the moment. The only thing that matters is
+# that kayak-kernel is built last. Build everything else in alphabetical
+# order.
+buildorder() {
+    mapfile -d '' sorted < <( printf '%s\n' ${!fulltargets[@]} | sort | \
+       grep -v kayak-kernel)
+    for target in ${sorted[@]} system/install/kayak-kernel; do
+        echo $target
+    done
 }
 
 list() {
@@ -97,8 +113,8 @@ list() {
 
 list_build() {
     PAT=${1-.}
-    for target in "${!fulltargets[@]}"
-    do
+
+    buildorder | while read target; do
         if [[ "$PAT" = "." ]]; then
             echo " * $target"
         elif [[ -n $(echo "$target" | grep "$PAT") ]]; then
@@ -107,21 +123,37 @@ list_build() {
     done
 }
 
+record_built() {
+	already_built+=([$1]=1)
+	echo $1 >> "$BUILT_CACHE"
+}
+
+clear_built() {
+    [ -f "$BUILT_CACHE" ] && rm -f "$BUILT_CACHE"
+}
+
+restore_built() {
+    [ -f "$BUILT_CACHE" ] || return
+    for pkg in `cat "$BUILT_CACHE"`; do
+        already_built+=([$pkg]=1)
+    done
+}
+
 built_packages_p5m() {
     for PKG in $(awk '/^set name=pkg.fmri/ {print $3;}' $1 | sed -e 's/value=//' -e 's/.*\/\/[^\/]*\///g' -e 's/@.*//')
     do
-	already_built+=([$PKG]=1)
+        record_built $PKG
     done
 }
 
 built_packages_sh() {
     for PKG in $(grep -v '##IGNORE##' $1 | sed -e 's/^ +//' -e 's/ +#.+//' -e 's/=/ /g' -e 's/^.+make_package/make_package/g' | awk '{if($1=="PKG"){PKG=$2; print $2;} if($1=="make_package"){print PKG"="$2;}}')
     do
-        if [ -n "`echo ${PKG} | grep '.='`" ] ; then
-	    echo "NOP" >/dev/null
-	else
-	    already_built+=([$PKG]=1)
-	fi
+        if [ -n "`echo ${PKG} | grep '.='`" ]; then
+            echo "NOP" >/dev/null
+        else
+            record_built $PKG
+        fi
     done
 }
 
@@ -238,21 +270,36 @@ case "$1" in
 
     build)
 	shift
-	tobuild=$*
+	tobuild="$*"
+
+    skipuntil=
+    if [ "$tobuild" = "continue" ]; then
+		tobuild=all
+        restore_built
+	elif [[ "$tobuild" = from\ * ]]; then
+		skipuntil=${tobuild#from }
+		tobuild=all
+        restore_built
+    elif [ -z "$tobuild" -o "$tobuild" = all ]; then
+        if [ -f "$BUILT_CACHE" -a -z "$BATCH" ]; then
+            ask_to_continue_ "" \
+              "Built package cache will be cleared, continue?" "y/n" "[yYnN]"
+            [ "$REPLY" == "y" -o "$REPLY" == "Y" ] || exit 1
+        fi
+        clear_built
+	fi
+
 	if [ -z "$tobuild" ] || [ "$tobuild" == "all" ]; then
 		batch_flag="-b"
 
-		mapfile -d '' sorted < \
-		    <( printf '%s\n' ${!fulltargets[@]} | sort | \
-		       grep -v kayak-kernel)
 		pkgcount=${#fulltargets[@]}
 		pkgnum=0
-		for tgt in ${sorted[@]} system/install/kayak-kernel; do
+        for tgt in `buildorder`; do
 			((pkgnum = pkgnum + 1))
-                        # Uncomment the echo line if you want to see a
-                        # one-package-per-line status of what's building in
-                        # /tmp/debug.<PID>.
-                        # echo "Target = $tgt" >> /tmp/debug.$$
+
+			[ -n "$skipuntil" -a "$skipuntil" != $tgt ] \
+			    && continue || skipuntil=
+
 			echo "\n"
 			echo "***********"
 			echo "*********** ($pkgnum/$pkgcount) Building $tgt"
@@ -272,3 +319,5 @@ case "$1" in
 	;;
 esac
 
+# Vim hints
+# vim:ts=4:sw=4:et:


### PR DESCRIPTION
This is a set of changes to `buildctl` to reduce the time needed to iteratively build OmniOS in the event that parts of the build fail and require fixing.

It adds some new options to the `buildctl` command:

```
./buildctl
    ...
    build continue            (continue interrupted build)
    build from <pkg>          (build <pkg> then those after)
```

and also will prompt if a full build is started when there is a cache file left over from a previous build, if not in batch mode.

Example, starting a full build and interrupting it after the first package has built.

```
% ./buildctl build all

***********
*********** (1/200) Building archiver/gnu-tar
***********

===== Build started at Thu Jul 13 10:56:32 UTC 2017 =====
--- Published archiver/gnu-tar@1.29,5.11-0.151023
Done.

***********
*********** (2/200) Building compress/bzip2
***********

===== Build started at Thu Jul 13 10:57:24 UTC 2017 =====
Package name: compress/bzip2
^C
zsh: interrupt  ./buildctl build all
```

Starting a new full build and being prompted to confirm that you want the cache to be thrown away:

```
% ./buildctl build all
Built package cache will be cleared, continue? (y/n) n
```

Starting a continuation build:

```
% ./buildctl build continue

***********
*********** (1/200) Building archiver/gnu-tar
***********

--- Package archiver/gnu-tar was already built.

***********
*********** (2/200) Building compress/bzip2
***********

===== Build started at Thu Jul 13 10:58:22 UTC 2017 =====
```

Building from `libary/zlib` onwards:

```
% ./buildctl build from library/zlib

***********
*********** (113/200) Building library/zlib
***********
```