### PR TITLE
update mercurial to version 4.3.1

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.2.3
+VER=4.3.1
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"


### PR DESCRIPTION
Considering the latest security fix release notes:
> Note that since we dropped Python 2.6 and these issues are pretty bad, we did the back port to 4.2.3. We may not do further 4.2 releases, so please plan around Python 2.7 in the near future if you haven't already.

and since we are up to Python 2.7, I think we should head to 4.3.x for r24.

```
hadfl@mars:~$ hg version
Mercurial Distributed SCM (version 4.3.1)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2017 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```