### PR TITLE
ncurses: update to 6.0-20170722

### DIFF
--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -28,8 +28,10 @@
 . ../../lib/functions.sh
 
 PROG=ncurses
-VER=6.0
+VER=6.0-20170722
 VERHUMAN=$VER
+BUILDDIR=$PROG-$VER
+VER=${VER/-/.}
 PKG=library/ncurses
 SUMMARY="A CRT screen handling and optimization package."
 DESC="$SUMMARY"
@@ -92,7 +94,7 @@ build_abi6() {
 }
 
 init
-download_source $PROG $PROG $VER
+download_source $PROG $PROG $VERHUMAN
 patch_source
 prep_build
 build_abi5

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -33,7 +33,7 @@
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
 | library/libxml2			| 2.9.4			| http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.29		| http://xmlsoft.org/libxslt/news.html
-| library/ncurses			| 6.0.20170722		| https://ftp.gnu.org/gnu/ncurses/
+| library/ncurses			| 6.0.20170722		| https://ftp.gnu.org/gnu/ncurses/ http://invisible-mirror.net/archives/ncurses/current/
 | library/nghttp2			| 1.24.0		| https://nghttp2.org/blog/
 | library/nspr				| 4.14			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.41			| https://ftp.pcre.org/pub/pcre/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -33,7 +33,7 @@
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
 | library/libxml2			| 2.9.4			| http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.29		| http://xmlsoft.org/libxslt/news.html
-| library/ncurses			| 6.0			| https://ftp.gnu.org/gnu/ncurses/
+| library/ncurses			| 6.0.20170722		| https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.24.0		| https://nghttp2.org/blog/
 | library/nspr				| 4.14			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.41			| https://ftp.pcre.org/pub/pcre/


### PR DESCRIPTION
Fixes:
	CVE 2017-10684
	CVE-2017-10685
	CVE-2017-11112
	CVE-2017-11113

```
bloody# greset -V
ncurses 6.0.20170722
```

Have tested vim, less and tmux for basic functionality.