### PR TITLE
dbus: update to 1.11.14

### DIFF
--- a/build/dbus/build.sh
+++ b/build/dbus/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=dbus
-VER=1.11.12
+VER=1.11.14
 PKG=dbus ##IGNORE##
 SUMMARY="$PROG - IPC-based message notifications"
 DESC="$SUMMARY"
@@ -81,6 +81,7 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+run_testsuite check
 make_isa_stub
 post_install
 

--- a/build/dbus/testsuite.log
+++ b/build/dbus/testsuite.log
@@ -1,0 +1,50 @@
+Making check in dbus
+Making check in bus
+Making check in tools
+Making check in test
+Making check in .
+  GEN      copy-config-local
+-- No need to copy test data as srcdir = builddir
+  GEN      uninstalled-config-local
+PASS: test-shell 1
+PASS: test-shell 2
+PASS: test-shell 3
+PASS: test-shell 4
+PASS: test-shell 5
+PASS: test-shell 6
+PASS: test-shell 7
+PASS: test-shell 8
+PASS: test-shell 9
+PASS: test-shell 10
+PASS: test-shell 11
+PASS: test-printf 1
+PASS: test-printf 2
+PASS: test-printf 3
+PASS: test-printf 4
+PASS: test-printf 5
+PASS: test-printf 6
+PASS: test-printf 7
+============================================================================
+Testsuite summary for dbus 1.11.14
+============================================================================
+# TOTAL: 18
+# PASS:  18
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+Making check in name-test
+============================================================================
+Testsuite summary for dbus 1.11.14
+============================================================================
+# TOTAL: 0
+# PASS:  0
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+Making check in doc

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -97,7 +97,7 @@ depend fmri=system/install/kayak@1.1,5.11-@PVER@ type=incorporate
 depend fmri=system/install/kayak-kernel@1.1,5.11-@PVER@ type=incorporate
 depend fmri=system/kvm@1.0,5.11-@PVER@ type=incorporate
 depend fmri=system/library/c++/sunpro@0.5.11,5.11-@PVER@ type=incorporate
-depend fmri=system/library/dbus@1.11.12,5.11-@PVER@ type=incorporate
+depend fmri=system/library/dbus@1.11,5.11-@PVER@ type=incorporate
 depend fmri=system/library/g++-4-runtime@4.8.1,5.11-@PVER@ type=incorporate
 depend fmri=system/library/gcc-4-runtime@4.8.1,5.11-@PVER@ type=incorporate
 depend fmri=system/library/g++-5-runtime@5.1,5.11-@PVER@ type=incorporate

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -53,7 +53,7 @@
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.0		| http://www.tcsh.org/
 | shell/zsh				| 5.3.1			| http://zsh.sourceforge.net/News/
-| system/library/dbus			| 1.11.12		| https://www.freedesktop.org/wiki/Software/dbus/#index5h1
+| system/library/dbus			| 1.11.14		| https://www.freedesktop.org/wiki/Software/dbus/#index5h1
 | system/library/pcap			| 1.8.1			| http://www.tcpdump.org/#latest-releases
 | system/management/ipmitool		| 1.8.18		| https://sourceforge.net/projects/ipmitool/
 | system/management/snmp/net-snmp	| 5.7.3			| http://www.net-snmp.org/download.html


### PR DESCRIPTION
Straightforward upgrade of the dbus package.

(NB: This adds a testsuite run which depends on the merge of https://github.com/omniosorg/omnios-build/pull/83)