### PR TITLE
gtar: Add missing dependencies

### DIFF
--- a/build/gtar/build.sh
+++ b/build/gtar/build.sh
@@ -33,6 +33,8 @@ PKG=archiver/gnu-tar
 SUMMARY="gtar - GNU tar"
 DESC="GNU tar - A utility used to store, backup, and transport files (gtar) $VER"
 
+RUN_DEPENDS_IPS="system/extended-system-utilities compress/gzip compress/bzip2 compress/xz"
+
 BUILDARCH=32
 # GNU tar doesn't like to be configured by root.  This var ignores those errors
 export FORCE_UNSAFE_CONFIGURE=1


### PR DESCRIPTION
See https://github.com/omniosorg/illumos-omnios/issues/25

```
bloody% pkg contents -m gnu-tar | grep require
depend fmri=compress/bzip2 type=require
depend fmri=compress/gzip type=require
depend fmri=compress/xz type=require
depend fmri=pkg:/system/library@0.5.11-0.151022 type=require
depend fmri=system/extended-system-utilities type=require
```

Backport for r151022l