### PR TITLE
git: update to 2.14.1

### DIFF
--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -29,7 +29,7 @@
 . ../../lib/functions.sh
 
 PROG=git
-VER=2.13.5
+VER=2.14.1
 PKG=developer/versioning/git
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"

--- a/build/git/testsuite.log
+++ b/build/git/testsuite.log
@@ -139,4 +139,4 @@ ok 42 - re-init from a linked worktree
 1..42
 gmake[2]: *** [Makefile:49: t0001-init.sh] Error 1
 gmake[1]: *** [Makefile:36: test] Error 2
-gmake: *** [Makefile:2322: test] Error 2
+gmake: *** [Makefile:2415: test] Error 2

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -33,7 +33,7 @@ depend fmri=developer/parser/bison@3.0,5.11-@PVER@ type=incorporate
 depend fmri=developer/sunstudio12.1@12.1,5.11-@PVER@ type=incorporate
 depend fmri=developer/swig@2.0.12,5.11-@PVER@ type=incorporate
 depend fmri=developer/versioning/sccs@0.5.11,5.11-@PVER@ type=incorporate
-depend fmri=developer/versioning/git@2.13,5.11-@PVER@ type=incorporate
+depend fmri=developer/versioning/git@2.14,5.11-@PVER@ type=incorporate
 depend fmri=developer/versioning/mercurial@4,5.11-@PVER@ type=incorporate
 depend fmri=driver/virtualization/kvm@1.0,5.11-@PVER@ type=incorporate
 depend fmri=driver/tuntap@1.3,5.11-@PVER@ type=incorporate

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -20,7 +20,7 @@
 | developer/macro/gnu-m4		| 1.4.18		| http://savannah.gnu.org/news/?group=m4
 | developer/parser/bison		| 3.0.4			| https://savannah.gnu.org/news/?group=bison
 | developer/pkg-config			| 0.29.2		| https://www.freedesktop.org/wiki/Software/pkg-config/
-| developer/versioning/git		| 2.13.5		| https://git-scm.com/downloads
+| developer/versioning/git		| 2.14.1		| https://git-scm.com/downloads
 | developer/versioning/mercurial	| 4.2.3			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap
 | editor/vim				| 8.0.586		| http://www.vim.org/download.php


### PR DESCRIPTION

```
bloody# git --version
git version 2.14.1
bloody# git clone https://github.com/omniosorg/omnios-build /tmp/l
Cloning into '/tmp/l'...
remote: Counting objects: 13404, done.
remote: Compressing objects: 100% (41/41), done.
remote: Total 13404 (delta 21), reused 31 (delta 8), pack-reused 13351
Receiving objects: 100% (13404/13404), 45.07 MiB | 275.00 KiB/s, done.
Resolving deltas: 100% (7299/7299), done.
```