### PR TITLE
pciutils: update to 3.5.5

### DIFF
--- a/build/pciutils/build.sh
+++ b/build/pciutils/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=pciutils
-VER=3.5.4
+VER=3.5.5
 VERHUMAN=$VER
 PKG=system/pciutils
 SUMMARY="Programs (lspci, setpci) for inspecting and manipulating configuration of PCI devices"

--- a/build/pciutils/local.mog
+++ b/build/pciutils/local.mog
@@ -23,5 +23,8 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+#
+# PCI IDs are delivered via system/pciutils/pci.ids
 <transform file path=usr/share/pci.ids.gz$ -> drop>
+<transform file path=.*update-pciids -> drop>
 license COPYING license=GPLv2

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -57,7 +57,7 @@
 | system/library/pcap			| 1.8.1			| http://www.tcpdump.org/#latest-releases
 | system/management/ipmitool		| 1.8.18		| https://sourceforge.net/projects/ipmitool/
 | system/management/snmp/net-snmp	| 5.7.3			| http://www.net-snmp.org/download.html
-| system/pciutils			| 3.5.4			| https://www.kernel.org/pub/software/utils/pciutils/
+| system/pciutils			| 3.5.5			| https://www.kernel.org/pub/software/utils/pciutils/
 | system/test/fio			| 2.12			| https://github.com/axboe/fio/releases
 | terminal/screen			| 4.6.1			| http://savannah.gnu.org/news/?group=screen
 | terminal/tmux				| 2.5			| https://github.com/tmux/tmux/releases


### PR DESCRIPTION
Update pciutils to version 3.5.5 and drop the `update-pciids` utility and man page from the package since the PCI IDs themselves are delivered by the `system/pciutils/pci.ids` package and the `update-pciids` utility doesn't work anyway.