### PR TITLE
automake: update to 1.15.1

### DIFF
--- a/build/automake/build.sh
+++ b/build/automake/build.sh
@@ -28,11 +28,14 @@
 . ../../lib/functions.sh
 
 PROG=automake
-VER=1.15
+VER=1.15.1
 VERHUMAN=$VER
 PKG=developer/build/automake
 SUMMARY="GNU Automake $VER"
 DESC="GNU Automake - A Makefile generator ($VER)"
+
+# skip tests when in batch mode as they take 1h+
+[ -n "$BATCH" ] && SKIP_TESTSUITE=1
 
 BUILDARCH=32
 BUILD_DEPENDS_IPS="compress/xz developer/build/autoconf"
@@ -46,6 +49,7 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+PATH=/usr/gnu/bin:$PATH run_testsuite check
 make_isa_stub
 make_package
 clean_up

--- a/build/automake/testsuite.log
+++ b/build/automake/testsuite.log
@@ -1,0 +1,2686 @@
+SKIP: t/get-sysconf.sh
+XFAIL: t/pm/Cond2.pl
+XFAIL: t/pm/Cond3.pl
+PASS: t/pm/Condition.pl
+PASS: t/pm/Condition-t.pl
+XFAIL: t/pm/DisjCon2.pl
+XFAIL: t/pm/DisjCon3.pl
+PASS: t/pm/DisjConditions.pl
+PASS: t/pm/DisjConditions-t.pl
+PASS: t/pm/Version.pl
+XFAIL: t/pm/Version2.pl
+XFAIL: t/pm/Version3.pl
+PASS: t/pm/Wrap.pl
+XFAIL: t/instspc.tap 1 - squote in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 2 - squote in destdir # TODO long-standing limitation
+XFAIL: t/instspc.tap 3 - dquote in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 4 - dquote in destdir # TODO long-standing limitation
+XFAIL: t/instspc.tap 5 - bquote in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 6 - bquote in destdir # TODO long-standing limitation
+XFAIL: t/instspc.tap 7 - sharp in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 8 - sharp in destdir # TODO long-standing limitation
+XFAIL: t/instspc.tap 9 - dollar in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 10 - dollar in destdir # TODO long-standing limitation
+PASS: t/instspc.tap 11 - bang in builddir
+PASS: t/instspc.tap 12 - bang in destdir
+XFAIL: t/instspc.tap 13 - bslash in builddir # TODO long-standing limitation
+PASS: t/instspc.tap 14 - bslash in destdir
+XFAIL: t/instspc.tap 15 - ampersand in builddir # TODO long-standing limitation
+PASS: t/instspc.tap 16 - ampersand in destdir
+PASS: t/instspc.tap 17 - percent in builddir
+PASS: t/instspc.tap 18 - percent in destdir
+PASS: t/instspc.tap 19 - leftpar in builddir
+PASS: t/instspc.tap 20 - leftpar in destdir
+PASS: t/instspc.tap 21 - rightpar in builddir
+PASS: t/instspc.tap 22 - rightpar in destdir
+PASS: t/instspc.tap 23 - pipe in builddir
+PASS: t/instspc.tap 24 - pipe in destdir
+PASS: t/instspc.tap 25 - caret in builddir
+PASS: t/instspc.tap 26 - caret in destdir
+PASS: t/instspc.tap 27 - tilde in builddir
+PASS: t/instspc.tap 28 - tilde in destdir
+PASS: t/instspc.tap 29 - qmark in builddir
+PASS: t/instspc.tap 30 - qmark in destdir
+PASS: t/instspc.tap 31 - star in builddir
+PASS: t/instspc.tap 32 - star in destdir
+PASS: t/instspc.tap 33 - plus in builddir
+PASS: t/instspc.tap 34 - plus in destdir
+PASS: t/instspc.tap 35 - minus in builddir
+PASS: t/instspc.tap 36 - minus in destdir
+PASS: t/instspc.tap 37 - comma in builddir
+PASS: t/instspc.tap 38 - comma in destdir
+PASS: t/instspc.tap 39 - colon in builddir
+PASS: t/instspc.tap 40 - colon in destdir
+PASS: t/instspc.tap 41 - semicol in builddir
+PASS: t/instspc.tap 42 - semicol in destdir
+PASS: t/instspc.tap 43 - equal in builddir
+PASS: t/instspc.tap 44 - equal in destdir
+PASS: t/instspc.tap 45 - less in builddir
+PASS: t/instspc.tap 46 - less in destdir
+PASS: t/instspc.tap 47 - more in builddir
+PASS: t/instspc.tap 48 - more in destdir
+PASS: t/instspc.tap 49 - at in builddir
+PASS: t/instspc.tap 50 - at in destdir
+PASS: t/instspc.tap 51 - lqbrack in builddir
+PASS: t/instspc.tap 52 - lqbrack in destdir
+PASS: t/instspc.tap 53 - rqbrack in builddir
+PASS: t/instspc.tap 54 - rqbrack in destdir
+PASS: t/instspc.tap 55 - lcbrack in builddir
+PASS: t/instspc.tap 56 - lcbrack in destdir
+PASS: t/instspc.tap 57 - rcbrack in builddir
+PASS: t/instspc.tap 58 - rcbrack in destdir
+PASS: t/instspc.tap 59 - space in builddir
+PASS: t/instspc.tap 60 - space in destdir
+PASS: t/instspc.tap 61 - tab in builddir
+PASS: t/instspc.tap 62 - tab in destdir
+XFAIL: t/instspc.tap 63 - linefeed in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 64 - linefeed in destdir # TODO long-standing limitation
+PASS: t/instspc.tap 65 - backspace in builddir
+PASS: t/instspc.tap 66 - backspace in destdir
+PASS: t/instspc.tap 67 - formfeed in builddir
+PASS: t/instspc.tap 68 - formfeed in destdir
+PASS: t/instspc.tap 69 - carriageret in builddir
+PASS: t/instspc.tap 70 - carriageret in destdir
+XFAIL: t/instspc.tap 71 - quadrigraph0 in builddir # TODO long-standing limitation
+PASS: t/instspc.tap 72 - quadrigraph0 in destdir
+PASS: t/instspc.tap 73 - quadrigraph1 in builddir
+PASS: t/instspc.tap 74 - quadrigraph1 in destdir
+PASS: t/instspc.tap 75 - quadrigraph2 in builddir
+PASS: t/instspc.tap 76 - quadrigraph2 in destdir
+PASS: t/instspc.tap 77 - quadrigraph3 in builddir
+PASS: t/instspc.tap 78 - quadrigraph3 in destdir
+PASS: t/instspc.tap 79 - quadrigraph4 in builddir
+PASS: t/instspc.tap 80 - quadrigraph4 in destdir
+PASS: t/instspc.tap 81 - a_b in builddir
+PASS: t/instspc.tap 82 - a_b in destdir
+PASS: t/instspc.tap 83 - a__b in builddir
+PASS: t/instspc.tap 84 - a__b in destdir
+XFAIL: t/instspc.tap 85 - a_lf_b in builddir # TODO long-standing limitation
+XFAIL: t/instspc.tap 86 - a_lf_b in destdir # TODO long-standing limitation
+PASS: t/instspc.tap 87 - dotdotdot in builddir
+PASS: t/instspc.tap 88 - dotdotdot in destdir
+PASS: t/instspc.tap 89 - dosdrive in builddir
+PASS: t/instspc.tap 90 - dosdrive in destdir
+PASS: t/instspc.tap 91 - miscglob1 in builddir
+PASS: t/instspc.tap 92 - miscglob1 in destdir
+PASS: t/instspc.tap 93 - miscglob2 in builddir
+PASS: t/instspc.tap 94 - miscglob2 in destdir
+PASS: t/aclocal.sh
+PASS: t/aclocal-I-order-1.sh
+PASS: t/aclocal-I-order-2.sh
+PASS: t/aclocal-I-order-3.sh
+PASS: t/aclocal-I-and-install.sh
+PASS: t/aclocal-acdir.sh
+PASS: t/aclocal-amflags.sh
+PASS: t/aclocal-autoconf-version-check.sh
+PASS: t/aclocal-comments-respected.sh
+PASS: t/aclocal-deleted-header-aclocal-amflags.sh
+PASS: t/aclocal-deleted-header.sh
+PASS: t/aclocal-deps-subdir.sh
+PASS: t/aclocal-deps.sh
+PASS: t/aclocal-dirlist.sh
+PASS: t/aclocal-dirlist-globbing.sh
+PASS: t/aclocal-dirlist-abspath.sh
+PASS: t/aclocal-install-absdir.sh
+PASS: t/aclocal-install-fail.sh
+PASS: t/aclocal-install-mkdir.sh
+PASS: t/aclocal-m4-include-are-scanned-aclocal-amflags.sh
+PASS: t/aclocal-m4-include-are-scanned.sh
+PASS: t/aclocal-m4-sinclude.sh
+PASS: t/aclocal-macrodir.tap 1 - AC_CONFIG_MACRO_DIR is honored
+PASS: t/aclocal-macrodir.tap 2 - AC_CONFIG_MACRO_DIR([foo]) interaction with --install
+PASS: t/aclocal-macrodir.tap 3 - '-I' option wins over AC_CONFIG_MACRO_DIR
+PASS: t/aclocal-macrodir.tap 4 - AC_CONFIG_MACRO_DIR([foo]) can create directory 'foo'
+PASS: t/aclocal-macrodir.tap 5 - AC_CONFIG_MACRO_DIR([non-existent]) warns with -Wunsupported
+PASS: t/aclocal-macrodir.tap 6 - AC_CONFIG_MACRO_DIR([not-exist]) and ACLOCAL_AMFLAGS = -I not-exist
+SKIP: t/aclocal-macrodir.tap 7 # SKIP autoconf is too old (AC_CONFIG_MACRO_DIRS not defined)
+PASS: t/aclocal-macrodirs.tap 1 - AC_CONFIG_MACRO_DIRS is honored
+PASS: t/aclocal-macrodirs.tap 2 - AC_CONFIG_MACRO_DIRS several arguments
+PASS: t/aclocal-macrodirs.tap 3 - AC_CONFIG_MACRO_DIRS several calls
+PASS: t/aclocal-macrodirs.tap 4 - AC_CONFIG_MACRO_DIRS extra whitespace
+PASS: t/aclocal-macrodirs.tap 5 - AC_CONFIG_MACRO_DIRS precedence
+PASS: t/aclocal-macrodirs.tap 6 - AC_CONFIG_MACRO_DIRS interaction with --install
+PASS: t/aclocal-macrodirs.tap 7 - several AC_CONFIG_MACRO_DIRS arguments and --install
+PASS: t/aclocal-macrodirs.tap 8 - several AC_CONFIG_MACRO_DIRS calls and --install
+PASS: t/aclocal-macrodirs.tap 9 - '-I' option wins over AC_CONFIG_MACRO_DIRS
+PASS: t/aclocal-macrodirs.tap 10 - AC_CONFIG_MACRO_DIRS([foo]) can create directory 'foo'
+PASS: t/aclocal-macrodirs.tap 11 - AC_CONFIG_MACRO_DIRS([non-existent]) warns (1)
+PASS: t/aclocal-macrodirs.tap 12 - AC_CONFIG_MACRO_DIRS([non-existent]) warns (2)
+PASS: t/aclocal-macrodirs.tap 13 - AC_CONFIG_MACRO_DIRS([existent non-existent]) errors out
+PASS: t/aclocal-macrodirs.tap 14 - AC_CONFIG_MACRO_DIRS([not-exist]) and ACLOCAL_AMFLAGS = -I not-exist
+SKIP: t/aclocal-macrodirs.tap 15 # SKIP autoconf is too old (AC_CONFIG_MACRO_DIRS not defined)
+PASS: t/aclocal-missing-macros.sh
+PASS: t/aclocal-no-extra-scan.sh
+PASS: t/aclocal-no-force.sh
+PASS: t/aclocal-no-install-no-mkdir.sh
+PASS: t/aclocal-no-symlinked-overwrite.sh
+PASS: t/aclocal-no-unused-required.sh
+PASS: t/aclocal-path.sh
+PASS: t/aclocal-path-install.sh
+PASS: t/aclocal-path-install-serial.sh
+PASS: t/aclocal-path-nonexistent.sh
+PASS: t/aclocal-path-precedence.sh
+PASS: t/aclocal-pr450.sh
+PASS: t/aclocal-print-acdir.sh
+PASS: t/aclocal-req.sh
+PASS: t/aclocal-remake-misc.sh
+PASS: t/aclocal-scan-configure-ac-pr319.sh
+PASS: t/aclocal-serial.sh
+PASS: t/aclocal-underquoted-defun.sh
+PASS: t/aclocal-verbose-install.sh
+PASS: t/auxdir-pr15981.sh
+PASS: t/auxdir-cc-pr15981.sh
+PASS: t/ac-output-old.tap 1 - aclocal groks '\' in AC_OUTPUT (acoutbs1)
+PASS: t/ac-output-old.tap 2 - automake groks '\' in AC_OUTPUT (acoutbs1)
+PASS: t/ac-output-old.tap 3 - autoconf groks '\' in AC_OUTPUT (acoutbs1)
+PASS: t/ac-output-old.tap 4 - can ./configure in acoutbs1
+PASS: t/ac-output-old.tap 5 - zot created in acoutbs1
+PASS: t/ac-output-old.tap 6 - '\' not leaked in filenames in acoutbs1
+PASS: t/ac-output-old.tap 7 - aclocal groks '\' in AC_OUTPUT (acoutbs2)
+PASS: t/ac-output-old.tap 8 - automake groks '\' in AC_OUTPUT (acoutbs2)
+PASS: t/ac-output-old.tap 9 - autoconf groks '\' in AC_OUTPUT (acoutbs2)
+PASS: t/ac-output-old.tap 10 - can ./configure in acoutbs2
+PASS: t/ac-output-old.tap 11 - zot created in acoutbs2
+PASS: t/ac-output-old.tap 12 - '\' not leaked in filenames in acoutbs2
+PASS: t/ac-output-old.tap 13 - aclocal and quoted AC_OUTPUT second argument
+PASS: t/ac-output-old.tap 14 - automake and quoted AC_OUTPUT second argument
+PASS: t/ac-output-old.tap 15 - aclocal and two AC_OUTPUT arguments on same line
+PASS: t/ac-output-old.tap 16 - automake and two AC_OUTPUT arguments on same line
+PASS: t/ac-output-old.tap 17 - aclocal and AC_OUTPUT (acoutput2)
+PASS: t/ac-output-old.tap 18 - automake and AC_OUTPUT (acoutput2)
+PASS: t/ac-output-old.tap 19 - foo.in mentioned two times in Makefile.in (acoutput2)
+PASS: t/ac-output-old.tap 20 - 'automake -a -f' and AC_OUTPUT (acoutput2)
+PASS: t/ac-output-old.tap 21 - aclocal and two AC_OUTPUT arguments on two lines
+PASS: t/ac-output-old.tap 22 - automake and two AC_OUTPUT arguments on two lines
+PASS: t/acsilent.sh
+PASS: t/acsubst.sh
+PASS: t/acsubst2.sh
+PASS: t/add-missing.tap 1 - [link minimal] missing files, automake fails
+PASS: t/add-missing.tap 2 - [link minimal] warn about missing file install-sh
+PASS: t/add-missing.tap 3 - [link minimal] suggest --add-missing for install-sh
+PASS: t/add-missing.tap 4 - [link minimal] warn about missing file missing
+PASS: t/add-missing.tap 5 - [link minimal] suggest --add-missing for missing
+PASS: t/add-missing.tap 6 - [link minimal] no extra files installed
+PASS: t/add-missing.tap 7 - [link minimal] automake run successfully
+PASS: t/add-missing.tap 8 - [link minimal] file install-sh installed
+PASS: t/add-missing.tap 9 - [link minimal] file missing installed
+PASS: t/add-missing.tap 10 - [link minimal] report installation of install-sh
+PASS: t/add-missing.tap 11 - [link minimal] report installation of missing
+PASS: t/add-missing.tap 12 - [link minimal] all and only expected files installed
+PASS: t/add-missing.tap 13 - [link minimal] install-sh has been symlinked
+PASS: t/add-missing.tap 14 - [link minimal] missing has been symlinked
+PASS: t/add-missing.tap 15 - [link minimal] automake finds all added files
+PASS: t/add-missing.tap 16 - [copy minimal] missing files, automake fails
+PASS: t/add-missing.tap 17 - [copy minimal] warn about missing file install-sh
+PASS: t/add-missing.tap 18 - [copy minimal] suggest --add-missing for install-sh
+PASS: t/add-missing.tap 19 - [copy minimal] warn about missing file missing
+PASS: t/add-missing.tap 20 - [copy minimal] suggest --add-missing for missing
+PASS: t/add-missing.tap 21 - [copy minimal] no extra files installed
+PASS: t/add-missing.tap 22 - [copy minimal] automake run successfully
+PASS: t/add-missing.tap 23 - [copy minimal] file install-sh installed
+PASS: t/add-missing.tap 24 - [copy minimal] file missing installed
+PASS: t/add-missing.tap 25 - [copy minimal] report installation of install-sh
+PASS: t/add-missing.tap 26 - [copy minimal] report installation of missing
+PASS: t/add-missing.tap 27 - [copy minimal] all and only expected files installed
+PASS: t/add-missing.tap 28 - [copy minimal] install-sh has not been symlinked
+PASS: t/add-missing.tap 29 - [copy minimal] missing has not been symlinked
+PASS: t/add-missing.tap 30 - [copy minimal] automake finds all added files
+PASS: t/add-missing.tap 31 - [link depcomp/C] missing files, automake fails
+PASS: t/add-missing.tap 32 - [link depcomp/C] warn about missing file depcomp
+PASS: t/add-missing.tap 33 - [link depcomp/C] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 34 - [link depcomp/C] warn about missing file compile
+PASS: t/add-missing.tap 35 - [link depcomp/C] suggest --add-missing for compile
+PASS: t/add-missing.tap 36 - [link depcomp/C] no extra files installed
+PASS: t/add-missing.tap 37 - [link depcomp/C] automake run successfully
+PASS: t/add-missing.tap 38 - [link depcomp/C] file depcomp installed
+PASS: t/add-missing.tap 39 - [link depcomp/C] file compile installed
+PASS: t/add-missing.tap 40 - [link depcomp/C] report installation of depcomp
+PASS: t/add-missing.tap 41 - [link depcomp/C] report installation of compile
+PASS: t/add-missing.tap 42 - [link depcomp/C] all and only expected files installed
+PASS: t/add-missing.tap 43 - [link depcomp/C] depcomp has been symlinked
+PASS: t/add-missing.tap 44 - [link depcomp/C] compile has been symlinked
+PASS: t/add-missing.tap 45 - [link depcomp/C] automake finds all added files
+PASS: t/add-missing.tap 46 - [copy depcomp/C] missing files, automake fails
+PASS: t/add-missing.tap 47 - [copy depcomp/C] warn about missing file depcomp
+PASS: t/add-missing.tap 48 - [copy depcomp/C] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 49 - [copy depcomp/C] warn about missing file compile
+PASS: t/add-missing.tap 50 - [copy depcomp/C] suggest --add-missing for compile
+PASS: t/add-missing.tap 51 - [copy depcomp/C] no extra files installed
+PASS: t/add-missing.tap 52 - [copy depcomp/C] automake run successfully
+PASS: t/add-missing.tap 53 - [copy depcomp/C] file depcomp installed
+PASS: t/add-missing.tap 54 - [copy depcomp/C] file compile installed
+PASS: t/add-missing.tap 55 - [copy depcomp/C] report installation of depcomp
+PASS: t/add-missing.tap 56 - [copy depcomp/C] report installation of compile
+PASS: t/add-missing.tap 57 - [copy depcomp/C] all and only expected files installed
+PASS: t/add-missing.tap 58 - [copy depcomp/C] depcomp has not been symlinked
+PASS: t/add-missing.tap 59 - [copy depcomp/C] compile has not been symlinked
+PASS: t/add-missing.tap 60 - [copy depcomp/C] automake finds all added files
+PASS: t/add-missing.tap 61 - [link depcomp/C++] missing files, automake fails
+PASS: t/add-missing.tap 62 - [link depcomp/C++] warn about missing file depcomp
+PASS: t/add-missing.tap 63 - [link depcomp/C++] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 64 - [link depcomp/C++] no extra files installed
+PASS: t/add-missing.tap 65 - [link depcomp/C++] automake run successfully
+PASS: t/add-missing.tap 66 - [link depcomp/C++] file depcomp installed
+PASS: t/add-missing.tap 67 - [link depcomp/C++] report installation of depcomp
+PASS: t/add-missing.tap 68 - [link depcomp/C++] all and only expected files installed
+PASS: t/add-missing.tap 69 - [link depcomp/C++] depcomp has been symlinked
+PASS: t/add-missing.tap 70 - [link depcomp/C++] automake finds all added files
+PASS: t/add-missing.tap 71 - [copy depcomp/C++] missing files, automake fails
+PASS: t/add-missing.tap 72 - [copy depcomp/C++] warn about missing file depcomp
+PASS: t/add-missing.tap 73 - [copy depcomp/C++] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 74 - [copy depcomp/C++] no extra files installed
+PASS: t/add-missing.tap 75 - [copy depcomp/C++] automake run successfully
+PASS: t/add-missing.tap 76 - [copy depcomp/C++] file depcomp installed
+PASS: t/add-missing.tap 77 - [copy depcomp/C++] report installation of depcomp
+PASS: t/add-missing.tap 78 - [copy depcomp/C++] all and only expected files installed
+PASS: t/add-missing.tap 79 - [copy depcomp/C++] depcomp has not been symlinked
+PASS: t/add-missing.tap 80 - [copy depcomp/C++] automake finds all added files
+PASS: t/add-missing.tap 81 - [compile] aclocal.m4 rebuilt
+PASS: t/add-missing.tap 82 - [link compile] missing files, automake fails
+PASS: t/add-missing.tap 83 - [link compile] warn about missing file compile
+PASS: t/add-missing.tap 84 - [link compile] suggest --add-missing for compile
+PASS: t/add-missing.tap 85 - [link compile] no extra files installed
+PASS: t/add-missing.tap 86 - [link compile] automake run successfully
+PASS: t/add-missing.tap 87 - [link compile] file compile installed
+PASS: t/add-missing.tap 88 - [link compile] report installation of compile
+PASS: t/add-missing.tap 89 - [link compile] all and only expected files installed
+PASS: t/add-missing.tap 90 - [link compile] compile has been symlinked
+PASS: t/add-missing.tap 91 - [link compile] automake finds all added files
+PASS: t/add-missing.tap 92 - [copy compile] missing files, automake fails
+PASS: t/add-missing.tap 93 - [copy compile] warn about missing file compile
+PASS: t/add-missing.tap 94 - [copy compile] suggest --add-missing for compile
+PASS: t/add-missing.tap 95 - [copy compile] no extra files installed
+PASS: t/add-missing.tap 96 - [copy compile] automake run successfully
+PASS: t/add-missing.tap 97 - [copy compile] file compile installed
+PASS: t/add-missing.tap 98 - [copy compile] report installation of compile
+PASS: t/add-missing.tap 99 - [copy compile] all and only expected files installed
+PASS: t/add-missing.tap 100 - [copy compile] compile has not been symlinked
+PASS: t/add-missing.tap 101 - [copy compile] automake finds all added files
+PASS: t/add-missing.tap 102 - [link cfg-build] missing files, automake fails
+PASS: t/add-missing.tap 103 - [link cfg-build] warn about missing file config.sub
+PASS: t/add-missing.tap 104 - [link cfg-build] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 105 - [link cfg-build] warn about missing file config.guess
+PASS: t/add-missing.tap 106 - [link cfg-build] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 107 - [link cfg-build] no extra files installed
+PASS: t/add-missing.tap 108 - [link cfg-build] automake run successfully
+PASS: t/add-missing.tap 109 - [link cfg-build] file config.sub installed
+PASS: t/add-missing.tap 110 - [link cfg-build] file config.guess installed
+PASS: t/add-missing.tap 111 - [link cfg-build] report installation of config.sub
+PASS: t/add-missing.tap 112 - [link cfg-build] report installation of config.guess
+PASS: t/add-missing.tap 113 - [link cfg-build] all and only expected files installed
+PASS: t/add-missing.tap 114 - [link cfg-build] config.sub has been symlinked
+PASS: t/add-missing.tap 115 - [link cfg-build] config.guess has been symlinked
+PASS: t/add-missing.tap 116 - [link cfg-build] automake finds all added files
+PASS: t/add-missing.tap 117 - [copy cfg-build] missing files, automake fails
+PASS: t/add-missing.tap 118 - [copy cfg-build] warn about missing file config.sub
+PASS: t/add-missing.tap 119 - [copy cfg-build] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 120 - [copy cfg-build] warn about missing file config.guess
+PASS: t/add-missing.tap 121 - [copy cfg-build] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 122 - [copy cfg-build] no extra files installed
+PASS: t/add-missing.tap 123 - [copy cfg-build] automake run successfully
+PASS: t/add-missing.tap 124 - [copy cfg-build] file config.sub installed
+PASS: t/add-missing.tap 125 - [copy cfg-build] file config.guess installed
+PASS: t/add-missing.tap 126 - [copy cfg-build] report installation of config.sub
+PASS: t/add-missing.tap 127 - [copy cfg-build] report installation of config.guess
+PASS: t/add-missing.tap 128 - [copy cfg-build] all and only expected files installed
+PASS: t/add-missing.tap 129 - [copy cfg-build] config.sub has not been symlinked
+PASS: t/add-missing.tap 130 - [copy cfg-build] config.guess has not been symlinked
+PASS: t/add-missing.tap 131 - [copy cfg-build] automake finds all added files
+PASS: t/add-missing.tap 132 - [link cfg-host] missing files, automake fails
+PASS: t/add-missing.tap 133 - [link cfg-host] warn about missing file config.sub
+PASS: t/add-missing.tap 134 - [link cfg-host] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 135 - [link cfg-host] warn about missing file config.guess
+PASS: t/add-missing.tap 136 - [link cfg-host] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 137 - [link cfg-host] no extra files installed
+PASS: t/add-missing.tap 138 - [link cfg-host] automake run successfully
+PASS: t/add-missing.tap 139 - [link cfg-host] file config.sub installed
+PASS: t/add-missing.tap 140 - [link cfg-host] file config.guess installed
+PASS: t/add-missing.tap 141 - [link cfg-host] report installation of config.sub
+PASS: t/add-missing.tap 142 - [link cfg-host] report installation of config.guess
+PASS: t/add-missing.tap 143 - [link cfg-host] all and only expected files installed
+PASS: t/add-missing.tap 144 - [link cfg-host] config.sub has been symlinked
+PASS: t/add-missing.tap 145 - [link cfg-host] config.guess has been symlinked
+PASS: t/add-missing.tap 146 - [link cfg-host] automake finds all added files
+PASS: t/add-missing.tap 147 - [copy cfg-host] missing files, automake fails
+PASS: t/add-missing.tap 148 - [copy cfg-host] warn about missing file config.sub
+PASS: t/add-missing.tap 149 - [copy cfg-host] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 150 - [copy cfg-host] warn about missing file config.guess
+PASS: t/add-missing.tap 151 - [copy cfg-host] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 152 - [copy cfg-host] no extra files installed
+PASS: t/add-missing.tap 153 - [copy cfg-host] automake run successfully
+PASS: t/add-missing.tap 154 - [copy cfg-host] file config.sub installed
+PASS: t/add-missing.tap 155 - [copy cfg-host] file config.guess installed
+PASS: t/add-missing.tap 156 - [copy cfg-host] report installation of config.sub
+PASS: t/add-missing.tap 157 - [copy cfg-host] report installation of config.guess
+PASS: t/add-missing.tap 158 - [copy cfg-host] all and only expected files installed
+PASS: t/add-missing.tap 159 - [copy cfg-host] config.sub has not been symlinked
+PASS: t/add-missing.tap 160 - [copy cfg-host] config.guess has not been symlinked
+PASS: t/add-missing.tap 161 - [copy cfg-host] automake finds all added files
+PASS: t/add-missing.tap 162 - [link cfg-target] missing files, automake fails
+PASS: t/add-missing.tap 163 - [link cfg-target] warn about missing file config.sub
+PASS: t/add-missing.tap 164 - [link cfg-target] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 165 - [link cfg-target] warn about missing file config.guess
+PASS: t/add-missing.tap 166 - [link cfg-target] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 167 - [link cfg-target] no extra files installed
+PASS: t/add-missing.tap 168 - [link cfg-target] automake run successfully
+PASS: t/add-missing.tap 169 - [link cfg-target] file config.sub installed
+PASS: t/add-missing.tap 170 - [link cfg-target] file config.guess installed
+PASS: t/add-missing.tap 171 - [link cfg-target] report installation of config.sub
+PASS: t/add-missing.tap 172 - [link cfg-target] report installation of config.guess
+PASS: t/add-missing.tap 173 - [link cfg-target] all and only expected files installed
+PASS: t/add-missing.tap 174 - [link cfg-target] config.sub has been symlinked
+PASS: t/add-missing.tap 175 - [link cfg-target] config.guess has been symlinked
+PASS: t/add-missing.tap 176 - [link cfg-target] automake finds all added files
+PASS: t/add-missing.tap 177 - [copy cfg-target] missing files, automake fails
+PASS: t/add-missing.tap 178 - [copy cfg-target] warn about missing file config.sub
+PASS: t/add-missing.tap 179 - [copy cfg-target] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 180 - [copy cfg-target] warn about missing file config.guess
+PASS: t/add-missing.tap 181 - [copy cfg-target] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 182 - [copy cfg-target] no extra files installed
+PASS: t/add-missing.tap 183 - [copy cfg-target] automake run successfully
+PASS: t/add-missing.tap 184 - [copy cfg-target] file config.sub installed
+PASS: t/add-missing.tap 185 - [copy cfg-target] file config.guess installed
+PASS: t/add-missing.tap 186 - [copy cfg-target] report installation of config.sub
+PASS: t/add-missing.tap 187 - [copy cfg-target] report installation of config.guess
+PASS: t/add-missing.tap 188 - [copy cfg-target] all and only expected files installed
+PASS: t/add-missing.tap 189 - [copy cfg-target] config.sub has not been symlinked
+PASS: t/add-missing.tap 190 - [copy cfg-target] config.guess has not been symlinked
+PASS: t/add-missing.tap 191 - [copy cfg-target] automake finds all added files
+PASS: t/add-missing.tap 192 - [link cfg-system] missing files, automake fails
+PASS: t/add-missing.tap 193 - [link cfg-system] warn about missing file config.sub
+PASS: t/add-missing.tap 194 - [link cfg-system] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 195 - [link cfg-system] warn about missing file config.guess
+PASS: t/add-missing.tap 196 - [link cfg-system] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 197 - [link cfg-system] no extra files installed
+PASS: t/add-missing.tap 198 - [link cfg-system] automake run successfully
+PASS: t/add-missing.tap 199 - [link cfg-system] file config.sub installed
+PASS: t/add-missing.tap 200 - [link cfg-system] file config.guess installed
+PASS: t/add-missing.tap 201 - [link cfg-system] report installation of config.sub
+PASS: t/add-missing.tap 202 - [link cfg-system] report installation of config.guess
+PASS: t/add-missing.tap 203 - [link cfg-system] all and only expected files installed
+PASS: t/add-missing.tap 204 - [link cfg-system] config.sub has been symlinked
+PASS: t/add-missing.tap 205 - [link cfg-system] config.guess has been symlinked
+PASS: t/add-missing.tap 206 - [link cfg-system] automake finds all added files
+PASS: t/add-missing.tap 207 - [copy cfg-system] missing files, automake fails
+PASS: t/add-missing.tap 208 - [copy cfg-system] warn about missing file config.sub
+PASS: t/add-missing.tap 209 - [copy cfg-system] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 210 - [copy cfg-system] warn about missing file config.guess
+PASS: t/add-missing.tap 211 - [copy cfg-system] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 212 - [copy cfg-system] no extra files installed
+PASS: t/add-missing.tap 213 - [copy cfg-system] automake run successfully
+PASS: t/add-missing.tap 214 - [copy cfg-system] file config.sub installed
+PASS: t/add-missing.tap 215 - [copy cfg-system] file config.guess installed
+PASS: t/add-missing.tap 216 - [copy cfg-system] report installation of config.sub
+PASS: t/add-missing.tap 217 - [copy cfg-system] report installation of config.guess
+PASS: t/add-missing.tap 218 - [copy cfg-system] all and only expected files installed
+PASS: t/add-missing.tap 219 - [copy cfg-system] config.sub has not been symlinked
+PASS: t/add-missing.tap 220 - [copy cfg-system] config.guess has not been symlinked
+PASS: t/add-missing.tap 221 - [copy cfg-system] automake finds all added files
+PASS: t/add-missing.tap 222 - [link ylwrap/Lex] missing files, automake fails
+PASS: t/add-missing.tap 223 - [link ylwrap/Lex] warn about missing file ylwrap
+PASS: t/add-missing.tap 224 - [link ylwrap/Lex] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 225 - [link ylwrap/Lex] warn about missing file compile
+PASS: t/add-missing.tap 226 - [link ylwrap/Lex] suggest --add-missing for compile
+PASS: t/add-missing.tap 227 - [link ylwrap/Lex] no extra files installed
+PASS: t/add-missing.tap 228 - [link ylwrap/Lex] automake run successfully
+PASS: t/add-missing.tap 229 - [link ylwrap/Lex] file ylwrap installed
+PASS: t/add-missing.tap 230 - [link ylwrap/Lex] file compile installed
+PASS: t/add-missing.tap 231 - [link ylwrap/Lex] report installation of ylwrap
+PASS: t/add-missing.tap 232 - [link ylwrap/Lex] report installation of compile
+PASS: t/add-missing.tap 233 - [link ylwrap/Lex] all and only expected files installed
+PASS: t/add-missing.tap 234 - [link ylwrap/Lex] ylwrap has been symlinked
+PASS: t/add-missing.tap 235 - [link ylwrap/Lex] compile has been symlinked
+PASS: t/add-missing.tap 236 - [link ylwrap/Lex] automake finds all added files
+PASS: t/add-missing.tap 237 - [copy ylwrap/Lex] missing files, automake fails
+PASS: t/add-missing.tap 238 - [copy ylwrap/Lex] warn about missing file ylwrap
+PASS: t/add-missing.tap 239 - [copy ylwrap/Lex] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 240 - [copy ylwrap/Lex] warn about missing file compile
+PASS: t/add-missing.tap 241 - [copy ylwrap/Lex] suggest --add-missing for compile
+PASS: t/add-missing.tap 242 - [copy ylwrap/Lex] no extra files installed
+PASS: t/add-missing.tap 243 - [copy ylwrap/Lex] automake run successfully
+PASS: t/add-missing.tap 244 - [copy ylwrap/Lex] file ylwrap installed
+PASS: t/add-missing.tap 245 - [copy ylwrap/Lex] file compile installed
+PASS: t/add-missing.tap 246 - [copy ylwrap/Lex] report installation of ylwrap
+PASS: t/add-missing.tap 247 - [copy ylwrap/Lex] report installation of compile
+PASS: t/add-missing.tap 248 - [copy ylwrap/Lex] all and only expected files installed
+PASS: t/add-missing.tap 249 - [copy ylwrap/Lex] ylwrap has not been symlinked
+PASS: t/add-missing.tap 250 - [copy ylwrap/Lex] compile has not been symlinked
+PASS: t/add-missing.tap 251 - [copy ylwrap/Lex] automake finds all added files
+PASS: t/add-missing.tap 252 - [link ylwrap/Yacc] missing files, automake fails
+PASS: t/add-missing.tap 253 - [link ylwrap/Yacc] warn about missing file ylwrap
+PASS: t/add-missing.tap 254 - [link ylwrap/Yacc] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 255 - [link ylwrap/Yacc] warn about missing file compile
+PASS: t/add-missing.tap 256 - [link ylwrap/Yacc] suggest --add-missing for compile
+PASS: t/add-missing.tap 257 - [link ylwrap/Yacc] no extra files installed
+PASS: t/add-missing.tap 258 - [link ylwrap/Yacc] automake run successfully
+PASS: t/add-missing.tap 259 - [link ylwrap/Yacc] file ylwrap installed
+PASS: t/add-missing.tap 260 - [link ylwrap/Yacc] file compile installed
+PASS: t/add-missing.tap 261 - [link ylwrap/Yacc] report installation of ylwrap
+PASS: t/add-missing.tap 262 - [link ylwrap/Yacc] report installation of compile
+PASS: t/add-missing.tap 263 - [link ylwrap/Yacc] all and only expected files installed
+PASS: t/add-missing.tap 264 - [link ylwrap/Yacc] ylwrap has been symlinked
+PASS: t/add-missing.tap 265 - [link ylwrap/Yacc] compile has been symlinked
+PASS: t/add-missing.tap 266 - [link ylwrap/Yacc] automake finds all added files
+PASS: t/add-missing.tap 267 - [copy ylwrap/Yacc] missing files, automake fails
+PASS: t/add-missing.tap 268 - [copy ylwrap/Yacc] warn about missing file ylwrap
+PASS: t/add-missing.tap 269 - [copy ylwrap/Yacc] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 270 - [copy ylwrap/Yacc] warn about missing file compile
+PASS: t/add-missing.tap 271 - [copy ylwrap/Yacc] suggest --add-missing for compile
+PASS: t/add-missing.tap 272 - [copy ylwrap/Yacc] no extra files installed
+PASS: t/add-missing.tap 273 - [copy ylwrap/Yacc] automake run successfully
+PASS: t/add-missing.tap 274 - [copy ylwrap/Yacc] file ylwrap installed
+PASS: t/add-missing.tap 275 - [copy ylwrap/Yacc] file compile installed
+PASS: t/add-missing.tap 276 - [copy ylwrap/Yacc] report installation of ylwrap
+PASS: t/add-missing.tap 277 - [copy ylwrap/Yacc] report installation of compile
+PASS: t/add-missing.tap 278 - [copy ylwrap/Yacc] all and only expected files installed
+PASS: t/add-missing.tap 279 - [copy ylwrap/Yacc] ylwrap has not been symlinked
+PASS: t/add-missing.tap 280 - [copy ylwrap/Yacc] compile has not been symlinked
+PASS: t/add-missing.tap 281 - [copy ylwrap/Yacc] automake finds all added files
+PASS: t/add-missing.tap 282 - [link Texinfo] missing files, automake fails
+PASS: t/add-missing.tap 283 - [link Texinfo] warn about missing file texinfo.tex
+PASS: t/add-missing.tap 284 - [link Texinfo] suggest --add-missing for texinfo.tex
+PASS: t/add-missing.tap 285 - [link Texinfo] no extra files installed
+PASS: t/add-missing.tap 286 - [link Texinfo] automake run successfully
+PASS: t/add-missing.tap 287 - [link Texinfo] file texinfo.tex installed
+PASS: t/add-missing.tap 288 - [link Texinfo] report installation of texinfo.tex
+PASS: t/add-missing.tap 289 - [link Texinfo] all and only expected files installed
+PASS: t/add-missing.tap 290 - [link Texinfo] texinfo.tex has been symlinked
+PASS: t/add-missing.tap 291 - [link Texinfo] automake finds all added files
+PASS: t/add-missing.tap 292 - [copy Texinfo] missing files, automake fails
+PASS: t/add-missing.tap 293 - [copy Texinfo] warn about missing file texinfo.tex
+PASS: t/add-missing.tap 294 - [copy Texinfo] suggest --add-missing for texinfo.tex
+PASS: t/add-missing.tap 295 - [copy Texinfo] no extra files installed
+PASS: t/add-missing.tap 296 - [copy Texinfo] automake run successfully
+PASS: t/add-missing.tap 297 - [copy Texinfo] file texinfo.tex installed
+PASS: t/add-missing.tap 298 - [copy Texinfo] report installation of texinfo.tex
+PASS: t/add-missing.tap 299 - [copy Texinfo] all and only expected files installed
+PASS: t/add-missing.tap 300 - [copy Texinfo] texinfo.tex has not been symlinked
+PASS: t/add-missing.tap 301 - [copy Texinfo] automake finds all added files
+PASS: t/add-missing.tap 302 - [link Texinfo/mdate-sh] missing files, automake fails
+PASS: t/add-missing.tap 303 - [link Texinfo/mdate-sh] warn about missing file mdate-sh
+PASS: t/add-missing.tap 304 - [link Texinfo/mdate-sh] suggest --add-missing for mdate-sh
+PASS: t/add-missing.tap 305 - [link Texinfo/mdate-sh] warn about missing file texinfo.tex
+PASS: t/add-missing.tap 306 - [link Texinfo/mdate-sh] suggest --add-missing for texinfo.tex
+PASS: t/add-missing.tap 307 - [link Texinfo/mdate-sh] no extra files installed
+PASS: t/add-missing.tap 308 - [link Texinfo/mdate-sh] automake run successfully
+PASS: t/add-missing.tap 309 - [link Texinfo/mdate-sh] file mdate-sh installed
+PASS: t/add-missing.tap 310 - [link Texinfo/mdate-sh] file texinfo.tex installed
+PASS: t/add-missing.tap 311 - [link Texinfo/mdate-sh] report installation of mdate-sh
+PASS: t/add-missing.tap 312 - [link Texinfo/mdate-sh] report installation of texinfo.tex
+PASS: t/add-missing.tap 313 - [link Texinfo/mdate-sh] all and only expected files installed
+PASS: t/add-missing.tap 314 - [link Texinfo/mdate-sh] mdate-sh has been symlinked
+PASS: t/add-missing.tap 315 - [link Texinfo/mdate-sh] texinfo.tex has been symlinked
+PASS: t/add-missing.tap 316 - [link Texinfo/mdate-sh] automake finds all added files
+PASS: t/add-missing.tap 317 - [copy Texinfo/mdate-sh] missing files, automake fails
+PASS: t/add-missing.tap 318 - [copy Texinfo/mdate-sh] warn about missing file mdate-sh
+PASS: t/add-missing.tap 319 - [copy Texinfo/mdate-sh] suggest --add-missing for mdate-sh
+PASS: t/add-missing.tap 320 - [copy Texinfo/mdate-sh] warn about missing file texinfo.tex
+PASS: t/add-missing.tap 321 - [copy Texinfo/mdate-sh] suggest --add-missing for texinfo.tex
+PASS: t/add-missing.tap 322 - [copy Texinfo/mdate-sh] no extra files installed
+PASS: t/add-missing.tap 323 - [copy Texinfo/mdate-sh] automake run successfully
+PASS: t/add-missing.tap 324 - [copy Texinfo/mdate-sh] file mdate-sh installed
+PASS: t/add-missing.tap 325 - [copy Texinfo/mdate-sh] file texinfo.tex installed
+PASS: t/add-missing.tap 326 - [copy Texinfo/mdate-sh] report installation of mdate-sh
+PASS: t/add-missing.tap 327 - [copy Texinfo/mdate-sh] report installation of texinfo.tex
+PASS: t/add-missing.tap 328 - [copy Texinfo/mdate-sh] all and only expected files installed
+PASS: t/add-missing.tap 329 - [copy Texinfo/mdate-sh] mdate-sh has not been symlinked
+PASS: t/add-missing.tap 330 - [copy Texinfo/mdate-sh] texinfo.tex has not been symlinked
+PASS: t/add-missing.tap 331 - [copy Texinfo/mdate-sh] automake finds all added files
+PASS: t/add-missing.tap 332 - [link py-compile] missing files, automake fails
+PASS: t/add-missing.tap 333 - [link py-compile] warn about missing file py-compile
+PASS: t/add-missing.tap 334 - [link py-compile] suggest --add-missing for py-compile
+PASS: t/add-missing.tap 335 - [link py-compile] no extra files installed
+PASS: t/add-missing.tap 336 - [link py-compile] automake run successfully
+PASS: t/add-missing.tap 337 - [link py-compile] file py-compile installed
+PASS: t/add-missing.tap 338 - [link py-compile] report installation of py-compile
+PASS: t/add-missing.tap 339 - [link py-compile] all and only expected files installed
+PASS: t/add-missing.tap 340 - [link py-compile] py-compile has been symlinked
+PASS: t/add-missing.tap 341 - [link py-compile] automake finds all added files
+PASS: t/add-missing.tap 342 - [copy py-compile] missing files, automake fails
+PASS: t/add-missing.tap 343 - [copy py-compile] warn about missing file py-compile
+PASS: t/add-missing.tap 344 - [copy py-compile] suggest --add-missing for py-compile
+PASS: t/add-missing.tap 345 - [copy py-compile] no extra files installed
+PASS: t/add-missing.tap 346 - [copy py-compile] automake run successfully
+PASS: t/add-missing.tap 347 - [copy py-compile] file py-compile installed
+PASS: t/add-missing.tap 348 - [copy py-compile] report installation of py-compile
+PASS: t/add-missing.tap 349 - [copy py-compile] all and only expected files installed
+PASS: t/add-missing.tap 350 - [copy py-compile] py-compile has not been symlinked
+PASS: t/add-missing.tap 351 - [copy py-compile] automake finds all added files
+PASS: t/add-missing.tap 352 - [link misc] missing files, automake fails
+PASS: t/add-missing.tap 353 - [link misc] warn about missing file py-compile
+PASS: t/add-missing.tap 354 - [link misc] suggest --add-missing for py-compile
+PASS: t/add-missing.tap 355 - [link misc] warn about missing file depcomp
+PASS: t/add-missing.tap 356 - [link misc] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 357 - [link misc] warn about missing file ylwrap
+PASS: t/add-missing.tap 358 - [link misc] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 359 - [link misc] warn about missing file config.sub
+PASS: t/add-missing.tap 360 - [link misc] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 361 - [link misc] warn about missing file config.guess
+PASS: t/add-missing.tap 362 - [link misc] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 363 - [link misc] no extra files installed
+PASS: t/add-missing.tap 364 - [link misc] automake run successfully
+PASS: t/add-missing.tap 365 - [link misc] file py-compile installed
+PASS: t/add-missing.tap 366 - [link misc] file depcomp installed
+PASS: t/add-missing.tap 367 - [link misc] file ylwrap installed
+PASS: t/add-missing.tap 368 - [link misc] file config.sub installed
+PASS: t/add-missing.tap 369 - [link misc] file config.guess installed
+PASS: t/add-missing.tap 370 - [link misc] report installation of py-compile
+PASS: t/add-missing.tap 371 - [link misc] report installation of depcomp
+PASS: t/add-missing.tap 372 - [link misc] report installation of ylwrap
+PASS: t/add-missing.tap 373 - [link misc] report installation of config.sub
+PASS: t/add-missing.tap 374 - [link misc] report installation of config.guess
+PASS: t/add-missing.tap 375 - [link misc] all and only expected files installed
+PASS: t/add-missing.tap 376 - [link misc] py-compile has been symlinked
+PASS: t/add-missing.tap 377 - [link misc] depcomp has been symlinked
+PASS: t/add-missing.tap 378 - [link misc] ylwrap has been symlinked
+PASS: t/add-missing.tap 379 - [link misc] config.sub has been symlinked
+PASS: t/add-missing.tap 380 - [link misc] config.guess has been symlinked
+PASS: t/add-missing.tap 381 - [link misc] automake finds all added files
+PASS: t/add-missing.tap 382 - [copy misc] missing files, automake fails
+PASS: t/add-missing.tap 383 - [copy misc] warn about missing file py-compile
+PASS: t/add-missing.tap 384 - [copy misc] suggest --add-missing for py-compile
+PASS: t/add-missing.tap 385 - [copy misc] warn about missing file depcomp
+PASS: t/add-missing.tap 386 - [copy misc] suggest --add-missing for depcomp
+PASS: t/add-missing.tap 387 - [copy misc] warn about missing file ylwrap
+PASS: t/add-missing.tap 388 - [copy misc] suggest --add-missing for ylwrap
+PASS: t/add-missing.tap 389 - [copy misc] warn about missing file config.sub
+PASS: t/add-missing.tap 390 - [copy misc] suggest --add-missing for config.sub
+PASS: t/add-missing.tap 391 - [copy misc] warn about missing file config.guess
+PASS: t/add-missing.tap 392 - [copy misc] suggest --add-missing for config.guess
+PASS: t/add-missing.tap 393 - [copy misc] no extra files installed
+PASS: t/add-missing.tap 394 - [copy misc] automake run successfully
+PASS: t/add-missing.tap 395 - [copy misc] file py-compile installed
+PASS: t/add-missing.tap 396 - [copy misc] file depcomp installed
+PASS: t/add-missing.tap 397 - [copy misc] file ylwrap installed
+PASS: t/add-missing.tap 398 - [copy misc] file config.sub installed
+PASS: t/add-missing.tap 399 - [copy misc] file config.guess installed
+PASS: t/add-missing.tap 400 - [copy misc] report installation of py-compile
+PASS: t/add-missing.tap 401 - [copy misc] report installation of depcomp
+PASS: t/add-missing.tap 402 - [copy misc] report installation of ylwrap
+PASS: t/add-missing.tap 403 - [copy misc] report installation of config.sub
+PASS: t/add-missing.tap 404 - [copy misc] report installation of config.guess
+PASS: t/add-missing.tap 405 - [copy misc] all and only expected files installed
+PASS: t/add-missing.tap 406 - [copy misc] py-compile has not been symlinked
+PASS: t/add-missing.tap 407 - [copy misc] depcomp has not been symlinked
+PASS: t/add-missing.tap 408 - [copy misc] ylwrap has not been symlinked
+PASS: t/add-missing.tap 409 - [copy misc] config.sub has not been symlinked
+PASS: t/add-missing.tap 410 - [copy misc] config.guess has not been symlinked
+PASS: t/add-missing.tap 411 - [copy misc] automake finds all added files
+PASS: t/add-missing-multiple.sh
+XFAIL: t/all.sh
+PASS: t/all2.sh
+PASS: t/alloca.sh
+PASS: t/alloca2.sh
+PASS: t/alpha.sh
+PASS: t/alpha2.sh
+PASS: t/amhello-cflags.sh
+amhello-cross-compile: skipped test: required program 'i586-mingw32msvc-gcc' not available
+SKIP: t/amhello-cross-compile.sh
+PASS: t/amhello-binpkg.sh
+PASS: t/aminit-moreargs-deprecation.sh
+PASS: t/aminit-trailing-dnl-comment-pr16841.sh
+PASS: t/amassign.sh
+PASS: t/am-config-header.sh
+PASS: t/am-prog-cc-stdc.sh
+PASS: t/am-prog-cc-c-o.sh
+PASS: t/am-macro-not-found.sh
+PASS: t/amopt.sh
+PASS: t/amopts-location.sh
+PASS: t/amopts-variable-expansion.sh
+PASS: t/amsubst.sh
+PASS: t/am-default-source-ext.sh
+PASS: t/am-include-only-one-generated-fragment.sh
+PASS: t/ansi2knr-no-more.sh
+PASS: t/ar-lib.sh
+PASS: t/ar-lib2.sh
+PASS: t/ar-lib3.sh
+PASS: t/libtool-macros.sh
+PASS: t/ar-lib4.sh
+ar-lib5a: skipped test: Microsoft 'lib' utility not available
+SKIP: t/ar-lib5a.sh
+PASS: t/ar-lib5b.sh
+PASS: t/ar-lib6a.sh
+PASS: t/ar-lib6b.sh
+PASS: t/ar-lib7.sh
+PASS: t/ar.sh
+PASS: t/ar2.sh
+PASS: t/ar3.sh
+PASS: t/ar4.sh
+PASS: t/ar5.sh
+PASS: t/asm.sh
+PASS: t/asm2.sh
+PASS: t/asm3.sh
+PASS: t/autodist.sh
+PASS: t/autodist-subdir.sh
+PASS: t/autodist-acconfig.sh
+PASS: t/autodist-acconfig-no-subdir.sh
+PASS: t/autodist-aclocal-m4.sh
+PASS: t/autodist-config-headers.sh
+PASS: t/autodist-configure-no-subdir.sh
+PASS: t/autodist-no-duplicate.sh
+autodist-stamp-vti: skipped test: required program 'makeinfo' not available
+SKIP: t/autodist-stamp-vti.sh
+PASS: t/autohdr.sh
+PASS: t/autohdr3.sh
+PASS: t/autohdr4.sh
+PASS: t/autohdr-subdir-pr12495.sh
+PASS: t/autohdrdry.sh
+PASS: t/automake-cmdline.tap 1 - invalid long option (run)
+PASS: t/automake-cmdline.tap 2 - invalid long option (stderr)
+PASS: t/automake-cmdline.tap 3 - list of options terminated by '--' (run)
+PASS: t/automake-cmdline.tap 4 - list of options terminated by '--' (stderr)
+PASS: t/automake-cmdline.tap 5 - empty argument (run)
+PASS: t/automake-cmdline.tap 6 - empty argument (stderr)
+PASS: t/automake-cmdline.tap 7 - missing argument for long option (run)
+PASS: t/automake-cmdline.tap 8 - missing argument for long option (stderr)
+PASS: t/automake-cmdline.tap 9 - missing argument for short option (run)
+PASS: t/automake-cmdline.tap 10 - missing argument for short option (stderr)
+PASS: t/automake-cmdline.tap 11 - '--help' as option argument (run)
+PASS: t/automake-cmdline.tap 12 - '--help' as option argument (stderr)
+PASS: t/automake-cmdline.tap 13 - '--help' as option argument (run)
+PASS: t/automake-cmdline.tap 14 - '--help' as option argument (stderr)
+PASS: t/automake-cmdline.tap 15 - ambiguous incomplete option (run)
+PASS: t/automake-cmdline.tap 16 - ambiguous incomplete option (stderr)
+PASS: t/automake-cmdline.tap 17 - unambiguous incomplete long option
+PASS: t/auxdir.sh
+PASS: t/auxdir6.sh
+PASS: t/auxdir7.sh
+PASS: t/auxdir8.sh
+PASS: t/auxdir-autodetect.sh
+PASS: t/auxdir-computed.tap 1 - aclocal
+XFAIL: t/auxdir-computed.tap 2 - automake -a # TODO long-standing limitation
+XFAIL: t/auxdir-computed.tap 3 - automake # TODO long-standing limitation
+PASS: t/auxdir-misplaced.sh
+PASS: t/auxdir-nonexistent.sh
+XFAIL: t/auxdir-pr19311.sh
+PASS: t/auxdir-unportable.tap 1 - automake exited 1
+PASS: t/auxdir-unportable.tap 2 - warn about non-existent unportable auxdir name
+PASS: t/auxdir-unportable.tap 3 - automake exited 1
+PASS: t/auxdir-unportable.tap 4 - warn about existent unportable auxdir name
+PASS: t/backcompat.sh
+PASS: t/backcompat2.sh
+PASS: t/backcompat3.sh
+PASS: t/backcompat6.sh
+PASS: t/backcompat-acout.sh
+PASS: t/backslash-issues.sh
+PASS: t/backslash-before-trailing-whitespace.sh
+PASS: t/badline.sh
+PASS: t/badopt.sh
+PASS: t/badprog.sh
+PASS: t/built-sources-check.sh
+PASS: t/built-sources-cond.sh
+PASS: t/built-sources-fork-bomb.sh
+PASS: t/built-sources-install.sh
+PASS: t/built-sources-subdir.sh
+PASS: t/built-sources.sh
+PASS: t/candist.sh
+PASS: t/canon.sh
+PASS: t/canon2.sh
+PASS: t/canon3.sh
+PASS: t/canon4.sh
+PASS: t/canon5.sh
+PASS: t/canon6.sh
+PASS: t/canon7.sh
+PASS: t/canon8.sh
+PASS: t/canon-name.sh
+PASS: t/ccnoco.sh
+PASS: t/ccnoco-lib.sh
+PASS: t/ccnoco-lt.sh
+PASS: t/ccnoco3.sh
+PASS: t/ccnoco4.sh
+PASS: t/ccnoco-deps.sh
+PASS: t/check.sh
+PASS: t/check2.sh
+PASS: t/check4.sh
+PASS: t/check5.sh
+PASS: t/check6.sh
+PASS: t/check7.sh
+PASS: t/check8.sh
+PASS: t/check10.sh
+PASS: t/check11.sh
+check12: skipped test: DejaGnu is not available
+SKIP: t/check12.sh
+PASS: t/check-subst.sh
+PASS: t/check-subst-prog.sh
+PASS: t/check-exported-srcdir.sh
+PASS: t/check-fd-redirect.sh
+PASS: t/check-tests-in-builddir.sh
+PASS: t/check-no-test-driver.sh
+PASS: t/check-concurrency-bug9245.sh
+PASS: t/checkall.sh
+PASS: t/clean.sh
+PASS: t/colneq.sh
+PASS: t/colneq2.sh
+PASS: t/colneq3.sh
+PASS: t/colon.sh
+PASS: t/colon2.sh
+PASS: t/colon3.sh
+PASS: t/colon4.sh
+PASS: t/colon5.sh
+PASS: t/colon6.sh
+PASS: t/colon7.sh
+PASS: t/color-tests.sh
+color-tests2: skipped test: requires a working expect program
+SKIP: t/color-tests2.sh
+PASS: t/color-tests-opt.sh
+PASS: t/comment.sh
+PASS: t/comment2.sh
+PASS: t/comment3.sh
+PASS: t/comment4.sh
+PASS: t/comment5.sh
+PASS: t/comment6.sh
+PASS: t/comment7.sh
+PASS: t/comment8.sh
+PASS: t/comment9.sh
+PASS: t/commen10.sh
+PASS: t/commen11.sh
+PASS: t/comment-block.sh
+PASS: t/comments-in-var-def.sh
+PASS: t/compile.sh
+PASS: t/compile2.sh
+PASS: t/compile3.sh
+compile4: skipped test: Microsoft C compiler 'cl' not available
+SKIP: t/compile4.sh
+compile5: skipped test: target OS is not MinGW
+SKIP: t/compile5.sh
+PASS: t/compile6.sh
+compile7: skipped test: Intel C compiler 'icl' not available
+SKIP: t/compile7.sh
+PASS: t/compile_f90_c_cxx.sh
+PASS: t/compile_f_c_cxx.sh
+PASS: t/cond-basic.sh
+PASS: t/cond.sh
+PASS: t/cond3.sh
+PASS: t/cond4.sh
+PASS: t/cond5.sh
+PASS: t/cond6.sh
+PASS: t/cond7.sh
+PASS: t/cond8.sh
+PASS: t/cond9.sh
+PASS: t/cond10.sh
+PASS: t/cond11.sh
+PASS: t/cond13.sh
+PASS: t/cond14.sh
+PASS: t/cond15.sh
+PASS: t/cond16.sh
+XFAIL: t/cond17.sh
+PASS: t/cond18.sh
+PASS: t/cond19.sh
+PASS: t/cond20.sh
+PASS: t/cond21.sh
+PASS: t/cond22.sh
+PASS: t/cond23.sh
+PASS: t/cond24.sh
+PASS: t/cond25.sh
+PASS: t/cond26.sh
+PASS: t/cond27.sh
+PASS: t/cond28.sh
+PASS: t/cond30.sh
+PASS: t/cond31.sh
+PASS: t/cond32.sh
+PASS: t/cond33.sh
+PASS: t/cond34.sh
+PASS: t/cond35.sh
+PASS: t/cond36.sh
+PASS: t/cond37.sh
+PASS: t/cond38.sh
+PASS: t/cond39.sh
+PASS: t/cond40.sh
+PASS: t/cond41.sh
+PASS: t/cond42.sh
+PASS: t/cond43.sh
+PASS: t/cond44.sh
+PASS: t/cond45.sh
+PASS: t/cond46.sh
+PASS: t/condd.sh
+PASS: t/condhook.sh
+PASS: t/condhook2.sh
+PASS: t/condinc.sh
+PASS: t/condinc2.sh
+PASS: t/condlib.sh
+PASS: t/condman2.sh
+PASS: t/condman3.sh
+PASS: t/configure.sh
+PASS: t/confdeps.sh
+PASS: t/conff.sh
+PASS: t/conff2.sh
+PASS: t/conffile-leading-dot.sh
+PASS: t/confh.sh
+PASS: t/confh4.sh
+PASS: t/confh5.sh
+PASS: t/confh6.sh
+PASS: t/confh7.sh
+PASS: t/confh8.sh
+PASS: t/confh-subdir-clean.sh
+PASS: t/confincl.sh
+PASS: t/conflnk.sh
+PASS: t/conflnk2.sh
+PASS: t/conflnk3.sh
+PASS: t/conflnk4.sh
+PASS: t/confsub.sh
+PASS: t/confvar.sh
+PASS: t/confvar2.sh
+PASS: t/copy.sh
+PASS: t/cscope.tap 1 - [relative VPATH] configure
+PASS: t/cscope.tap 2 - [relative VPATH] make -n cscope
+SKIP: t/cscope.tap 3 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 4 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 5 # SKIP no proper cscope program available
+PASS: t/cscope.tap 6 - [relative VPATH] make distcheck
+PASS: t/cscope.tap 7 - [absolute VPATH] configure
+PASS: t/cscope.tap 8 - [absolute VPATH] make -n cscope
+SKIP: t/cscope.tap 9 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 10 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 11 # SKIP no proper cscope program available
+PASS: t/cscope.tap 12 - [absolute VPATH] make distcheck
+PASS: t/cscope.tap 13 - [in-tree build] configure
+PASS: t/cscope.tap 14 - [in-tree build] make -n cscope
+SKIP: t/cscope.tap 15 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 16 # SKIP no proper cscope program available
+SKIP: t/cscope.tap 17 # SKIP no proper cscope program available
+PASS: t/cscope.tap 18 - [in-tree build] make distcheck
+PASS: t/cscope2.sh
+cscope3: skipped test: required program 'cscope' not available
+SKIP: t/cscope3.sh
+PASS: t/c-demo.sh
+PASS: t/cxx.sh
+PASS: t/cxx2.sh
+PASS: t/cxxcpp.sh
+PASS: t/cxx-demo.sh
+PASS: t/cxx-lt-demo.sh
+PASS: t/cxxlibobj.sh
+PASS: t/cxxlink.sh
+PASS: t/cxxnoc.sh
+PASS: t/cygnus-no-more.sh
+PASS: t/cygwin32.sh
+PASS: t/dash.sh
+PASS: t/defun.sh
+PASS: t/defun2.sh
+PASS: t/dejagnu.sh
+PASS: t/dejagnu2.sh
+dejagnu3: skipped test: DejaGnu is not available
+SKIP: t/dejagnu3.sh
+dejagnu4: skipped test: DejaGnu is not available
+SKIP: t/dejagnu4.sh
+dejagnu5: skipped test: DejaGnu is not available
+SKIP: t/dejagnu5.sh
+dejagnu6: skipped test: DejaGnu is not available
+SKIP: t/dejagnu6.sh
+dejagnu7: skipped test: DejaGnu is not available
+SKIP: t/dejagnu7.sh
+dejagnu-absolute-builddir: skipped test: DejaGnu is not available
+SKIP: t/dejagnu-absolute-builddir.sh
+dejagnu-relative-srcdir: skipped test: DejaGnu is not available
+SKIP: t/dejagnu-relative-srcdir.sh
+dejagnu-siteexp-extend: skipped test: DejaGnu is not available
+SKIP: t/dejagnu-siteexp-extend.sh
+PASS: t/dejagnu-siteexp-append.sh
+PASS: t/dejagnu-siteexp-useredit.sh
+PASS: t/deleted-am.sh
+PASS: t/deleted-m4.sh
+PASS: t/depacl2.sh
+PASS: t/depcomp.sh
+PASS: t/depcomp2.sh
+PASS: t/depcomp8a.sh
+PASS: t/depcomp8b.sh
+PASS: t/depcomp-implicit-auxdir.sh
+PASS: t/depdist.sh
+PASS: t/depend.sh
+PASS: t/depend3.sh
+PASS: t/depend4.sh
+PASS: t/depend5.sh
+PASS: t/depend6.sh
+PASS: t/deprecated-acinit.sh
+PASS: t/destdir.sh
+PASS: t/dir-named-obj-is-bad.sh
+PASS: t/discover.sh
+PASS: t/dist-formats.tap 1 - default [automake]
+PASS: t/dist-formats.tap 2 - default [autoconf]
+PASS: t/dist-formats.tap 3 - default [configure]
+PASS: t/dist-formats.tap 4 - default [make distcheck]
+PASS: t/dist-formats.tap 5 - 'make dist' only builds *.tar.gz by default
+PASS: t/dist-formats.tap 6 - 'dist-gzip' target always created
+PASS: t/dist-formats.tap 7 - 'make dist-gzip' work by default
+PASS: t/dist-formats.tap 8 - 'dist-lzip' target always created
+SKIP: t/dist-formats.tap 9 - 'make dist-lzip' work by default # SKIP 'lzip' not available
+PASS: t/dist-formats.tap 10 - 'dist-xz' target always created
+PASS: t/dist-formats.tap 11 - 'make dist-xz' work by default
+PASS: t/dist-formats.tap 12 - 'dist-bzip2' target always created
+PASS: t/dist-formats.tap 13 - 'make dist-bzip2' work by default
+PASS: t/dist-formats.tap 14 - 'dist-zip' target always created
+PASS: t/dist-formats.tap 15 - 'make dist-zip' work by default
+PASS: t/dist-formats.tap 16 - no-dist-gzip (am) without other formats is an error
+PASS: t/dist-formats.tap 17 - no-dist-gzip (am) without other formats gives diagnostic
+PASS: t/dist-formats.tap 18 - no-dist-gzip (ac) without other formats is an error
+PASS: t/dist-formats.tap 19 - no-dist-gzip (ac) without other formats gives diagnostic
+PASS: t/dist-formats.tap 20 - am=dist-bzip2,no-dist-gzip [automake]
+PASS: t/dist-formats.tap 21 - am=dist-bzip2,no-dist-gzip [autoconf]
+PASS: t/dist-formats.tap 22 - am=dist-bzip2,no-dist-gzip [configure]
+PASS: t/dist-formats.tap 23 - am=dist-bzip2,no-dist-gzip [ark-name]
+PASS: t/dist-formats.tap 24 - am=dist-bzip2,no-dist-gzip [distcheck]
+PASS: t/dist-formats.tap 25 - am=dist-bzip2,no-dist-gzip [ark-exists]
+PASS: t/dist-formats.tap 26 - am=dist-bzip2,no-dist-gzip [no .tar.gz]
+PASS: t/dist-formats.tap 27 - am=dist-xz ac=no-dist-gzip [automake]
+PASS: t/dist-formats.tap 28 - am=dist-xz ac=no-dist-gzip [autoconf]
+PASS: t/dist-formats.tap 29 - am=dist-xz ac=no-dist-gzip [configure]
+PASS: t/dist-formats.tap 30 - am=dist-xz ac=no-dist-gzip [ark-name]
+PASS: t/dist-formats.tap 31 - am=dist-xz ac=no-dist-gzip [distcheck]
+PASS: t/dist-formats.tap 32 - am=dist-xz ac=no-dist-gzip [ark-exists]
+PASS: t/dist-formats.tap 33 - am=dist-xz ac=no-dist-gzip [no .tar.gz]
+PASS: t/dist-formats.tap 34 - am=no-dist-gzip ac=dist-lzip [automake]
+PASS: t/dist-formats.tap 35 - am=no-dist-gzip ac=dist-lzip [autoconf]
+PASS: t/dist-formats.tap 36 - am=no-dist-gzip ac=dist-lzip [configure]
+PASS: t/dist-formats.tap 37 - am=no-dist-gzip ac=dist-lzip [ark-name]
+SKIP: t/dist-formats.tap 38 - am=no-dist-gzip ac=dist-lzip [distcheck] # SKIP 'lzip' not available
+SKIP: t/dist-formats.tap 39 - am=no-dist-gzip ac=dist-lzip [ark-exists] # SKIP 'lzip' not available
+PASS: t/dist-formats.tap 40 - am=no-dist-gzip ac=dist-lzip [no .tar.gz]
+PASS: t/dist-formats.tap 41 - ac=dist-zip,no-dist-gzip [automake]
+PASS: t/dist-formats.tap 42 - ac=dist-zip,no-dist-gzip [autoconf]
+PASS: t/dist-formats.tap 43 - ac=dist-zip,no-dist-gzip [configure]
+PASS: t/dist-formats.tap 44 - ac=dist-zip,no-dist-gzip [ark-name]
+PASS: t/dist-formats.tap 45 - ac=dist-zip,no-dist-gzip [distcheck]
+PASS: t/dist-formats.tap 46 - ac=dist-zip,no-dist-gzip [ark-exists]
+PASS: t/dist-formats.tap 47 - ac=dist-zip,no-dist-gzip [no .tar.gz]
+PASS: t/dist-formats.tap 48 - dist-gzip persistence [automake]
+PASS: t/dist-formats.tap 49 - dist-gzip persistence [autoconf]
+PASS: t/dist-formats.tap 50 - dist-gzip persistence [configure]
+PASS: t/dist-formats.tap 51 - 'dist-gzip' target always created
+PASS: t/dist-formats.tap 52 - 'make dist-gzip' work by default
+PASS: t/dist-formats.tap 53 - gzip+bzip2+xz [automake]
+PASS: t/dist-formats.tap 54 - gzip+bzip2+xz [autoconf]
+PASS: t/dist-formats.tap 55 - gzip+bzip2+xz [configure]
+PASS: t/dist-formats.tap 56 - gzip+bzip2+xz [make -j4 dist-all]
+PASS: t/dist-formats.tap 57 - gzip+bzip2+xz [check .tar.gz tarball]
+PASS: t/dist-formats.tap 58 - gzip+bzip2+xz [check .tar.bz2 tarball]
+PASS: t/dist-formats.tap 59 - gzip+bzip2+xz [check .tar.xz tarball]
+PASS: t/dist-formats.tap 60 - all compressors together [aclocal]
+PASS: t/dist-formats.tap 61 - all compressors together [automake]
+PASS: t/dist-formats.tap 62 - all compressors together [autoconf]
+PASS: t/dist-formats.tap 63 - all compressors together [configure]
+SKIP: t/dist-formats.tap 64 - all compressors together [make distcheck, real] # SKIP not all compressors available
+PASS: t/dist-formats.tap 65 - all compressors together ['make dist-all', stubbed]
+PASS: t/dist-formats.tap 66 - all compressors together ['make dist -j4', stubbed]
+PASS: t/dist-lzma.sh
+PASS: t/dist-tarZ.sh
+dist-shar: skipped test: required program 'shar' not available
+SKIP: t/dist-shar.sh
+PASS: t/dist-auxdir-many-subdirs.sh
+PASS: t/dist-auxfile-2.sh
+PASS: t/dist-auxfile.sh
+PASS: t/dist-included-parent-dir.sh
+PASS: t/dist-missing-am.sh
+PASS: t/dist-missing-included-m4.sh
+PASS: t/dist-missing-m4.sh
+PASS: t/dist-readonly.sh
+PASS: t/dist-repeated.sh
+XFAIL: t/dist-pr109765.sh
+PASS: t/distcleancheck.sh
+PASS: t/distcom2.sh
+PASS: t/distcom3.sh
+PASS: t/distcom4.sh
+PASS: t/distcom5.sh
+PASS: t/distcom-subdir.sh
+FAIL: t/distdir.sh
+FAIL: t/disthook.sh
+PASS: t/distlinks.sh
+PASS: t/distlinksbrk.sh
+PASS: t/distname.sh
+PASS: t/distcheck-configure-flags.sh
+PASS: t/distcheck-configure-flags-am.sh
+PASS: t/distcheck-configure-flags-subpkg.sh
+PASS: t/distcheck-hook.sh
+PASS: t/distcheck-hook2.sh
+PASS: t/distcheck-writable-srcdir.sh
+PASS: t/distcheck-missing-m4.sh
+PASS: t/distcheck-outdated-m4.sh
+PASS: t/distcheck-no-prefix-or-srcdir-override.sh
+distcheck-override-infodir: skipped test: required program 'makeinfo' not available
+SKIP: t/distcheck-override-infodir.sh
+PASS: t/distcheck-pr9579.sh
+distcheck-pr10470: skipped test: system is able to remove "in use" directories
+SKIP: t/distcheck-pr10470.sh
+PASS: t/distcheck-pr18286.sh
+PASS: t/dmalloc.sh
+PASS: t/doc-parsing-buglets-colneq-subst.sh
+PASS: t/doc-parsing-buglets-tabs.sh
+PASS: t/dollar.sh
+PASS: t/dollarvar.sh
+PASS: t/dollarvar2.sh
+PASS: t/double.sh
+PASS: t/dup2.sh
+PASS: t/else.sh
+PASS: t/empty-data-primary.sh
+PASS: t/empty-sources-primary.tap 1 - aclocal
+PASS: t/empty-sources-primary.tap 2 - automake
+PASS: t/empty-sources-primary.tap 3 - default _SOURCES
+PASS: t/empty-sources-primary.tap 4 - empty _SOURCES (basic)
+PASS: t/empty-sources-primary.tap 5 - empty _SOURCES (elaborate)
+PASS: t/exdir.sh
+PASS: t/exdir2.sh
+PASS: t/exdir3.sh
+PASS: t/exeext.sh
+PASS: t/exeext2.sh
+PASS: t/exeext3.sh
+PASS: t/exeext4.sh
+PASS: t/extra-sources.sh
+PASS: t/ext.sh
+PASS: t/ext2.sh
+PASS: t/ext3.sh
+PASS: t/extra.sh
+PASS: t/extra-sources-no-spurious.sh
+PASS: t/extra-data.sh
+FAIL: t/extra-dist-vpath-dir.sh
+FAIL: t/extra-dist-dirs-and-subdirs.sh
+FAIL: t/extra-dist-vpath-dir-merge.sh
+PASS: t/extra-dist-wildcards.sh
+FAIL: t/extra-dist-wildcards-gnu.sh
+PASS: t/extra-dist-wildcards-vpath.sh
+PASS: t/extra-programs-misc.sh
+PASS: t/extra-programs-and-libs.sh
+PASS: t/extra-programs-empty.sh
+PASS: t/extra-portability.sh
+PASS: t/extra-portability2.sh
+PASS: t/extra-portability3.sh
+PASS: t/extra-deps.sh
+PASS: t/extra-deps-lt.sh
+PASS: t/f90only.sh
+PASS: t/flavor.sh
+PASS: t/flibs.sh
+FAIL: t/fn99.sh
+FAIL: t/fn99subdir.sh
+PASS: t/fnoc.sh
+PASS: t/forcemiss.sh
+PASS: t/forcemiss2.sh
+PASS: t/fort1.sh
+FAIL: t/fort2.sh
+FAIL: t/fort4.sh
+FAIL: t/fort5.sh
+PASS: t/fonly.sh
+PASS: t/fortdep.sh
+PASS: t/gcj.sh
+PASS: t/gcj2.sh
+PASS: t/gcj3.sh
+gcj4: skipped test: GNU Java compiler unavailable
+SKIP: t/gcj4.sh
+PASS: t/gcj5.sh
+gcj6: skipped test: GNU Java compiler unavailable
+SKIP: t/gcj6.sh
+gettext-macros: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-macros.sh
+gettext-basics: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-basics.sh
+gettext-config-rpath: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-config-rpath.sh
+gettext-external-pr338: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-external-pr338.sh
+gettext-intl-subdir: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-intl-subdir.sh
+gettext-pr381: skipped test: couldn't find or get gettext macros
+SKIP: t/gettext-pr381.sh
+PASS: t/gnumake.sh
+PASS: t/gnuwarn.sh
+PASS: t/gnuwarn2.sh
+PASS: t/gnits.sh
+PASS: t/gnits2.sh
+PASS: t/gnits3.sh
+PASS: t/hdr-vars-defined-once.sh
+PASS: t/header.sh
+PASS: t/help.sh
+PASS: t/help2.sh
+PASS: t/help3.sh
+PASS: t/help4.sh
+PASS: t/help-depend.sh
+PASS: t/help-depend2.sh
+PASS: t/help-dmalloc.sh
+PASS: t/help-init.sh
+PASS: t/help-lispdir.sh
+PASS: t/help-python.sh
+PASS: t/help-silent.sh
+PASS: t/help-upc.sh
+PASS: t/hfs.sh
+PASS: t/implicit.sh
+PASS: t/init.sh
+PASS: t/init2.sh
+PASS: t/dist-install-sh.sh
+PASS: t/dist-with-unreadable-makefile-fails.sh
+PASS: t/installdir.sh
+PASS: t/add-missing-install-sh.sh
+PASS: t/install-sh-unittests.sh
+PASS: t/install-sh-option-C.sh
+PASS: t/instdat.sh
+PASS: t/instdat2.sh
+PASS: t/instdir.sh
+PASS: t/instdir2.sh
+PASS: t/instdir-cond.sh
+XFAIL: t/instdir-cond2.sh
+PASS: t/instdir-no-empty.sh
+PASS: t/instdir-java.sh
+instdir-lisp: skipped test: required program 'emacs' not available
+SKIP: t/instdir-lisp.sh
+PASS: t/instdir-ltlib.sh
+PASS: t/instdir-prog.sh
+PASS: t/instdir-python.sh
+instdir-texi: skipped test: required program 'makeinfo' not available
+SKIP: t/instdir-texi.sh
+PASS: t/instexec.sh
+PASS: t/instfail.sh
+instfail-info: skipped test: required program 'makeinfo' not available
+SKIP: t/instfail-info.sh
+PASS: t/instfail-java.sh
+PASS: t/instfail-libtool.sh
+PASS: t/insthook.sh
+PASS: t/instman.sh
+PASS: t/instman2.sh
+PASS: t/instmany.sh
+PASS: t/instmany-mans.sh
+PASS: t/instmany-python.sh
+install-info-dir: skipped test: required program 'makeinfo' not available
+SKIP: t/install-info-dir.sh
+PASS: t/interp.sh
+PASS: t/interp2.sh
+PASS: t/java.sh
+PASS: t/java2.sh
+PASS: t/java3.sh
+PASS: t/javadir-undefined.sh
+PASS: t/javaflags.sh
+PASS: t/java-check.sh
+PASS: t/java-clean.sh
+PASS: t/java-compile-install.sh
+PASS: t/java-compile-run-flat.sh
+PASS: t/java-compile-run-nested.sh
+PASS: t/java-empty-classpath.sh
+PASS: t/javaprim.sh
+PASS: t/javasubst.sh
+PASS: t/java-extra.sh
+PASS: t/java-mix.sh
+PASS: t/java-no-duplicate.sh
+XFAIL: t/java-nobase.sh
+PASS: t/java-noinst.sh
+PASS: t/java-rebuild.sh
+PASS: t/java-sources.sh
+PASS: t/java-uninstall.sh
+PASS: t/ldadd.sh
+PASS: t/ldflags.sh
+PASS: t/lex.sh
+PASS: t/lex2.sh
+PASS: t/lex3.sh
+PASS: t/lex5.sh
+PASS: t/lexcpp.sh
+PASS: t/lexvpath.sh
+XFAIL: t/lex-subobj-nodep.sh
+PASS: t/lex-header.sh
+PASS: t/lex-lib.sh
+PASS: t/lex-lib-external.sh
+PASS: t/lex-libobj.sh
+PASS: t/lex-multiple.sh
+PASS: t/lex-noyywrap.sh
+PASS: t/lex-clean-cxx.sh
+PASS: t/lex-clean.sh
+PASS: t/lex-depend-cxx.sh
+PASS: t/lex-depend-grep.sh
+PASS: t/lex-depend.sh
+PASS: t/lex-line.sh
+PASS: t/lex-nodist.sh
+PASS: t/lex-pr204.sh
+PASS: t/lflags.sh
+PASS: t/lflags-cxx.sh
+PASS: t/libexec.sh
+PASS: t/libobj-basic.sh
+PASS: t/libobj2.sh
+PASS: t/libobj3.sh
+PASS: t/libobj4.sh
+PASS: t/libobj5.sh
+PASS: t/libobj7.sh
+PASS: t/libobj10.sh
+PASS: t/libobj12.sh
+PASS: t/libobj13.sh
+PASS: t/libobj14.sh
+PASS: t/libobj15a.sh
+PASS: t/libobj15b.sh
+PASS: t/libobj15c.sh
+PASS: t/libobj16a.sh
+PASS: t/libobj16b.sh
+PASS: t/libobj17.sh
+PASS: t/libobj18.sh
+PASS: t/libobj19.sh
+PASS: t/libobj20a.sh
+PASS: t/libobj20b.sh
+PASS: t/libobj20c.sh
+PASS: t/library.sh
+PASS: t/library2.sh
+PASS: t/library3.sh
+PASS: t/libtool.sh
+PASS: t/libtool2.sh
+PASS: t/libtool3.sh
+PASS: t/libtool4.sh
+PASS: t/libtool5.sh
+PASS: t/libtool6.sh
+PASS: t/libtool7.sh
+PASS: t/libtool8.sh
+PASS: t/libtool9.sh
+PASS: t/libtoo10.sh
+PASS: t/libtoo11.sh
+PASS: t/license.sh
+PASS: t/license2.sh
+PASS: t/link_c_cxx.sh
+PASS: t/link_cond.sh
+PASS: t/link_dist.sh
+PASS: t/link_f90_only.sh
+PASS: t/link_fc.sh
+PASS: t/link_fccxx.sh
+PASS: t/link_fcxx.sh
+PASS: t/link_f_only.sh
+PASS: t/link_override.sh
+PASS: t/lisp2.sh
+lisp3: skipped test: required program 'emacs' not available
+SKIP: t/lisp3.sh
+lisp4: skipped test: required program 'emacs' not available
+SKIP: t/lisp4.sh
+lisp5: skipped test: required program 'emacs' not available
+SKIP: t/lisp5.sh
+lisp6: skipped test: required program 'emacs' not available
+SKIP: t/lisp6.sh
+PASS: t/lisp7.sh
+lisp8: skipped test: required program 'emacs' not available
+SKIP: t/lisp8.sh
+lisp-loadpath: skipped test: required program 'emacs' not available
+SKIP: t/lisp-loadpath.sh
+lisp-subdir: skipped test: required program 'emacs' not available
+SKIP: t/lisp-subdir.sh
+lisp-subdir2: skipped test: required program 'emacs' not available
+SKIP: t/lisp-subdir2.sh
+lisp-subdir-mix: skipped test: required program 'emacs' not available
+SKIP: t/lisp-subdir-mix.sh
+lispdry: skipped test: required program 'emacs' not available
+SKIP: t/lispdry.sh
+lisp-pr11806: skipped test: required program 'emacs' not available
+SKIP: t/lisp-pr11806.sh
+PASS: t/lisp-flags.sh
+PASS: t/listval.sh
+PASS: t/location.sh
+PASS: t/longline.sh
+PASS: t/longlin2.sh
+PASS: t/ltcond.sh
+PASS: t/ltcond2.sh
+PASS: t/ltconv.sh
+PASS: t/ltdeps.sh
+PASS: t/ltinit.sh
+PASS: t/ltinstloc.sh
+PASS: t/ltlibobjs.sh
+PASS: t/ltlibsrc.sh
+PASS: t/ltorder.sh
+PASS: t/m4-inclusion.sh
+PASS: t/maintclean.sh
+PASS: t/maintclean-vpath.sh
+PASS: t/maintmode-configure-msg.sh
+PASS: t/make.sh
+PASS: t/makefile-deps.sh
+PASS: t/makej.sh
+PASS: t/makej2.sh
+PASS: t/maken.sh
+PASS: t/maken3.sh
+PASS: t/makevars.sh
+PASS: t/make-dryrun.tap 1 - run
+PASS: t/make-dryrun.tap 2 - run (-s)
+PASS: t/make-dryrun.tap 3 - run (-s -r)
+PASS: t/make-dryrun.tap 4 - run
+PASS: t/make-dryrun.tap 5 - run (-s)
+PASS: t/make-dryrun.tap 6 - run (-s -r)
+PASS: t/make-dryrun.tap 7 - run
+PASS: t/make-dryrun.tap 8 - run (-s)
+PASS: t/make-dryrun.tap 9 - run (-s -r)
+PASS: t/make-dryrun.tap 10 - run
+PASS: t/make-dryrun.tap 11 - run (-s)
+PASS: t/make-dryrun.tap 12 - run (-s -r)
+PASS: t/make-dryrun.tap 13 - run
+PASS: t/make-dryrun.tap 14 - run (-s)
+PASS: t/make-dryrun.tap 15 - run (-s -r)
+PASS: t/make-dryrun.tap 16 - run
+PASS: t/make-dryrun.tap 17 - run (-s)
+PASS: t/make-dryrun.tap 18 - run (-s -r)
+PASS: t/make-dryrun.tap 19 - dry
+PASS: t/make-dryrun.tap 20 - dry (-s)
+PASS: t/make-dryrun.tap 21 - dry (-s -r)
+PASS: t/make-dryrun.tap 22 - dry
+PASS: t/make-dryrun.tap 23 - dry (-s)
+PASS: t/make-dryrun.tap 24 - dry (-s -r)
+PASS: t/make-dryrun.tap 25 - run [bug#13760]
+PASS: t/make-dryrun.tap 26 - run [bug#13760] (-s)
+PASS: t/make-dryrun.tap 27 - run [bug#13760] (-s -r)
+PASS: t/make-dryrun.tap 28 - run [bug#13760]
+PASS: t/make-dryrun.tap 29 - run [bug#13760] (-s)
+PASS: t/make-dryrun.tap 30 - run [bug#13760] (-s -r)
+PASS: t/make-dryrun.tap 31 - dry [bug#13760]
+PASS: t/make-dryrun.tap 32 - dry [bug#13760] (-s)
+PASS: t/make-dryrun.tap 33 - dry [bug#13760] (-s -r)
+PASS: t/make-dryrun.tap 34 - dry [bug#13760]
+PASS: t/make-dryrun.tap 35 - dry [bug#13760] (-s)
+PASS: t/make-dryrun.tap 36 - dry [bug#13760] (-s -r)
+PASS: t/make-dryrun.tap 37 - run [metachars]
+PASS: t/make-dryrun.tap 38 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 39 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 40 - run [metachars]
+PASS: t/make-dryrun.tap 41 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 42 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 43 - run [metachars]
+PASS: t/make-dryrun.tap 44 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 45 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 46 - run [metachars]
+PASS: t/make-dryrun.tap 47 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 48 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 49 - run [metachars]
+PASS: t/make-dryrun.tap 50 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 51 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 52 - run [metachars]
+PASS: t/make-dryrun.tap 53 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 54 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 55 - run [metachars]
+PASS: t/make-dryrun.tap 56 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 57 - run [metachars] (-s -r)
+PASS: t/make-dryrun.tap 58 - run [metachars]
+PASS: t/make-dryrun.tap 59 - run [metachars] (-s)
+PASS: t/make-dryrun.tap 60 - run [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 1 - k-n
+PASS: t/make-keepgoing.tap 2 - k-n (-s)
+PASS: t/make-keepgoing.tap 3 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 4 - k-n
+PASS: t/make-keepgoing.tap 5 - k-n (-s)
+PASS: t/make-keepgoing.tap 6 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 7 - k-n
+PASS: t/make-keepgoing.tap 8 - k-n (-s)
+PASS: t/make-keepgoing.tap 9 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 10 - k-n
+PASS: t/make-keepgoing.tap 11 - k-n (-s)
+PASS: t/make-keepgoing.tap 12 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 13 - k-n
+PASS: t/make-keepgoing.tap 14 - k-n (-s)
+PASS: t/make-keepgoing.tap 15 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 16 - k-n
+PASS: t/make-keepgoing.tap 17 - k-n (-s)
+PASS: t/make-keepgoing.tap 18 - k-n (-s -r)
+PASS: t/make-keepgoing.tap 19 - k-y
+PASS: t/make-keepgoing.tap 20 - k-y (-s)
+PASS: t/make-keepgoing.tap 21 - k-y (-s -r)
+PASS: t/make-keepgoing.tap 22 - k-y
+PASS: t/make-keepgoing.tap 23 - k-y (-s)
+PASS: t/make-keepgoing.tap 24 - k-y (-s -r)
+PASS: t/make-keepgoing.tap 25 - k-n [bug#12554]
+PASS: t/make-keepgoing.tap 26 - k-n [bug#12554] (-s)
+PASS: t/make-keepgoing.tap 27 - k-n [bug#12554] (-s -r)
+PASS: t/make-keepgoing.tap 28 - k-n [bug#12554]
+PASS: t/make-keepgoing.tap 29 - k-n [bug#12554] (-s)
+PASS: t/make-keepgoing.tap 30 - k-n [bug#12554] (-s -r)
+PASS: t/make-keepgoing.tap 31 - k-y [bug#12554]
+PASS: t/make-keepgoing.tap 32 - k-y [bug#12554] (-s)
+PASS: t/make-keepgoing.tap 33 - k-y [bug#12554] (-s -r)
+PASS: t/make-keepgoing.tap 34 - k-y [bug#12554]
+PASS: t/make-keepgoing.tap 35 - k-y [bug#12554] (-s)
+PASS: t/make-keepgoing.tap 36 - k-y [bug#12554] (-s -r)
+PASS: t/make-keepgoing.tap 37 - k-n [metachars]
+PASS: t/make-keepgoing.tap 38 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 39 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 40 - k-n [metachars]
+PASS: t/make-keepgoing.tap 41 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 42 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 43 - k-n [metachars]
+PASS: t/make-keepgoing.tap 44 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 45 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 46 - k-n [metachars]
+PASS: t/make-keepgoing.tap 47 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 48 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 49 - k-n [metachars]
+PASS: t/make-keepgoing.tap 50 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 51 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 52 - k-n [metachars]
+PASS: t/make-keepgoing.tap 53 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 54 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 55 - k-n [metachars]
+PASS: t/make-keepgoing.tap 56 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 57 - k-n [metachars] (-s -r)
+PASS: t/make-keepgoing.tap 58 - k-n [metachars]
+PASS: t/make-keepgoing.tap 59 - k-n [metachars] (-s)
+PASS: t/make-keepgoing.tap 60 - k-n [metachars] (-s -r)
+PASS: t/make-is-gnu.sh
+PASS: t/man.sh
+PASS: t/man2.sh
+PASS: t/man3.sh
+PASS: t/man5.sh
+man6: skipped test: required program 'help2man' not available
+SKIP: t/man6.sh
+PASS: t/man7.sh
+PASS: t/man8.sh
+PASS: t/mdate.sh
+PASS: t/mdate2.sh
+PASS: t/mdate3.sh
+PASS: t/mdate4.sh
+PASS: t/mdate5.sh
+PASS: t/mdate6.sh
+PASS: t/missing-version-mismatch.sh
+PASS: t/missing3.sh
+PASS: t/am-missing-prog.sh
+PASS: t/missing-auxfile-stops-makefiles-creation.sh
+PASS: t/mkdir_p.sh
+PASS: t/mkdirp-deprecation.sh
+PASS: t/mkinstall.sh
+PASS: t/mkinst2.sh
+PASS: t/mkinst3.sh
+PASS: t/mmode.sh
+PASS: t/mmodely.sh
+PASS: t/no-extra-c-stuff.sh
+PASS: t/no-extra-makefile-code.sh
+PASS: t/no-spurious-install-recursive.sh
+PASS: t/nobase.sh
+PASS: t/nobase-libtool.sh
+PASS: t/nobase-python.sh
+PASS: t/nobase-nodist.sh
+PASS: t/nodef.sh
+PASS: t/nodef2.sh
+PASS: t/nodep.sh
+PASS: t/nodep2.sh
+PASS: t/nodepcomp.sh
+PASS: t/nodist.sh
+PASS: t/nodist2.sh
+PASS: t/nodist3.sh
+PASS: t/noinst.sh
+PASS: t/noinstdir.sh
+PASS: t/nolink.sh
+PASS: t/nostdinc.sh
+PASS: t/notrans.sh
+PASS: t/number.sh
+PASS: t/objc-basic.sh
+SKIP: t/objc-minidemo.sh
+SKIP: t/objc-flags.sh
+SKIP: t/objc-deps.sh
+PASS: t/objcxx-basic.sh
+SKIP: t/objcxx-minidemo.sh
+SKIP: t/objcxx-flags.sh
+SKIP: t/objcxx-deps.sh
+SKIP: t/objc-megademo.sh
+XFAIL: t/objext-pr10128.sh
+PASS: t/oldvars.sh
+PASS: t/order.sh
+PASS: t/output.sh
+PASS: t/output2.sh
+PASS: t/output3.sh
+PASS: t/output4.sh
+PASS: t/output5.sh
+PASS: t/output6.sh
+PASS: t/output7.sh
+PASS: t/output8.sh
+PASS: t/output9.sh
+PASS: t/output10.sh
+PASS: t/output11.sh
+PASS: t/output12.sh
+PASS: t/output13.sh
+PASS: t/output-order.sh
+PASS: t/override-conditional-1.sh
+XFAIL: t/override-conditional-2.sh
+XFAIL: t/override-conditional-pr13940.sh
+PASS: t/override-html.sh
+PASS: t/override-suggest-local.sh
+PASS: t/parallel-am.sh
+PASS: t/parallel-am2.sh
+PASS: t/parallel-am3.sh
+PASS: t/serial-tests.sh
+PASS: t/parallel-tests-basics.sh
+PASS: t/parallel-tests-concurrency.sh
+PASS: t/parallel-tests-concurrency-2.sh
+PASS: t/parallel-tests-empty.sh
+PASS: t/parallel-tests-exit-status-reported.sh
+PASS: t/parallel-tests-generated-and-distributed.sh
+PASS: t/parallel-tests-recheck.sh
+PASS: t/parallel-tests-trailing-whitespace.sh
+PASS: t/parallel-tests-recheck-depends-on-all.sh
+PASS: t/parallel-tests-recheck-pr11791.sh
+PASS: t/parallel-tests-exeext.sh
+PASS: t/parallel-tests-suffix.sh
+PASS: t/parallel-tests-suffix-prog.sh
+PASS: t/parallel-tests-log-compiler-1.sh
+PASS: t/parallel-tests-log-compiler-2.sh
+PASS: t/parallel-tests-dry-run-1.sh
+PASS: t/parallel-tests-dry-run-2.sh
+PASS: t/parallel-tests-fd-redirect.sh
+PASS: t/parallel-tests-fd-redirect-exeext.sh
+PASS: t/parallel-tests-extra-programs.sh
+PASS: t/parallel-tests-unreadable.sh
+PASS: t/parallel-tests-subdir.sh
+PASS: t/parallel-tests-interrupt.tap 1 - logfile created and readable [SIG 1]
+PASS: t/parallel-tests-interrupt.tap 2 - logfile contains output from test script [SIG 1]
+PASS: t/parallel-tests-interrupt.tap 3 - signal 1 to test driver causes "make check" to fail
+PASS: t/parallel-tests-interrupt.tap 4 - test driver clean up log and tmp files after signal 1
+PASS: t/parallel-tests-interrupt.tap 5 - logfile created and readable [SIG 2]
+PASS: t/parallel-tests-interrupt.tap 6 - logfile contains output from test script [SIG 2]
+PASS: t/parallel-tests-interrupt.tap 7 - signal 2 to test driver causes "make check" to fail
+PASS: t/parallel-tests-interrupt.tap 8 - test driver clean up log and tmp files after signal 2
+PASS: t/parallel-tests-interrupt.tap 9 - logfile created and readable [SIG 13]
+PASS: t/parallel-tests-interrupt.tap 10 - logfile contains output from test script [SIG 13]
+PASS: t/parallel-tests-interrupt.tap 11 - signal 13 to test driver causes "make check" to fail
+PASS: t/parallel-tests-interrupt.tap 12 - test driver clean up log and tmp files after signal 13
+PASS: t/parallel-tests-interrupt.tap 13 - logfile created and readable [SIG 15]
+PASS: t/parallel-tests-interrupt.tap 14 - logfile contains output from test script [SIG 15]
+PASS: t/parallel-tests-interrupt.tap 15 - signal 15 to test driver causes "make check" to fail
+PASS: t/parallel-tests-interrupt.tap 16 - test driver clean up log and tmp files after signal 15
+PASS: t/parallel-tests-reset-term.sh
+PASS: t/parallel-tests-harderror.sh
+PASS: t/parallel-tests-log-override-1.sh
+PASS: t/parallel-tests-log-override-2.sh
+PASS: t/parallel-tests-log-override-recheck.sh
+PASS: t/parallel-tests-log-compiler-example.sh
+PASS: t/parallel-tests-cmdline-override.sh
+PASS: t/parallel-tests-fork-bomb.sh
+PASS: t/parallel-tests-empty-testlogs.sh
+PASS: t/parallel-tests-driver-install.sh
+PASS: t/parallel-tests-no-color-in-log.sh
+PASS: t/parallel-tests-no-spurious-summary.sh
+PASS: t/parallel-tests-exit-statuses.sh
+PASS: t/parallel-tests-console-output.sh
+PASS: t/parallel-tests-once.sh
+PASS: t/tests-environment.sh
+PASS: t/am-tests-environment.sh
+PASS: t/tests-environment-backcompat.sh
+PASS: t/testsuite-summary-color.sh
+PASS: t/testsuite-summary-count.sh
+PASS: t/testsuite-summary-count-many.sh
+PASS: t/testsuite-summary-reference-log.sh
+PASS: t/test-driver-acsubst.sh
+PASS: t/test-driver-cond.sh
+PASS: t/test-driver-custom-no-extra-driver.sh
+PASS: t/test-driver-custom.sh
+PASS: t/test-driver-custom-xfail-tests.sh
+PASS: t/test-driver-custom-multitest.sh
+PASS: t/test-driver-custom-multitest-recheck.sh
+PASS: t/test-driver-custom-multitest-recheck2.sh
+PASS: t/test-driver-create-log-dir.sh
+PASS: t/test-driver-strip-vpath.sh
+PASS: t/test-driver-trs-suffix-registered.sh
+PASS: t/test-driver-fail.sh
+PASS: t/test-driver-is-distributed.sh
+PASS: t/test-harness-vpath-rewrite.sh
+PASS: t/test-log.sh
+PASS: t/test-logs-repeated.sh
+PASS: t/test-metadata-global-log.sh
+PASS: t/test-metadata-global-result.sh
+PASS: t/test-metadata-recheck.sh
+PASS: t/test-metadata-results.sh
+PASS: t/test-missing.sh
+PASS: t/test-missing2.sh
+PASS: t/test-trs-basic.sh
+PASS: t/test-trs-recover.sh
+PASS: t/test-trs-recover2.sh
+PASS: t/test-extensions.sh
+PASS: t/test-extensions-cond.sh
+PASS: t/parse.sh
+PASS: t/percent.sh
+PASS: t/percent2.sh
+PASS: t/per-target-flags.sh
+PASS: t/phony.sh
+PASS: t/precious.sh
+PASS: t/pluseq.sh
+PASS: t/pluseq2.sh
+PASS: t/pluseq3.sh
+PASS: t/pluseq4.sh
+PASS: t/pluseq5.sh
+PASS: t/pluseq6.sh
+PASS: t/pluseq7.sh
+PASS: t/pluseq8.sh
+PASS: t/pluseq9.sh
+PASS: t/pluseq10.sh
+PASS: t/pluseq11.sh
+PASS: t/posixsubst-data.sh
+PASS: t/posixsubst-extradist.sh
+PASS: t/posixsubst-ldadd.sh
+PASS: t/posixsubst-libraries.sh
+PASS: t/posixsubst-ltlibraries.sh
+PASS: t/posixsubst-programs.sh
+PASS: t/posixsubst-scripts.sh
+PASS: t/posixsubst-sources.sh
+PASS: t/posixsubst-tests.sh
+PASS: t/postproc.sh
+PASS: t/ppf77.sh
+PASS: t/pr2.sh
+PASS: t/pr9.sh
+PASS: t/pr72.sh
+PASS: t/pr87.sh
+PASS: t/pr211.sh
+PASS: t/pr220.sh
+PASS: t/pr224.sh
+PASS: t/pr229.sh
+PASS: t/pr243.sh
+PASS: t/pr266.sh
+PASS: t/pr279.sh
+PASS: t/pr279-2.sh
+PASS: t/pr287.sh
+PASS: t/pr300-lib.sh
+PASS: t/pr300-ltlib.sh
+PASS: t/pr300-prog.sh
+PASS: t/pr307.sh
+PASS: t/pr401.sh
+PASS: t/pr401b.sh
+PASS: t/pr401c.sh
+PASS: t/prefix.sh
+PASS: t/preproc-basics.sh
+PASS: t/preproc-c-compile.sh
+PASS: t/preproc-demo.sh
+PASS: t/preproc-errmsg.sh
+PASS: t/primary.sh
+PASS: t/primary2.sh
+PASS: t/primary3.sh
+PASS: t/primary-prefix-invalid-couples.tap 1 - 'automake -a' error out on mismatched prefix/primary couples
+PASS: t/primary-prefix-invalid-couples.tap 2 - mismatched prefix/primary in bin_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 3 - mismatched prefix/primary in bin_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 4 - mismatched prefix/primary in bin_LISP
+PASS: t/primary-prefix-invalid-couples.tap 5 - mismatched prefix/primary in bin_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 6 - mismatched prefix/primary in bin_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 7 - mismatched prefix/primary in bin_DATA
+PASS: t/primary-prefix-invalid-couples.tap 8 - mismatched prefix/primary in bin_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 9 - mismatched prefix/primary in data_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 10 - mismatched prefix/primary in data_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 11 - mismatched prefix/primary in data_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 12 - mismatched prefix/primary in data_LISP
+PASS: t/primary-prefix-invalid-couples.tap 13 - mismatched prefix/primary in data_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 14 - mismatched prefix/primary in data_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 15 - mismatched prefix/primary in data_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 16 - mismatched prefix/primary in data_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 17 - mismatched prefix/primary in dataroot_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 18 - mismatched prefix/primary in dataroot_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 19 - mismatched prefix/primary in dataroot_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 20 - mismatched prefix/primary in dataroot_LISP
+PASS: t/primary-prefix-invalid-couples.tap 21 - mismatched prefix/primary in dataroot_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 22 - mismatched prefix/primary in dataroot_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 23 - mismatched prefix/primary in dataroot_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 24 - mismatched prefix/primary in dataroot_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 25 - mismatched prefix/primary in doc_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 26 - mismatched prefix/primary in doc_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 27 - mismatched prefix/primary in doc_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 28 - mismatched prefix/primary in doc_LISP
+PASS: t/primary-prefix-invalid-couples.tap 29 - mismatched prefix/primary in doc_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 30 - mismatched prefix/primary in doc_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 31 - mismatched prefix/primary in doc_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 32 - mismatched prefix/primary in doc_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 33 - mismatched prefix/primary in dvi_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 34 - mismatched prefix/primary in dvi_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 35 - mismatched prefix/primary in dvi_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 36 - mismatched prefix/primary in dvi_LISP
+PASS: t/primary-prefix-invalid-couples.tap 37 - mismatched prefix/primary in dvi_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 38 - mismatched prefix/primary in dvi_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 39 - mismatched prefix/primary in dvi_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 40 - mismatched prefix/primary in dvi_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 41 - mismatched prefix/primary in exec_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 42 - mismatched prefix/primary in exec_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 43 - mismatched prefix/primary in exec_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 44 - mismatched prefix/primary in exec_LISP
+PASS: t/primary-prefix-invalid-couples.tap 45 - mismatched prefix/primary in exec_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 46 - mismatched prefix/primary in exec_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 47 - mismatched prefix/primary in exec_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 48 - mismatched prefix/primary in exec_DATA
+PASS: t/primary-prefix-invalid-couples.tap 49 - mismatched prefix/primary in exec_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 50 - mismatched prefix/primary in html_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 51 - mismatched prefix/primary in html_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 52 - mismatched prefix/primary in html_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 53 - mismatched prefix/primary in html_LISP
+PASS: t/primary-prefix-invalid-couples.tap 54 - mismatched prefix/primary in html_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 55 - mismatched prefix/primary in html_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 56 - mismatched prefix/primary in html_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 57 - mismatched prefix/primary in html_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 58 - mismatched prefix/primary in include_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 59 - mismatched prefix/primary in include_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 60 - mismatched prefix/primary in include_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 61 - mismatched prefix/primary in include_LISP
+PASS: t/primary-prefix-invalid-couples.tap 62 - mismatched prefix/primary in include_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 63 - mismatched prefix/primary in include_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 64 - mismatched prefix/primary in include_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 65 - mismatched prefix/primary in include_DATA
+PASS: t/primary-prefix-invalid-couples.tap 66 - mismatched prefix/primary in info_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 67 - mismatched prefix/primary in info_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 68 - mismatched prefix/primary in info_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 69 - mismatched prefix/primary in info_LISP
+PASS: t/primary-prefix-invalid-couples.tap 70 - mismatched prefix/primary in info_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 71 - mismatched prefix/primary in info_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 72 - mismatched prefix/primary in info_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 73 - mismatched prefix/primary in info_DATA
+PASS: t/primary-prefix-invalid-couples.tap 74 - mismatched prefix/primary in info_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 75 - mismatched prefix/primary in lib_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 76 - mismatched prefix/primary in lib_LISP
+PASS: t/primary-prefix-invalid-couples.tap 77 - mismatched prefix/primary in lib_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 78 - mismatched prefix/primary in lib_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 79 - mismatched prefix/primary in lib_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 80 - mismatched prefix/primary in lib_DATA
+PASS: t/primary-prefix-invalid-couples.tap 81 - mismatched prefix/primary in lib_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 82 - mismatched prefix/primary in libexec_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 83 - mismatched prefix/primary in libexec_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 84 - mismatched prefix/primary in libexec_LISP
+PASS: t/primary-prefix-invalid-couples.tap 85 - mismatched prefix/primary in libexec_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 86 - mismatched prefix/primary in libexec_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 87 - mismatched prefix/primary in libexec_DATA
+PASS: t/primary-prefix-invalid-couples.tap 88 - mismatched prefix/primary in libexec_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 89 - mismatched prefix/primary in lisp_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 90 - mismatched prefix/primary in lisp_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 91 - mismatched prefix/primary in lisp_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 92 - mismatched prefix/primary in lisp_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 93 - mismatched prefix/primary in lisp_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 94 - mismatched prefix/primary in lisp_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 95 - mismatched prefix/primary in lisp_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 96 - mismatched prefix/primary in locale_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 97 - mismatched prefix/primary in locale_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 98 - mismatched prefix/primary in locale_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 99 - mismatched prefix/primary in locale_LISP
+PASS: t/primary-prefix-invalid-couples.tap 100 - mismatched prefix/primary in locale_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 101 - mismatched prefix/primary in locale_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 102 - mismatched prefix/primary in locale_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 103 - mismatched prefix/primary in locale_DATA
+PASS: t/primary-prefix-invalid-couples.tap 104 - mismatched prefix/primary in locale_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 105 - mismatched prefix/primary in localstate_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 106 - mismatched prefix/primary in localstate_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 107 - mismatched prefix/primary in localstate_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 108 - mismatched prefix/primary in localstate_LISP
+PASS: t/primary-prefix-invalid-couples.tap 109 - mismatched prefix/primary in localstate_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 110 - mismatched prefix/primary in localstate_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 111 - mismatched prefix/primary in localstate_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 112 - mismatched prefix/primary in localstate_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 113 - mismatched prefix/primary in man_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 114 - mismatched prefix/primary in man_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 115 - mismatched prefix/primary in man_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 116 - mismatched prefix/primary in man_LISP
+PASS: t/primary-prefix-invalid-couples.tap 117 - mismatched prefix/primary in man_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 118 - mismatched prefix/primary in man_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 119 - mismatched prefix/primary in man_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 120 - mismatched prefix/primary in man_DATA
+PASS: t/primary-prefix-invalid-couples.tap 121 - mismatched prefix/primary in man_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 122 - mismatched prefix/primary in man1_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 123 - mismatched prefix/primary in man1_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 124 - mismatched prefix/primary in man1_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 125 - mismatched prefix/primary in man1_LISP
+PASS: t/primary-prefix-invalid-couples.tap 126 - mismatched prefix/primary in man1_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 127 - mismatched prefix/primary in man1_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 128 - mismatched prefix/primary in man1_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 129 - mismatched prefix/primary in man1_DATA
+PASS: t/primary-prefix-invalid-couples.tap 130 - mismatched prefix/primary in man1_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 131 - mismatched prefix/primary in man2_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 132 - mismatched prefix/primary in man2_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 133 - mismatched prefix/primary in man2_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 134 - mismatched prefix/primary in man2_LISP
+PASS: t/primary-prefix-invalid-couples.tap 135 - mismatched prefix/primary in man2_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 136 - mismatched prefix/primary in man2_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 137 - mismatched prefix/primary in man2_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 138 - mismatched prefix/primary in man2_DATA
+PASS: t/primary-prefix-invalid-couples.tap 139 - mismatched prefix/primary in man2_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 140 - mismatched prefix/primary in man3_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 141 - mismatched prefix/primary in man3_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 142 - mismatched prefix/primary in man3_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 143 - mismatched prefix/primary in man3_LISP
+PASS: t/primary-prefix-invalid-couples.tap 144 - mismatched prefix/primary in man3_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 145 - mismatched prefix/primary in man3_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 146 - mismatched prefix/primary in man3_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 147 - mismatched prefix/primary in man3_DATA
+PASS: t/primary-prefix-invalid-couples.tap 148 - mismatched prefix/primary in man3_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 149 - mismatched prefix/primary in man4_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 150 - mismatched prefix/primary in man4_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 151 - mismatched prefix/primary in man4_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 152 - mismatched prefix/primary in man4_LISP
+PASS: t/primary-prefix-invalid-couples.tap 153 - mismatched prefix/primary in man4_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 154 - mismatched prefix/primary in man4_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 155 - mismatched prefix/primary in man4_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 156 - mismatched prefix/primary in man4_DATA
+PASS: t/primary-prefix-invalid-couples.tap 157 - mismatched prefix/primary in man4_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 158 - mismatched prefix/primary in man5_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 159 - mismatched prefix/primary in man5_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 160 - mismatched prefix/primary in man5_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 161 - mismatched prefix/primary in man5_LISP
+PASS: t/primary-prefix-invalid-couples.tap 162 - mismatched prefix/primary in man5_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 163 - mismatched prefix/primary in man5_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 164 - mismatched prefix/primary in man5_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 165 - mismatched prefix/primary in man5_DATA
+PASS: t/primary-prefix-invalid-couples.tap 166 - mismatched prefix/primary in man5_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 167 - mismatched prefix/primary in man6_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 168 - mismatched prefix/primary in man6_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 169 - mismatched prefix/primary in man6_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 170 - mismatched prefix/primary in man6_LISP
+PASS: t/primary-prefix-invalid-couples.tap 171 - mismatched prefix/primary in man6_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 172 - mismatched prefix/primary in man6_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 173 - mismatched prefix/primary in man6_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 174 - mismatched prefix/primary in man6_DATA
+PASS: t/primary-prefix-invalid-couples.tap 175 - mismatched prefix/primary in man6_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 176 - mismatched prefix/primary in man7_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 177 - mismatched prefix/primary in man7_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 178 - mismatched prefix/primary in man7_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 179 - mismatched prefix/primary in man7_LISP
+PASS: t/primary-prefix-invalid-couples.tap 180 - mismatched prefix/primary in man7_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 181 - mismatched prefix/primary in man7_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 182 - mismatched prefix/primary in man7_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 183 - mismatched prefix/primary in man7_DATA
+PASS: t/primary-prefix-invalid-couples.tap 184 - mismatched prefix/primary in man7_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 185 - mismatched prefix/primary in man8_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 186 - mismatched prefix/primary in man8_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 187 - mismatched prefix/primary in man8_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 188 - mismatched prefix/primary in man8_LISP
+PASS: t/primary-prefix-invalid-couples.tap 189 - mismatched prefix/primary in man8_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 190 - mismatched prefix/primary in man8_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 191 - mismatched prefix/primary in man8_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 192 - mismatched prefix/primary in man8_DATA
+PASS: t/primary-prefix-invalid-couples.tap 193 - mismatched prefix/primary in man8_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 194 - mismatched prefix/primary in man9_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 195 - mismatched prefix/primary in man9_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 196 - mismatched prefix/primary in man9_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 197 - mismatched prefix/primary in man9_LISP
+PASS: t/primary-prefix-invalid-couples.tap 198 - mismatched prefix/primary in man9_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 199 - mismatched prefix/primary in man9_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 200 - mismatched prefix/primary in man9_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 201 - mismatched prefix/primary in man9_DATA
+PASS: t/primary-prefix-invalid-couples.tap 202 - mismatched prefix/primary in man9_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 203 - mismatched prefix/primary in oldinclude_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 204 - mismatched prefix/primary in oldinclude_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 205 - mismatched prefix/primary in oldinclude_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 206 - mismatched prefix/primary in oldinclude_LISP
+PASS: t/primary-prefix-invalid-couples.tap 207 - mismatched prefix/primary in oldinclude_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 208 - mismatched prefix/primary in oldinclude_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 209 - mismatched prefix/primary in oldinclude_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 210 - mismatched prefix/primary in oldinclude_DATA
+PASS: t/primary-prefix-invalid-couples.tap 211 - mismatched prefix/primary in pdf_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 212 - mismatched prefix/primary in pdf_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 213 - mismatched prefix/primary in pdf_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 214 - mismatched prefix/primary in pdf_LISP
+PASS: t/primary-prefix-invalid-couples.tap 215 - mismatched prefix/primary in pdf_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 216 - mismatched prefix/primary in pdf_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 217 - mismatched prefix/primary in pdf_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 218 - mismatched prefix/primary in pdf_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 219 - mismatched prefix/primary in pkgdata_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 220 - mismatched prefix/primary in pkgdata_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 221 - mismatched prefix/primary in pkgdata_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 222 - mismatched prefix/primary in pkgdata_LISP
+PASS: t/primary-prefix-invalid-couples.tap 223 - mismatched prefix/primary in pkgdata_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 224 - mismatched prefix/primary in pkgdata_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 225 - mismatched prefix/primary in pkgdata_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 226 - mismatched prefix/primary in pkginclude_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 227 - mismatched prefix/primary in pkginclude_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 228 - mismatched prefix/primary in pkginclude_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 229 - mismatched prefix/primary in pkginclude_LISP
+PASS: t/primary-prefix-invalid-couples.tap 230 - mismatched prefix/primary in pkginclude_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 231 - mismatched prefix/primary in pkginclude_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 232 - mismatched prefix/primary in pkginclude_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 233 - mismatched prefix/primary in pkginclude_DATA
+PASS: t/primary-prefix-invalid-couples.tap 234 - mismatched prefix/primary in pkglib_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 235 - mismatched prefix/primary in pkglib_LISP
+PASS: t/primary-prefix-invalid-couples.tap 236 - mismatched prefix/primary in pkglib_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 237 - mismatched prefix/primary in pkglib_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 238 - mismatched prefix/primary in pkglib_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 239 - mismatched prefix/primary in pkglib_DATA
+PASS: t/primary-prefix-invalid-couples.tap 240 - mismatched prefix/primary in pkglib_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 241 - mismatched prefix/primary in pkglibexec_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 242 - mismatched prefix/primary in pkglibexec_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 243 - mismatched prefix/primary in pkglibexec_LISP
+PASS: t/primary-prefix-invalid-couples.tap 244 - mismatched prefix/primary in pkglibexec_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 245 - mismatched prefix/primary in pkglibexec_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 246 - mismatched prefix/primary in pkglibexec_DATA
+PASS: t/primary-prefix-invalid-couples.tap 247 - mismatched prefix/primary in pkglibexec_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 248 - mismatched prefix/primary in ps_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 249 - mismatched prefix/primary in ps_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 250 - mismatched prefix/primary in ps_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 251 - mismatched prefix/primary in ps_LISP
+PASS: t/primary-prefix-invalid-couples.tap 252 - mismatched prefix/primary in ps_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 253 - mismatched prefix/primary in ps_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 254 - mismatched prefix/primary in ps_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 255 - mismatched prefix/primary in ps_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 256 - mismatched prefix/primary in sbin_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 257 - mismatched prefix/primary in sbin_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 258 - mismatched prefix/primary in sbin_LISP
+PASS: t/primary-prefix-invalid-couples.tap 259 - mismatched prefix/primary in sbin_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 260 - mismatched prefix/primary in sbin_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 261 - mismatched prefix/primary in sbin_DATA
+PASS: t/primary-prefix-invalid-couples.tap 262 - mismatched prefix/primary in sbin_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 263 - mismatched prefix/primary in sharedstate_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 264 - mismatched prefix/primary in sharedstate_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 265 - mismatched prefix/primary in sharedstate_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 266 - mismatched prefix/primary in sharedstate_LISP
+PASS: t/primary-prefix-invalid-couples.tap 267 - mismatched prefix/primary in sharedstate_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 268 - mismatched prefix/primary in sharedstate_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 269 - mismatched prefix/primary in sharedstate_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 270 - mismatched prefix/primary in sharedstate_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 271 - mismatched prefix/primary in sysconf_PROGRAMS
+PASS: t/primary-prefix-invalid-couples.tap 272 - mismatched prefix/primary in sysconf_LIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 273 - mismatched prefix/primary in sysconf_LTLIBRARIES
+PASS: t/primary-prefix-invalid-couples.tap 274 - mismatched prefix/primary in sysconf_LISP
+PASS: t/primary-prefix-invalid-couples.tap 275 - mismatched prefix/primary in sysconf_PYTHON
+PASS: t/primary-prefix-invalid-couples.tap 276 - mismatched prefix/primary in sysconf_JAVA
+PASS: t/primary-prefix-invalid-couples.tap 277 - mismatched prefix/primary in sysconf_SCRIPTS
+PASS: t/primary-prefix-invalid-couples.tap 278 - mismatched prefix/primary in sysconf_HEADERS
+PASS: t/primary-prefix-invalid-couples.tap 279 - automake error out on mismatched prefix/primary couples
+PASS: t/primary-prefix-invalid-couples.tap 280 - ... and with the same diagnostic of 'automake -a'
+PASS: t/primary-prefix-valid-couples.sh
+PASS: t/primary-prefix-couples-force-valid.sh
+PASS: t/primary-prefix-couples-documented-valid.sh
+PASS: t/print-libdir.sh
+PASS: t/proginst.sh
+PASS: t/programs-primary-rewritten.sh
+PASS: t/py-compile-basic.sh
+PASS: t/py-compile-basedir.sh
+PASS: t/py-compile-destdir.sh
+PASS: t/py-compile-env.sh
+PASS: t/py-compile-option-terminate.sh
+PASS: t/py-compile-usage.sh
+PASS: t/python.sh
+PASS: t/python2.sh
+PASS: t/python3.sh
+PASS: t/python10.sh
+PASS: t/python11.sh
+PASS: t/python12.sh
+PASS: t/python-am-path-iftrue.sh
+PASS: t/python-missing.sh
+PASS: t/python-too-old.sh
+PASS: t/python-dist.sh
+PASS: t/python-vars.sh
+python-virtualenv: skipped test: required program 'virtualenv' not available
+SKIP: t/python-virtualenv.sh
+PASS: t/python-pr10995.sh
+PASS: t/recurs-user.sh
+PASS: t/recurs-user2.sh
+PASS: t/recurs-user-deeply-nested.sh
+PASS: t/recurs-user-indir.sh
+PASS: t/recurs-user-keep-going.sh
+PASS: t/recurs-user-many.sh
+PASS: t/recurs-user-no-subdirs.sh
+PASS: t/recurs-user-no-top-level.sh
+PASS: t/recurs-user-override.sh
+PASS: t/recurs-user-phony.sh
+PASS: t/recurs-user-wrap.sh
+PASS: t/relativize.tap 1 - ./{.} = .
+PASS: t/relativize.tap 2 - ./{..} = ..
+PASS: t/relativize.tap 3 - ../{top} = .
+PASS: t/relativize.tap 4 - x/{.} = x
+PASS: t/relativize.tap 5 - x/{.} = x/.
+PASS: t/relativize.tap 6 - x/{..} = x/..
+PASS: t/relativize.tap 7 - x/{x} = x/x
+PASS: t/relativize.tap 8 - x/{r/s/t} = x/r/s/t
+PASS: t/relativize.tap 9 - long-longer/{.} = long-longer
+PASS: t/relativize.tap 10 - long-longer/{.} = long-longer/.
+PASS: t/relativize.tap 11 - long-longer/{..} = long-longer/..
+PASS: t/relativize.tap 12 - long-longer/{x} = long-longer/x
+PASS: t/relativize.tap 13 - long-longer/{r/s/t} = long-longer/r/s/t
+PASS: t/relativize.tap 14 - a/b/{.} = a/b
+PASS: t/relativize.tap 15 - a/b/{.} = a/b/.
+PASS: t/relativize.tap 16 - a/b/{..} = a/b/..
+PASS: t/relativize.tap 17 - a/b/{x} = a/b/x
+PASS: t/relativize.tap 18 - a/b/{r/s/t} = a/b/r/s/t
+PASS: t/relativize.tap 19 - 1/2/3/4/5/{.} = 1/2/3/4/5
+PASS: t/relativize.tap 20 - 1/2/3/4/5/{.} = 1/2/3/4/5/.
+PASS: t/relativize.tap 21 - 1/2/3/4/5/{..} = 1/2/3/4/5/..
+PASS: t/relativize.tap 22 - 1/2/3/4/5/{x} = 1/2/3/4/5/x
+PASS: t/relativize.tap 23 - 1/2/3/4/5/{r/s/t} = 1/2/3/4/5/r/s/t
+PASS: t/relativize.tap 24 - one/{../two} = two
+PASS: t/relativize.tap 25 - a/{../b/c} = b/c
+PASS: t/relativize.tap 26 - a/b/{../..} = .
+PASS: t/relativize.tap 27 - a/b/{../../foo} = foo
+PASS: t/relativize.tap 28 - a/b/{../../foo/bar} = foo/bar
+PASS: t/relativize.tap 29 - a/b/{../c} = a/c
+PASS: t/relativize.tap 30 - a/b/{../c/d} = a/c/d
+PASS: t/relativize.tap 31 - foo/bar/baz/{../qux/zap} = foo/bar/qux/zap
+PASS: t/relativize.tap 32 - ../foo/{../top} = .
+PASS: t/relativize.tap 33 - ../../{uber/top} = .
+PASS: t/relativize.tap 34 - ../../foo/{../uber/top} = .
+PASS: t/relativize.tap 35 - ../../x/{../uber/top/ok} = ok
+PASS: t/relativize.tap 36 - ../../x/{../uber/top/bo/ba} = bo/ba
+PASS: t/relativize.tap 37 - ../../x/{../uber/top/../ok2} = ../ok2
+PASS: t/relativize.tap 38 - ../a/b/c/d/e/{../../../../../top} = .
+PASS: t/remake-fail.sh
+PASS: t/remake-not-after-make-dist.sh
+PASS: t/remake-maintainer-mode.sh
+PASS: t/remake-makefile-intree.sh
+PASS: t/remake-makefile-vpath.sh
+PASS: t/remake-after-configure-ac.sh
+PASS: t/remake-after-makefile-am.sh
+PASS: t/remake-after-acinclude-m4.sh
+PASS: t/remake-after-aclocal-m4.sh
+PASS: t/remake-include-configure.sh
+PASS: t/remake-include-makefile.sh
+PASS: t/remake-include-aclocal.sh
+PASS: t/remake-config-status-dependencies.sh
+PASS: t/remake-configure-dependencies.sh
+PASS: t/remake-deeply-nested.sh
+PASS: t/remake-mild-stress.sh
+PASS: t/remake-all-1.sh
+PASS: t/remake-all-2.sh
+PASS: t/remake-recurs-user.sh
+PASS: t/remake-subdir.sh
+PASS: t/remake-subdir2.sh
+PASS: t/remake-subdir3.sh
+PASS: t/remake-subdir-only.sh
+PASS: t/remake-subdir-grepping.sh
+PASS: t/remake-subdir-from-subdir.sh
+PASS: t/remake-subdir-gnu.sh
+PASS: t/remake-subdir-no-makefile.sh
+PASS: t/remake-subdir-long-time.sh
+PASS: t/remake-gnulib-add-acsubst.sh
+PASS: t/remake-gnulib-add-header.sh
+PASS: t/remake-gnulib-remove-header.sh
+PASS: t/remake-moved-m4-file.sh
+PASS: t/remake-deleted-m4-file.sh
+PASS: t/remake-renamed-m4-file.sh
+PASS: t/remake-renamed-m4-macro-and-file.sh
+PASS: t/remake-renamed-m4-macro.sh
+XFAIL: t/remake-am-pr10111.sh
+XFAIL: t/remake-m4-pr10111.sh
+PASS: t/remake-deleted-am-2.sh
+PASS: t/remake-deleted-am-subdir.sh
+PASS: t/remake-deleted-am.sh
+PASS: t/remake-renamed-am.sh
+PASS: t/remake-aclocal-version-mismatch.sh
+PASS: t/remake-macrodir.sh
+XFAIL: t/remake-timing-bug-pr8365.sh
+PASS: t/reqd2.sh
+PASS: t/repeated-options.sh
+PASS: t/rm-f-probe.sh
+PASS: t/rulepat.sh
+PASS: t/self-check-cc-no-c-o.sh
+PASS: t/self-check-configure-help.sh
+PASS: t/self-check-dir.tap 1 - testdir has the expected path [unset am_create_testdir]
+PASS: t/self-check-dir.tap 2 - fully pre-populated testdir [unset am_create_testdir]
+PASS: t/self-check-dir.tap 3 - testdir has the expected path [am_create_testdir=empty]
+PASS: t/self-check-dir.tap 4 - do not pre-populate testdir [am_create_testdir=empty]
+PASS: t/self-check-dir.tap 5 - do not create nor chdir in testdir [am_create_testdir=no]
+PASS: t/self-check-exit.tap 1 - exit 1
+PASS: t/self-check-exit.tap 2 - sh -c 'exit 1'
+PASS: t/self-check-exit.tap 3 - exit 2
+PASS: t/self-check-exit.tap 4 - sh -c 'exit 2'
+PASS: t/self-check-exit.tap 5 - exit 3
+PASS: t/self-check-exit.tap 6 - sh -c 'exit 3'
+PASS: t/self-check-exit.tap 7 - exit 4
+PASS: t/self-check-exit.tap 8 - sh -c 'exit 4'
+PASS: t/self-check-exit.tap 9 - exit 5
+PASS: t/self-check-exit.tap 10 - sh -c 'exit 5'
+PASS: t/self-check-exit.tap 11 - exit 77
+PASS: t/self-check-exit.tap 12 - sh -c 'exit 77'
+PASS: t/self-check-exit.tap 13 - exit 99
+PASS: t/self-check-exit.tap 14 - sh -c 'exit 99'
+PASS: t/self-check-exit.tap 15 - exit 126
+PASS: t/self-check-exit.tap 16 - sh -c 'exit 126'
+PASS: t/self-check-exit.tap 17 - exit 127
+PASS: t/self-check-exit.tap 18 - sh -c 'exit 127'
+PASS: t/self-check-exit.tap 19 - exit 128
+PASS: t/self-check-exit.tap 20 - sh -c 'exit 128'
+PASS: t/self-check-exit.tap 21 - exit 129
+PASS: t/self-check-exit.tap 22 - sh -c 'exit 129'
+PASS: t/self-check-exit.tap 23 - exit 130
+PASS: t/self-check-exit.tap 24 - sh -c 'exit 130'
+PASS: t/self-check-exit.tap 25 - exit 255
+PASS: t/self-check-exit.tap 26 - sh -c 'exit 255'
+PASS: t/self-check-exit.tap 27 - kill -1
+PASS: t/self-check-exit.tap 28 - kill -2
+PASS: t/self-check-exit.tap 29 - kill -13
+PASS: t/self-check-exit.tap 30 - kill -15
+PASS: t/self-check-exit.tap 31 - command not found
+PASS: t/self-check-exit.tap 32 - permission denied
+PASS: t/self-check-explicit-skips.sh
+PASS: t/self-check-is_newest.tap 1 - is_newest c a
+PASS: t/self-check-is_newest.tap 2 - is_newest b a
+PASS: t/self-check-is_newest.tap 3 - not is_newest a b
+PASS: t/self-check-is_newest.tap 4 - is_newest c b
+PASS: t/self-check-is_newest.tap 5 - is_newest c c
+PASS: t/self-check-is_newest.tap 6 - is_newest c a b c
+PASS: t/self-check-is_newest.tap 7 - is_newest c d
+PASS: t/self-check-is_newest.tap 8 - is_newest v u
+PASS: t/self-check-is_newest.tap 9 - not is_newest u v
+PASS: t/self-check-is_newest.tap 10 - is_newest y u
+PASS: t/self-check-is_newest.tap 11 - not is_newest u y
+PASS: t/self-check-is_newest.tap 12 - is_newest v x
+PASS: t/self-check-is_newest.tap 13 - not is_newest x v
+PASS: t/self-check-is_newest.tap 14 - is_newest y x
+PASS: t/self-check-is_newest.tap 15 - not is_newest x y
+PASS: t/self-check-is_newest.tap 16 - is_newest x/foo x
+PASS: t/self-check-is_newest.tap 17 - not is_newest x x/foo
+PASS: t/self-check-is_newest.tap 18 - is_newest x u
+PASS: t/self-check-is_newest.tap 19 - is_newest u x
+PASS: t/self-check-is_newest.tap 20 - is_newest y x u v
+PASS: t/self-check-is_newest.tap 21 - is_newest y u x/foo a b c
+PASS: t/self-check-me.tap 1 - me=foo-bar-.sh
+PASS: t/self-check-me.tap 2 - me=_foo__bar.sh
+PASS: t/self-check-me.tap 3 - me=012.sh
+PASS: t/self-check-me.tap 4 - me=a.b.c.sh
+PASS: t/self-check-me.tap 5 - me=foo-bar-.tap
+PASS: t/self-check-me.tap 6 - me=_foo__bar.tap
+PASS: t/self-check-me.tap 7 - me=012.tap
+PASS: t/self-check-me.tap 8 - me=a.b.c.tap
+PASS: t/self-check-me.tap 9 - me=foo.bar
+PASS: t/self-check-me.tap 10 - me=abc.
+PASS: t/self-check-me.tap 11 - override of $me before test-init.sh causes no error
+PASS: t/self-check-me.tap 12 - $me from the environment is ignored
+PASS: t/self-check-report.sh
+PASS: t/self-check-seq.tap 1 - one-argument form [exit status = 0]
+PASS: t/self-check-seq.tap 2 - one-argument form [output]
+PASS: t/self-check-seq.tap 3 - two-arguments form [exit status = 0]
+PASS: t/self-check-seq.tap 4 - two-arguments form [output]
+PASS: t/self-check-seq.tap 5 - three-arguments form (1) [exit status = 0]
+PASS: t/self-check-seq.tap 6 - three-arguments form (1) [output]
+PASS: t/self-check-seq.tap 7 - three-arguments form (1) [exit status = 0]
+PASS: t/self-check-seq.tap 8 - three-arguments form (1) [output]
+PASS: t/self-check-seq.tap 9 - no argument is an error [exit status = 99]
+PASS: t/self-check-seq.tap 10 - no argument is an error [error message]
+PASS: t/self-check-seq.tap 11 - four arguments is an error [exit status = 99]
+PASS: t/self-check-seq.tap 12 - four arguments is an error [error message]
+PASS: t/self-check-seq.tap 13 - six arguments is an error [exit status = 99]
+PASS: t/self-check-seq.tap 14 - six arguments is an error [error message]
+PASS: t/self-check-shell-no-trail-bslash.sh
+PASS: t/self-check-is-blocked-signal.tap 1 - unblockable signal 9
+PASS: t/self-check-is-blocked-signal.tap 2 - blocked signal 13
+PASS: t/self-check-unindent.tap 1 - leading spaces [simple, exit status]
+PASS: t/self-check-unindent.tap 2 - leading spaces [simple, output]
+PASS: t/self-check-unindent.tap 3 - leading spaces [parallel, exit status]
+PASS: t/self-check-unindent.tap 4 - leading spaces [parallel, output]
+PASS: t/self-check-unindent.tap 5 - leading tab [simple, exit status]
+PASS: t/self-check-unindent.tap 6 - leading tab [simple, output]
+PASS: t/self-check-unindent.tap 7 - leading tab [parallel, exit status]
+PASS: t/self-check-unindent.tap 8 - leading tab [parallel, output]
+PASS: t/self-check-unindent.tap 9 - no leading whitespace [simple, exit status]
+PASS: t/self-check-unindent.tap 10 - no leading whitespace [simple, output]
+PASS: t/self-check-unindent.tap 11 - no leading whitespace [parallel, exit status]
+PASS: t/self-check-unindent.tap 12 - no leading whitespace [parallel, output]
+PASS: t/self-check-unindent.tap 13 - leading empty lines ignored (1) [simple, exit status]
+PASS: t/self-check-unindent.tap 14 - leading empty lines ignored (1) [simple, output]
+PASS: t/self-check-unindent.tap 15 - leading empty lines ignored (1) [parallel, exit status]
+PASS: t/self-check-unindent.tap 16 - leading empty lines ignored (1) [parallel, output]
+PASS: t/self-check-unindent.tap 17 - leading empty lines ignored (2) [simple, exit status]
+PASS: t/self-check-unindent.tap 18 - leading empty lines ignored (2) [simple, output]
+PASS: t/self-check-unindent.tap 19 - leading empty lines ignored (2) [parallel, exit status]
+PASS: t/self-check-unindent.tap 20 - leading empty lines ignored (2) [parallel, output]
+PASS: t/self-check-unindent.tap 21 - more elaborated parallel use [exit status]
+PASS: t/self-check-unindent.tap 22 - more elaborated parallel use [output]
+PASS: t/sanity.sh
+PASS: t/seenc.sh
+PASS: t/silent-c.sh
+PASS: t/silent-cxx.sh
+PASS: t/silent-lt.sh
+silent-f77: skipped test: no Fortran 77 compiler available
+SKIP: t/silent-f77.sh
+silent-f90: skipped test: no Fortran compiler available
+SKIP: t/silent-f90.sh
+silent-many-languages: skipped test: no Fortran compiler available
+SKIP: t/silent-many-languages.sh
+PASS: t/silent-gen.sh
+silent-texi: skipped test: required program 'makeinfo' not available
+SKIP: t/silent-texi.sh
+PASS: t/silent-lex.sh
+PASS: t/silent-yacc.sh
+PASS: t/silent-yacc-headers.sh
+PASS: t/silent-configsite.sh
+PASS: t/silent-nested-vars.sh
+PASS: t/silent-custom.sh
+PASS: t/src-acsubst.sh
+PASS: t/sourcefile-in-subdir.sh
+PASS: t/space.sh
+PASS: t/specflg6.sh
+PASS: t/specflg7.sh
+PASS: t/specflg8.sh
+PASS: t/specflg9.sh
+PASS: t/specflg-dummy.sh
+PASS: t/spell.sh
+PASS: t/spell2.sh
+PASS: t/spell3.sh
+PASS: t/spelling.sh
+PASS: t/spy-double-colon.sh
+PASS: t/spy-rm.tap 1 - /bin/rm -f
+PASS: t/spy-rm.tap 2 - rm -f
+PASS: t/spy-rm.tap 3 - /bin/rm -rf
+PASS: t/spy-rm.tap 4 - rm -rf
+PASS: t/spy-rm.tap 5 - /bin/rm -fr
+PASS: t/spy-rm.tap 6 - rm -fr
+PASS: t/spy-rm.tap 7 - /bin/rm -f -r
+PASS: t/spy-rm.tap 8 - rm -f -r
+PASS: t/spy-rm.tap 9 - /bin/rm -r -f
+PASS: t/spy-rm.tap 10 - rm -r -f
+PASS: t/stdinc.sh
+PASS: t/stamph2.sh
+PASS: t/stdlib.sh
+PASS: t/stdlib2.sh
+PASS: t/strictness-override.sh
+PASS: t/strictness-precedence.sh
+PASS: t/strip.sh
+strip2: skipped test: required program 'strip' not available
+SKIP: t/strip2.sh
+strip3: skipped test: required program 'strip' not available
+SKIP: t/strip3.sh
+PASS: t/subdir.sh
+PASS: t/subdir-ac-subst.sh
+PASS: t/subdir-add-pr46.sh
+PASS: t/subdir-add2-pr46.sh
+PASS: t/subdir-am-cond.sh
+PASS: t/subdir-cond-err.sh
+subdir-cond-gettext: skipped test: couldn't find or get gettext macros
+SKIP: t/subdir-cond-gettext.sh
+PASS: t/subdir-env-interference.sh
+PASS: t/subdir-order.sh
+PASS: t/subdir-with-slash.sh
+PASS: t/subdir-subsub.sh
+PASS: t/subdir-distclean.sh
+PASS: t/subdir-keep-going-pr12554.sh
+PASS: t/subobj.sh
+PASS: t/subobj2.sh
+PASS: t/subobj4.sh
+PASS: t/subobj5.sh
+PASS: t/subobj6.sh
+PASS: t/subobj7.sh
+PASS: t/subobj8.sh
+PASS: t/subobj9.sh
+PASS: t/subobj10.sh
+PASS: t/subobj11a.sh
+PASS: t/subobj11b.sh
+PASS: t/subobj11c.sh
+PASS: t/subobjname.sh
+PASS: t/subobj-clean-pr10697.sh
+PASS: t/subobj-clean-lt-pr10697.sh
+XFAIL: t/subobj-indir-pr13928.sh
+XFAIL: t/subobj-vpath-pr13928.sh
+PASS: t/subpkg.sh
+PASS: t/subpkg2.sh
+PASS: t/subpkg3.sh
+FAIL: t/subpkg4.sh
+PASS: t/subpkg-yacc.sh
+PASS: t/subpkg-macrodir.sh
+PASS: t/subst.sh
+PASS: t/subst3.sh
+PASS: t/subst4.sh
+PASS: t/subst5.sh
+PASS: t/subst-no-trailing-empty-line.sh
+PASS: t/substref.sh
+PASS: t/substre2.sh
+PASS: t/substtarg.sh
+PASS: t/suffix.sh
+PASS: t/suffix2.sh
+PASS: t/suffix3.tap 1 - aclocal
+PASS: t/suffix3.tap 2 - automake
+PASS: t/suffix3.tap 3 - intermediate files not mentioned
+PASS: t/suffix3.tap 4 - final object file figured out
+PASS: t/suffix3.tap 5 - autoconf
+PASS: t/suffix3.tap 6 - configure
+PASS: t/suffix3.tap 7 - make all
+PASS: t/suffix3.tap 8 - make distcheck
+PASS: t/suffix3.tap 9 - make distdir
+PASS: t/suffix3.tap 10 - intermediate file not distributed
+PASS: t/suffix4.sh
+PASS: t/suffix5.sh
+PASS: t/suffix6.sh
+PASS: t/suffix6b.sh
+PASS: t/suffix6c.sh
+PASS: t/suffix7.sh
+PASS: t/suffix8.tap 1 - libtoolize
+PASS: t/suffix8.tap 2 - aclocal
+PASS: t/suffix8.tap 3 - autoconf
+PASS: t/suffix8.tap 4 - automake
+PASS: t/suffix8.tap 5 - configure
+PASS: t/suffix8.tap 6 - make test0
+PASS: t/suffix8.tap 7 - make test1
+PASS: t/suffix8.tap 8 - make test2
+PASS: t/suffix8.tap 9 - make all
+PASS: t/suffix8.tap 10 - make distcheck
+PASS: t/suffix9.sh
+PASS: t/suffix10.tap 1 - libtoolize
+PASS: t/suffix10.tap 2 - aclocal
+PASS: t/suffix10.tap 3 - autoconf
+PASS: t/suffix10.tap 4 - automake
+PASS: t/suffix10.tap 5 - configure
+PASS: t/suffix10.tap 6 - make test
+PASS: t/suffix10.tap 7 - make all
+PASS: t/suffix11.tap 1 - aclocal
+PASS: t/suffix11.tap 2 - autoconf
+PASS: t/suffix11.tap 3 - automake exited 1
+PASS: t/suffix11.tap 4 - warn about unportable make usage
+PASS: t/suffix11.tap 5 - automake
+PASS: t/suffix11.tap 6 - configure
+PASS: t/suffix11.tap 7 - make test-fake
+PASS: t/suffix11.tap 8 - make test-real
+PASS: t/suffix11.tap 9 - make
+PASS: t/suffix11.tap 10 - make distcheck
+PASS: t/suffix-chain.tap 1 - aclocal
+PASS: t/suffix-chain.tap 2 - automake
+PASS: t/suffix-chain.tap 3 - autoconf
+PASS: t/suffix-chain.tap 4 - configure
+PASS: t/suffix-chain.tap 5 - make all
+PASS: t/suffix-chain.tap 6 - make distcheck
+PASS: t/suffix-chain.tap 7 - clean
+PASS: t/suffix-chain.tap 8 - make with explicit dependencies
+PASS: t/suffix-custom-pr14441.sh
+PASS: t/suffix-custom-subobj.sh
+PASS: t/suffix-custom-subobj-and-specflg.sh
+PASS: t/suffix-extra-c-stuff-pr14560.sh
+PASS: t/symlink.sh
+PASS: t/symlink2.sh
+PASS: t/syntax.sh
+PASS: t/tap-common-setup.sh
+PASS: t/tap-ambiguous-directive.sh
+PASS: t/tap-autonumber.sh
+PASS: t/tap-bailout.sh
+PASS: t/tap-bailout-leading-space.sh
+PASS: t/tap-bailout-and-logging.sh
+PASS: t/tap-bailout-suppress-badexit.sh
+PASS: t/tap-bailout-suppress-later-diagnostic.sh
+PASS: t/tap-bailout-suppress-later-errors.sh
+PASS: t/tap-color.sh
+PASS: t/tap-deps.sh
+PASS: t/tap-diagnostic.sh
+PASS: t/tap-empty-diagnostic.sh
+PASS: t/tap-empty.sh
+PASS: t/tap-escape-directive.sh
+PASS: t/tap-escape-directive-2.sh
+PASS: t/tap-exit.sh
+PASS: t/tap-signal.tap 1 - "make check" fails
+PASS: t/tap-signal.tap 2 - count of test results
+PASS: t/tap-signal.tap 3 - TAP driver catch test termination by signal SIGHUP
+PASS: t/tap-signal.tap 4 - TAP driver catch test termination by signal SIGINT
+PASS: t/tap-signal.tap 5 - TAP driver catch test termination by signal SIGQUIT
+PASS: t/tap-signal.tap 6 - TAP driver catch test termination by signal SIGKILL
+PASS: t/tap-signal.tap 7 - TAP driver catch test termination by signal SIGPIPE
+PASS: t/tap-signal.tap 8 - TAP driver catch test termination by signal SIGTERM
+PASS: t/tap-signal.tap 9 - "make check" passes [--ignore-exit]
+PASS: t/tap-signal.tap 10 - count of test results [--ignore-exit]
+PASS: t/tap-fancy.sh
+PASS: t/tap-fancy2.sh
+PASS: t/tap-global-log.sh
+PASS: t/tap-global-result.sh
+PASS: t/tap-log.sh
+PASS: t/tap-msg0-result.sh
+PASS: t/tap-msg0-directive.sh
+PASS: t/tap-msg0-planskip.sh
+PASS: t/tap-msg0-bailout.sh
+PASS: t/tap-msg0-misc.sh
+PASS: t/tap-merge-stdout-stderr.sh
+PASS: t/tap-no-merge-stdout-stderr.sh
+PASS: t/tap-no-disable-hard-error.sh
+PASS: t/tap-no-spurious-summary.sh
+PASS: t/tap-no-spurious-numbers.sh
+PASS: t/tap-no-spurious.sh
+PASS: t/tap-not-ok-skip.sh
+PASS: t/tap-number-wordboundary.sh
+PASS: t/tap-numeric-description.sh
+PASS: t/tap-negative-numbers.sh
+PASS: t/tap-numbers-leading-zero.sh
+PASS: t/tap-out-of-order.sh
+PASS: t/tap-passthrough.sh
+PASS: t/tap-passthrough-exit.sh
+PASS: t/tap-plan.sh
+PASS: t/tap-plan-corner.sh
+PASS: t/tap-plan-errors.sh
+PASS: t/tap-plan-middle.sh
+PASS: t/tap-plan-whitespace.sh
+PASS: t/tap-plan-leading-zero.sh
+PASS: t/tap-plan-malformed.sh
+PASS: t/tap-missing-plan-and-bad-exit.sh
+PASS: t/tap-planskip.sh
+PASS: t/tap-planskip-late.sh
+PASS: t/tap-planskip-and-logging.sh
+PASS: t/tap-planskip-unplanned.sh
+PASS: t/tap-planskip-unplanned-corner.sh
+PASS: t/tap-planskip-case-insensitive.sh
+PASS: t/tap-planskip-whitespace.sh
+PASS: t/tap-planskip-badexit.sh
+PASS: t/tap-planskip-bailout.sh
+PASS: t/tap-planskip-later-errors.sh
+PASS: t/tap-test-number-0.sh
+PASS: t/tap-recheck-logs.sh
+PASS: t/tap-result-comment.sh
+PASS: t/tap-todo-skip-together.sh
+PASS: t/tap-todo-skip-whitespace.sh
+PASS: t/tap-todo-skip.sh
+PASS: t/tap-unplanned.sh
+PASS: t/tap-whitespace-normalization.sh
+PASS: t/tap-with-and-without-number.sh
+PASS: t/tap-xfail-tests.sh
+PASS: t/tap-bad-prog.tap 1 - "make check" returns non-zero exit status
+PASS: t/tap-bad-prog.tap 2 - non-existent test is reported
+PASS: t/tap-bad-prog.tap 3 - non-executable test is reported
+PASS: t/tap-bad-prog.tap 4 - non-readable test is reported
+XFAIL: t/tap-bad-prog.tap 5 - no spurious "missing plan" message # TODO
+XFAIL: t/tap-bad-prog.tap 6 - no spurious results # TODO still get "missing plan"
+PASS: t/tap-basic.sh
+PASS: t/tap-diagnostic-custom.sh
+PASS: t/tap-driver-stderr.sh
+PASS: t/tap-doc.sh
+PASS: t/tap-doc2.sh
+PASS: t/tap-more.sh
+PASS: t/tap-more2.sh
+PASS: t/tap-recheck.sh
+PASS: t/tap-summary.sh
+PASS: t/tap-summary-color.sh
+PASS: t/tags.sh
+PASS: t/tags2.sh
+tagsub: skipped test: required program 'etags' not available
+SKIP: t/tagsub.sh
+tags-pr12372: skipped test: required program 'etags' not available
+SKIP: t/tags-pr12372.sh
+PASS: t/tar-ustar.sh
+PASS: t/tar-pax.sh
+PASS: t/tar-opts-errors.sh
+PASS: t/tar-ustar-id-too-high.sh
+PASS: t/tar-override.sh
+PASS: t/target-cflags.sh
+PASS: t/targetclash.sh
+PASS: t/tests-environment-fd-redirect.sh
+PASS: t/tests-environment-and-log-compiler.sh
+txinfo-absolute-srcdir-pr408: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-absolute-srcdir-pr408.sh
+PASS: t/txinfo-add-missing-and-dist.sh
+PASS: t/txinfo-bsd-make-recurs.sh
+txinfo-builddir: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-builddir.sh
+txinfo-clean: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-clean.sh
+PASS: t/txinfo-dvi-recurs.sh
+txinfo-info-in-srcdir: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-info-in-srcdir.sh
+txinfo-include: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-include.sh
+txinfo-makeinfo-error-no-clobber: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-makeinfo-error-no-clobber.sh
+txinfo-many-output-formats: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-many-output-formats.sh
+txinfo-many-output-formats-vpath: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-many-output-formats-vpath.sh
+txinfo-nodist-info: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-nodist-info.sh
+txinfo-no-clutter: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-no-clutter.sh
+PASS: t/txinfo-no-extra-dist.sh
+txinfo-no-installinfo: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-no-installinfo.sh
+PASS: t/txinfo-no-repeated-targets.sh
+PASS: t/txinfo-other-suffixes.sh
+PASS: t/txinfo-override-infodeps.sh
+txinfo-override-texinfo-tex: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-override-texinfo-tex.sh
+PASS: t/txinfo-setfilename-repeated.sh
+PASS: t/txinfo-setfilename-suffix-strip.sh
+txinfo-subdir-pr343: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-subdir-pr343.sh
+txinfo-tex-dist: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-tex-dist.sh
+PASS: t/txinfo-unrecognized-extension.sh
+PASS: t/txinfo-unrecognized-info-suffix.sh
+PASS: t/txinfo-vtexi.sh
+PASS: t/txinfo-vtexi2.sh
+PASS: t/txinfo-vtexi3.sh
+txinfo-vtexi4: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-vtexi4.sh
+txinfo-without-info-suffix: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo-without-info-suffix.sh
+txinfo19: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo19.sh
+txinfo23: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo23.sh
+txinfo24: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo24.sh
+txinfo25: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo25.sh
+txinfo28: skipped test: required program 'makeinfo' not available
+SKIP: t/txinfo28.sh
+PASS: t/transform.sh
+PASS: t/transform2.sh
+PASS: t/transform3.sh
+PASS: t/uninstall-fail.sh
+PASS: t/uninstall-pr9578.sh
+PASS: t/unused.sh
+SKIP: t/upc.sh
+PASS: t/upc2.sh
+SKIP: t/upc3.sh
+PASS: t/vala-configure.sh
+PASS: t/vala-grepping.sh
+pkg-config-macros: skipped test: pkg-config m4 macros not found
+SKIP: t/pkg-config-macros.sh
+vala-headers: skipped test: required program 'valac' not available
+SKIP: t/vala-headers.sh
+vala-libs: skipped test: required program 'valac' not available
+SKIP: t/vala-libs.sh
+vala-mix: skipped test: required program 'valac' not available
+SKIP: t/vala-mix.sh
+vala-mix2: skipped test: required program 'valac' not available
+SKIP: t/vala-mix2.sh
+vala-non-recursive-setup: skipped test: required program 'valac' not available
+SKIP: t/vala-non-recursive-setup.sh
+vala-parallel: skipped test: required program 'valac' not available
+SKIP: t/vala-parallel.sh
+vala-per-target-flags: skipped test: required program 'valac' not available
+SKIP: t/vala-per-target-flags.sh
+vala-recursive-setup: skipped test: required program 'valac' not available
+SKIP: t/vala-recursive-setup.sh
+vala-vapi: skipped test: required program 'valac' not available
+SKIP: t/vala-vapi.sh
+vala-vpath: skipped test: required program 'valac' not available
+SKIP: t/vala-vpath.sh
+PASS: t/vars.sh
+PASS: t/vars3.sh
+PASS: t/var-recurs.sh
+PASS: t/var-recurs2.sh
+PASS: t/vartar.sh
+PASS: t/vartypos.sh
+PASS: t/vartypo2.sh
+PASS: t/version3.sh
+PASS: t/version4.sh
+PASS: t/version6.sh
+version7: skipped test: required program 'makeinfo' not available
+SKIP: t/version7.sh
+PASS: t/version8.sh
+PASS: t/vpath.sh
+PASS: t/warnings-obsolete-default.sh
+PASS: t/warnings-override.sh
+PASS: t/warnings-precedence.sh
+PASS: t/warnings-strictness-interactions.sh
+PASS: t/warnings-unknown.sh
+PASS: t/warnopts.sh
+PASS: t/warnings-win-over-strictness.sh
+PASS: t/warning-groups-win-over-strictness.sh
+PASS: t/werror.sh
+PASS: t/werror2.sh
+PASS: t/werror3.sh
+PASS: t/werror4.sh
+PASS: t/whoami.sh
+PASS: t/xsource.sh
+PASS: t/yacc-misc.sh
+PASS: t/yacc-dry.sh
+PASS: t/yacc-cxx-grepping.sh
+PASS: t/yacc-vpath.sh
+PASS: t/yacc-auxdir.sh
+PASS: t/yacc-basic.sh
+PASS: t/yacc-cxx.sh
+PASS: t/yacc-bison-skeleton-cxx.sh
+PASS: t/yacc-bison-skeleton.sh
+PASS: t/yacc-clean.sh
+PASS: t/yacc-clean-cxx.sh
+PASS: t/yacc-d-basic.sh
+PASS: t/yacc-d-cxx.sh
+PASS: t/yacc-d-vpath.sh
+PASS: t/yacc-deleted-headers.sh
+PASS: t/yacc-depend.sh
+PASS: t/yacc-depend2.sh
+PASS: t/yacc-dist-nobuild-subdir.sh
+PASS: t/yacc-dist-nobuild.sh
+PASS: t/yacc-grepping.sh
+PASS: t/yacc-grepping2.sh
+PASS: t/yacc-headers-and-dist-pr47.sh
+PASS: t/yacc-line.sh
+PASS: t/yacc-mix-c-cxx.sh
+PASS: t/yacc-nodist.sh
+PASS: t/yacc-pr204.sh
+PASS: t/yacc-subdir.sh
+PASS: t/yacc-weirdnames.sh
+PASS: t/yflags.sh
+PASS: t/yflags-cxx.sh
+PASS: t/yflags-cmdline-override.sh
+PASS: t/yflags-conditional.sh
+PASS: t/yflags-d-false-positives.sh
+PASS: t/yflags-force-conditional.sh
+PASS: t/yflags-force-override.sh
+PASS: t/yflags-var-expand.sh
+PASS: t/ar-lib-w.sh
+PASS: t/built-sources-check-w.sh
+PASS: t/check-exported-srcdir-w.sh
+PASS: t/check-fd-redirect-w.sh
+PASS: t/check-subst-prog-w.sh
+PASS: t/check-subst-w.sh
+PASS: t/check-tests-in-builddir-w.sh
+PASS: t/check-w.sh
+PASS: t/check11-w.sh
+check12-w: skipped test: DejaGnu is not available
+SKIP: t/check12-w.sh
+PASS: t/check2-w.sh
+PASS: t/check4-w.sh
+PASS: t/check5-w.sh
+PASS: t/check6-w.sh
+PASS: t/check7-w.sh
+PASS: t/check8-w.sh
+PASS: t/color-tests-w.sh
+color-tests2-w: skipped test: requires a working expect program
+SKIP: t/color-tests2-w.sh
+PASS: t/compile-w.sh
+PASS: t/compile2-w.sh
+PASS: t/compile3-w.sh
+compile4-w: skipped test: Microsoft C compiler 'cl' not available
+SKIP: t/compile4-w.sh
+compile5-w: skipped test: target OS is not MinGW
+SKIP: t/compile5-w.sh
+PASS: t/compile6-w.sh
+compile7-w: skipped test: Intel C compiler 'icl' not available
+SKIP: t/compile7-w.sh
+PASS: t/exeext4-w.sh
+PASS: t/install-sh-option-C-w.sh
+PASS: t/install-sh-unittests-w.sh
+PASS: t/maken3-w.sh
+PASS: t/mdate5-w.sh
+PASS: t/mdate6-w.sh
+PASS: t/missing-version-mismatch-w.sh
+PASS: t/missing3-w.sh
+PASS: t/mkinst3-w.sh
+PASS: t/posixsubst-tests-w.sh
+ERROR: t/depcomp-lt-auto.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-lt-cpp.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-lt-dashmstdout.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-lt-disabled.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-lt-gcc.tap - Bail out! couldn't populate source directory '.'
+SKIP: t/depcomp-lt-makedepend.tap - required program 'makedepend' not available
+SKIP: t/depcomp-lt-msvcmsys.tap - Microsoft C compiler 'cl' not available
+SKIP: t/depcomp-lt-msvisualcpp.tap - Microsoft C compiler 'cl' not available
+ERROR: t/depcomp-auto.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-cpp.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-dashmstdout.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-disabled.tap - Bail out! couldn't populate source directory '.'
+ERROR: t/depcomp-gcc.tap - Bail out! couldn't populate source directory '.'
+SKIP: t/depcomp-makedepend.tap - required program 'makedepend' not available
+SKIP: t/depcomp-msvcmsys.tap - Microsoft C compiler 'cl' not available
+SKIP: t/depcomp-msvisualcpp.tap - Microsoft C compiler 'cl' not available
+parallel-tests-html: skipped test: no proper rst2html program found
+SKIP: contrib/t/parallel-tests-html.sh
+parallel-tests-html-recursive: skipped test: no proper rst2html program found
+SKIP: contrib/t/parallel-tests-html-recursive.sh
+PASS: contrib/t/help-multilib.sh
+PASS: contrib/t/multilib.sh
+============================================================================
+Testsuite summary for GNU Automake 1.15.1
+============================================================================
+# TOTAL: 2575
+# PASS:  2386
+# SKIP:  125
+# XFAIL: 42
+# FAIL:  12
+# XPASS: 0
+# ERROR: 10
+============================================================================
+See ./test-suite.log
+Please report to bug-automake@gnu.org
+============================================================================
+gmake[2]: *** [Makefile:3029: test-suite.log] Error 1
+gmake[1]: *** [Makefile:3137: check-TESTS] Error 2
+gmake: *** [Makefile:3368: check-am] Error 2

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -12,7 +12,7 @@
 | database/sqlite-3			| 3.19.3		| https://www.sqlite.org/
 | developer/bmake			| 20160926		| http://www.crufty.net/ftp/pub/sjg/
 | developer/build/autoconf		| 2.69			| https://savannah.gnu.org/news/?group=autocon 
-| developer/build/automake		| 1.15			| https://savannah.gnu.org/news/?group=automake
+| developer/build/automake		| 1.15.1		| https://savannah.gnu.org/news/?group=automake
 | developer/build/gnu-make		| 4.2.1			| http://savannah.gnu.org/news/?group=make
 | developer/build/libtool		| 2.4.6			| https://www.gnu.org/software/libtool/
 | developer/gcc51			| 5.1.0			| https://www.gnu.org/software/gcc/


### PR DESCRIPTION
```shell
hadfl@mars:~$ automake --version
automake (GNU automake) 1.15.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl-2.0.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Tom Tromey <tromey@redhat.com>
       and Alexandre Duret-Lutz <adl@gnu.org>.
```

test-suite diff from 1.15:
```diff
============================================================================
-Testsuite summary for GNU Automake 1.15
+Testsuite summary for GNU Automake 1.15.1
 ============================================================================
-# TOTAL: 2573
-# PASS:  2371
-# SKIP:  123
+# TOTAL: 2575
+# PASS:  2386
+# SKIP:  125
 # XFAIL: 42
-# FAIL:  25
+# FAIL:  12
 # XPASS: 0
-# ERROR: 12
+# ERROR: 10
 ============================================================================
 See ./test-suite.log
 Please report to bug-automake@gnu.org
 ============================================================================
```