### PR TITLE
libgmp-gcc51: Resolve duplicate dependency

### DIFF
--- a/build/gcc51/build-libgmp.sh
+++ b/build/gcc51/build-libgmp.sh
@@ -61,5 +61,5 @@ download_source $PROG $PROG $VER
 prep_build
 build
 make_isa_stub
-SKIP_PKGLINT=1 make_package libgmp.mog
+make_package libgmp.mog libgmp-final.mog
 clean_up

--- a/build/gcc51/libgmp-final.mog
+++ b/build/gcc51/libgmp-final.mog
@@ -1,0 +1,6 @@
+
+<transform depend type=require-any -> drop>
+
+depend type=require fmri=system/library/g++-5-runtime
+depend type=require fmri=system/library/gcc-5-runtime
+

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -656,6 +656,24 @@ make_package() {
     MANUAL_DEPS=$TMPDIR/${PKGE}.deps.mog
     GLOBAL_MOG_FILE=$MYDIR/global-transforms.mog
     MY_MOG_FILE=$TMPDIR/${PKGE}.mog
+    [ -f $SRCDIR/local.mog ] && \
+        LOCAL_MOG_FILE=$SRCDIR/local.mog || LOCAL_MOG_FILE=
+    EXTRA_MOG_FILE=
+    FINAL_MOG_FILE=
+    if [ -n "$1" ]; then
+            if [[ "$1" = /* ]]; then
+                EXTRA_MOG_FILE="$1"
+            else
+                EXTRA_MOG_FILE="$SRCDIR/$1"
+            fi
+    fi
+    if [ -n "$2" ]; then
+            if [[ "$2" = /* ]]; then
+                FINAL_MOG_FILE="$2"
+            else
+                FINAL_MOG_FILE="$SRCDIR/$2"
+            fi
+    fi
 
     ## Strip leading zeros in version components.
     VER=`echo $VER | sed -e 's/\.0*\([1-9]\)/.\1/g;'`
@@ -685,11 +703,8 @@ make_package() {
     echo "set name=pkg.summary value=\"$SUMMARY\"" >> $MY_MOG_FILE
     echo "set name=pkg.descr value=\"$DESCSTR\"" >> $MY_MOG_FILE
     echo "set name=publisher value=\"sa@omniosce.org\"" >> $MY_MOG_FILE
-    if [[ -f $SRCDIR/local.mog ]]; then
-        LOCAL_MOG_FILE=$SRCDIR/local.mog
-    fi
     logmsg "--- Applying transforms"
-    $PKGMOGRIFY $XFORM_ARGS $P5M_INT $MY_MOG_FILE $GLOBAL_MOG_FILE $LOCAL_MOG_FILE $* | $PKGFMT -u > $P5M_INT2
+    $PKGMOGRIFY $XFORM_ARGS $P5M_INT $MY_MOG_FILE $GLOBAL_MOG_FILE $LOCAL_MOG_FILE $EXTRA_MOG_FILE | $PKGFMT -u > $P5M_INT2
     logmsg "--- Resolving dependencies"
     (
         set -e
@@ -748,7 +763,8 @@ make_package() {
             fi
         done
     fi
-    $PKGMOGRIFY "${P5M_INT3}.res" "$MANUAL_DEPS" | $PKGFMT -u > $P5M_FINAL
+    $PKGMOGRIFY "${P5M_INT3}.res" "$MANUAL_DEPS" $FINAL_MOG_FILE | \
+        $PKGFMT -u > $P5M_FINAL
     if [[ -z $SKIP_PKGLINT ]] && ( [[ -n $BATCH ]] ||  ask_to_pkglint ); then
         $PKGLINT -c $TMPDIR/lint-cache -r $PKGSRVR $P5M_FINAL || \
             logerr "----- pkglint failed"


### PR DESCRIPTION
Fix the last remaining pkglint problem in the build.
Extends the package creation framework to accept an additional `.mog` file that is applied after package dependencies have been determined.

Fixes https://github.com/omniosorg/omnios-build/issues/10