### PR TITLE
screen: update to 4.6.1

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -361,7 +361,7 @@ depend fmri=system/xopen/xcu4@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones/brand/ipkg@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones/brand/lipkg@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones@0.5.11,5.11-@PVER@ type=require
-depend fmri=terminal/screen@4.5,5.11-@PVER@ type=require
+depend fmri=terminal/screen@4.6,5.11-@PVER@ type=require
 depend fmri=text/doctools@0.5.11,5.11-@PVER@ type=require
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=require
 depend fmri=text/gnu-diffutils@3.5,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -121,7 +121,7 @@ depend fmri=system/pciutils@3.5,5.11-@PVER@ type=incorporate
 depend fmri=system/pciutils/pci.ids@2.2,5.11-@PVER@ type=incorporate
 depend fmri=system/pkgtree@1,5.11-@PVER@ type=incorporate
 depend fmri=system/prerequisite/gnu@0.5.11,5.11-@PVER@ type=incorporate
-depend fmri=terminal/screen@4.5,5.11-@PVER@ type=incorporate
+depend fmri=terminal/screen@4.6,5.11-@PVER@ type=incorporate
 depend fmri=terminal/tmux@2.3,5.11-@PVER@ type=incorporate
 depend fmri=text/auto_ef@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=incorporate

--- a/build/screen/build.sh
+++ b/build/screen/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=screen
-VER=4.5.1
+VER=4.6.1
 PKG=terminal/screen
 SUMMARY="GNU Screen terminal multiplexer"
 DESC="$SUMMARY"

--- a/build/screen/patches/xnet-hack.patch
+++ b/build/screen/patches/xnet-hack.patch
@@ -1,10 +1,9 @@
-diff -ru screen-4.2.1-orig/socket.c screen-4.2.1/socket.c
---- screen-4.2.1-orig/socket.c	Sat Apr 26 12:22:43 2014
-+++ screen-4.2.1/socket.c	Wed Aug 13 17:39:58 2014
-@@ -31,7 +31,9 @@
+--- screen-4.6.1/socket.c	Mon Jul 10 19:26:25 2017
++++ screen-4.6.1.patched/socket.c	Sat Jul 15 20:03:50 2017
+@@ -33,7 +33,9 @@
+ #include <sys/types.h>
  #include <sys/stat.h>
  #include <fcntl.h>
- #if !defined(NAMEDPIPE)
 +#define _XPG4_2
  # include <sys/socket.h>
 +#undef _XPG4_2


### PR DESCRIPTION
Closes issue https://github.com/omniosorg/omnios-build/issues/26

```
bloody% screen --version
Screen version 4.06.01 (GNU) 10-Jul-17
```
