### PR TITLE
make poold optional

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -288,7 +288,6 @@ depend fmri=service/network/smtp/sendmail@8.14.4,5.11-@PVER@ type=group
 depend fmri=service/network/ssh@0.5.11,5.11-@PVER@ fmri=network/openssh-server type=require-any
 depend fmri=service/network/ssh-common@0.5.11,5.11-@PVER@ fmri=network/openssh-server type=require-any
 depend fmri=service/picl@0.5.11,5.11-@PVER@ type=require
-depend fmri=service/resource-pools/poold@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/resource-pools@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/storage/removable-media@0.5.11,5.11-@PVER@ type=require
 depend fmri=shell/bash@4.4,5.11-@PVER@ type=require


### PR DESCRIPTION
This will remove `poold` being part of OmniOS core installation for r24+.

It does not mean that `poold` (and likely Java) are removed from the core repo immediately, but it is a first step. Once removing it completely, the Java incorporation in `omnios-userland` should be removed, too.

Due to "misplaced" manifest and svc method of `poold`, it also depends on this upstream fix: https://www.illumos.org/issues/8549 (or we have to fix that in OmniOS)

Open for discussion.

cf. https://github.com/omniosorg/omnios-build/issues/6