### PR TITLE
gzip: fix non-deterministic packaging

### DIFF
--- a/build/gzip/build.sh
+++ b/build/gzip/build.sh
@@ -62,6 +62,14 @@ rename_files() {
     done
 }
 
+remove_files() {
+    logmsg "Removing unwanted files in $DESTDIR"
+    # Uncompress is delivered by system/extended-system-utilities
+    # Can't do this in local.mog as it's a hardlink and can either by
+    # discovered as a file or a hardlink.
+    find $DESTDIR -name uncompress -exec rm {} +
+}
+
 build32() {
     pushd $TMPDIR/$BUILDDIR > /dev/null
     logmsg "Building 32-bit"
@@ -72,6 +80,7 @@ build32() {
     rename_in_docs
     make_install32
     rename_files
+    remove_files
     popd > /dev/null
     unset ISALIST
     export ISALIST

--- a/build/gzip/local.mog
+++ b/build/gzip/local.mog
@@ -23,7 +23,5 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# uncompress is delivered by another package
-<transform hardlink path=.*/uncompress$ -> drop>
 <transform file path=usr/sfw/.* -> drop>
 license COPYING license=GPLv3


### PR DESCRIPTION
Here's one that took a lot less time to fix than diagnose!

gzip delivers a binary called `uncompress` which is a hard link to `gunzip`. However, `uncompress` is also delivered by `system/extended-system-utilities` so there is a conflict.

Sometimes the gzip package manifest is generated so that it looks like:

```
file usr/bin/gunzip group=bin mode=0755 owner=root path=usr/bin/gunzip
hardlink path=usr/bin/uncompress target=gunzip
```
which is fine, the hardlink is removed by an entry in `local.mog`.

However, half of the time, the manifest looks like:

```
file usr/bin/uncompress group=bin mode=0755 owner=root path=usr/bin/uncompress
hardlink path=usr/bin/gunzip target=uncompress
```
That is, the uncompress binary is found first then gunzip is added as a hard link to that. In this case, `/usr/bin/uncompress` gets left in the final package and a conflict occurs.

So, let's take the easy way out and remove the binary from disk before generating the package.