### PR TITLE
mercurial: update to 4.2.2

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.1.3
+VER=4.2.2
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"


### PR DESCRIPTION
```
hadfl@mars:~$ hg version
Mercurial Distributed SCM (version 4.2.2)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2017 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
`hg clone` for `openjdk` source fetch successful.