### PR TITLE
expat: update to 2.2.3

### DIFF
--- a/build/expat/build.sh
+++ b/build/expat/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=expat
-VER=2.2.2
+VER=2.2.3
 PKG=library/expat
 SUMMARY="libexpat - XML parser library"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -27,7 +27,7 @@
 | file/gnu-coreutils			| 8.27			| https://savannah.gnu.org/news/?group=coreutils
 | file/gnu-findutils			| 4.6.0			| https://ftp.gnu.org/pub/gnu/findutils/
 | library/c++/sigcpp			| 2.99.8		| https://download.gnome.org/sources/libsigc++/
-| library/expat				| 2.2.2			| https://libexpat.github.io/
+| library/expat				| 2.2.3			| https://libexpat.github.io/
 | library/gmp				| 6.1.2			| https://gmplib.org/
 | library/idnkit			| 1.0			| https://jprs.co.jp/idn/index-e.html
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/


### PR DESCRIPTION
Although the Expat release notes indicate that this is a security release, the security issue is windows specific. No backport to do for this update.