### PR TITLE
make LX zones part of core OmniOS

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -360,6 +360,7 @@ depend fmri=system/storage/luxadm@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/xopen/xcu4@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones/brand/ipkg@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones/brand/lipkg@0.5.11,5.11-@PVER@ type=require
+depend fmri=system/zones/brand/lx@0.5.11,5.11-@PVER@ type=require
 depend fmri=system/zones@0.5.11,5.11-@PVER@ type=require
 depend fmri=terminal/screen@4.6,5.11-@PVER@ type=require
 depend fmri=text/doctools@0.5.11,5.11-@PVER@ type=require


### PR DESCRIPTION
considering LX zones are no longer beta in OmniOS they should be part of core installation for r24+

open for discussion.