### PR TITLE
zlib: Fix pkglint (and add testsuite)

### DIFF
--- a/build/zlib/build.sh
+++ b/build/zlib/build.sh
@@ -61,12 +61,12 @@ move_libs() {
     popd>/dev/null
 }
 
-SKIP_PKGLINT=1
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+run_testsuite
 make_lintlibs z /usr/lib /usr/include
 make_isa_stub
 install_license

--- a/build/zlib/local.mog
+++ b/build/zlib/local.mog
@@ -1,2 +1,4 @@
 <transform file path=license$ -> drop>
+<transform link path=lib/64$ -> drop>
 license license license=zlib
+

--- a/build/zlib/testsuite.log
+++ b/build/zlib/testsuite.log
@@ -1,0 +1,30 @@
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib shared test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib 64-bit test OK ***


### PR DESCRIPTION
The `/lib/64` symlink is delivered by both `system/library` and `library/zlib` causing a conflict that is detected by the pkglint process.

```
reaper% pkg contents -m system/library | grep path=lib/64\
link path=lib/64 target=amd64
reaper% pkg contents -m library/zlib | grep path=lib/64\
link path=lib/64 target=amd64
```

...

```
ERROR pkglint.dupaction010.2      path lib/64 has missing mediator attributes across actions in pkg://omnios/system/library@0.5.11,5.11-0.151023:20170713T011155Z pkg:/library/zlib@1.2.11,5.11-0.151023
```

This change removes the link from the `library/zlib` package and re-enables lint for this package.
Since library/zlib depends on system/zlib, nothing is lost.

Also, as there is a test suite for zlib, this is enabled.