### PR TITLE
security fixes for git and hg

### DIFF
--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -29,7 +29,7 @@
 . ../../lib/functions.sh
 
 PROG=git
-VER=2.13.3
+VER=2.13.5
 PKG=developer/versioning/git
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"

--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.2.2
+VER=4.2.3
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -20,8 +20,8 @@
 | developer/macro/gnu-m4		| 1.4.18		| http://savannah.gnu.org/news/?group=m4
 | developer/parser/bison		| 3.0.4			| https://savannah.gnu.org/news/?group=bison
 | developer/pkg-config			| 0.29.2		| https://www.freedesktop.org/wiki/Software/pkg-config/
-| developer/versioning/git		| 2.13.3		| https://git-scm.com/downloads
-| developer/versioning/mercurial	| 4.2.2			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/git		| 2.13.5		| https://git-scm.com/downloads
+| developer/versioning/mercurial	| 4.2.3			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap
 | editor/vim				| 8.0.586		| http://www.vim.org/download.php
 | file/gnu-coreutils			| 8.27			| https://savannah.gnu.org/news/?group=coreutils


### PR DESCRIPTION
- CVE-2017-1000117
- CVE-2017-1000116

```
hadfl@mars:/omniosorg/build/bloody/omnios-build$ git version
git version 2.13.5

hadfl@mars:/omniosorg/build/bloody/omnios-build$ hg version
Mercurial Distributed SCM (version 4.2.3)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2017 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```