### PR TITLE
gnu-diffutils: update to 3.6

### DIFF
--- a/build/diffutils/build.sh
+++ b/build/diffutils/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=diffutils
-VER=3.5
+VER=3.6
 PKG=text/gnu-diffutils
 SUMMARY="GNU diffutils - Finds differences between and among files"
 DESC="$SUMMARY"

--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -364,7 +364,7 @@ depend fmri=system/zones@0.5.11,5.11-@PVER@ type=require
 depend fmri=terminal/screen@4.6,5.11-@PVER@ type=require
 depend fmri=text/doctools@0.5.11,5.11-@PVER@ type=require
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=require
-depend fmri=text/gnu-diffutils@3.5,5.11-@PVER@ type=require
+depend fmri=text/gnu-diffutils@3.6,5.11-@PVER@ type=require
 depend fmri=text/gnu-gettext@0.19.8,5.11-@PVER@ type=require
 depend fmri=text/gnu-grep@3.1,5.11-@PVER@ type=require
 depend fmri=text/gnu-patch@2.7,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -125,7 +125,7 @@ depend fmri=terminal/screen@4.6,5.11-@PVER@ type=incorporate
 depend fmri=terminal/tmux@2.3,5.11-@PVER@ type=incorporate
 depend fmri=text/auto_ef@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=text/gawk@4.1,5.11-@PVER@ type=incorporate
-depend fmri=text/gnu-diffutils@3.5,5.11-@PVER@ type=incorporate
+depend fmri=text/gnu-diffutils@3.6,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-gettext@0.19.8,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-grep@3.1,5.11-@PVER@ type=incorporate
 depend fmri=text/gnu-patch@2.7,5.11-@PVER@ type=incorporate


### PR DESCRIPTION
```
hadfl@mars:~$ gdiff -v
diff (GNU diffutils) 3.6
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Paul Eggert, Mike Haertel, David Hayes,
Richard Stallman, and Len Tower.
```