### PR TITLE
gnu-grep: update to ggrep 3.1

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -366,7 +366,7 @@ depend fmri=text/doctools@0.5.11,5.11-@PVER@ type=require
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=require
 depend fmri=text/gnu-diffutils@3.5,5.11-@PVER@ type=require
 depend fmri=text/gnu-gettext@0.19.8,5.11-@PVER@ type=require
-depend fmri=text/gnu-grep@3.0,5.11-@PVER@ type=require
+depend fmri=text/gnu-grep@3.1,5.11-@PVER@ type=require
 depend fmri=text/gnu-patch@2.7,5.11-@PVER@ type=require
 depend fmri=text/gnu-sed@4.4,5.11-@PVER@ type=require
 depend fmri=text/groff@1.21,5.11-@PVER@ type=require

--- a/build/grep/build.sh
+++ b/build/grep/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=grep       # App name
-VER=3.0         # App version
+VER=3.1         # App version
 PKG=text/gnu-grep    # Package name (without prefix)
 SUMMARY="ggrep - GNU grep utilities"
 DESC="$SUMMARY $VER"

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -127,7 +127,7 @@ depend fmri=text/auto_ef@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-diffutils@3.5,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-gettext@0.19.8,5.11-@PVER@ type=incorporate
-depend fmri=text/gnu-grep@3.0,5.11-@PVER@ type=incorporate
+depend fmri=text/gnu-grep@3.1,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-patch@2.7,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-sed@4.4,5.11-@PVER@ type=incorporate
 depend fmri=text/groff@1.22.3,5.11-@PVER@ type=incorporate


### PR DESCRIPTION
```shell
hadfl@mars:~$ ggrep -V
ggrep (GNU grep) 3.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others, see <http://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.
```