### PR TITLE
sqlite3: update to 3.20.0

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -16,7 +16,7 @@ depend fmri=compress/unzip@6.0,5.11-@PVER@ type=require
 depend fmri=compress/xz@5.2,5.11-@PVER@ type=require
 depend fmri=compress/zip@3.0,5.11-@PVER@ type=require
 depend fmri=web/ca-bundle@5.11,5.11-@PVER@ type=require
-depend fmri=database/sqlite-3@3.19,5.11-@PVER@ type=require
+depend fmri=database/sqlite-3@3.20,5.11-@PVER@ type=require
 depend fmri=developer/debug/mdb@0.5.11,5.11-@PVER@ type=require
 depend fmri=developer/linker@0.5.11,5.11-@PVER@ type=require
 depend fmri=diagnostic/cpu-counters@0.5.11,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -10,7 +10,7 @@ depend fmri=compress/unzip@6.0,5.11-@PVER@ type=incorporate
 depend fmri=compress/xz@5.2,5.11-@PVER@ type=incorporate
 depend fmri=compress/zip@3.0,5.11-@PVER@ type=incorporate
 depend fmri=data/iso-codes@3.75,5.11-@PVER@ type=incorporate
-depend fmri=database/sqlite-3@3.19,5.11-@PVER@ type=incorporate
+depend fmri=database/sqlite-3@3.20,5.11-@PVER@ type=incorporate
 depend fmri=developer/as@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=developer/build/autoconf@2.69,5.11-@PVER@ type=incorporate
 depend fmri=developer/build/automake@1.15,5.11-@PVER@ type=incorporate

--- a/build/sqlite3/build.sh
+++ b/build/sqlite3/build.sh
@@ -28,8 +28,8 @@
 . ../../lib/functions.sh
 
 PROG=sqlite-autoconf
-VER=3190300
-VERHUMAN=3.19.3
+VER=3200000
+VERHUMAN=3.20.0
 PKG=database/sqlite-3
 SUMMARY="SQL database engine library"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -9,7 +9,7 @@
 | compress/xz				| 5.2.3			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| http://www.info-zip.org/Zip.html
 | data/iso-codes			| 3.75			| http://pkg-isocodes.alioth.debian.org/downloads/
-| database/sqlite-3			| 3.19.3		| https://www.sqlite.org/
+| database/sqlite-3			| 3.20.0		| https://www.sqlite.org/
 | developer/bmake			| 20160926		| http://www.crufty.net/ftp/pub/sjg/
 | developer/build/autoconf		| 2.69			| https://savannah.gnu.org/news/?group=autocon 
 | developer/build/automake		| 1.15.1		| https://savannah.gnu.org/news/?group=automake


### PR DESCRIPTION
Maintenance update to sqlite3

```
bloody% sqlite3
SQLite version 3.20.0 2017-08-01 13:24:15
Enter ".help" for usage hints.
Connected to a transient in-memory database.
```