### PR TITLE
curl: update to 7.55.1

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=curl       # App name
-VER=7.54.1      # App version
+VER=7.55.1      # App version
 PKG=web/curl    # Package name (without prefix)
 SUMMARY="$PROG - command line tool for transferring data with URL syntax"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -69,7 +69,7 @@
 | text/gnu-sed				| 4.4			| http://savannah.gnu.org/news/?group=sed
 | text/groff				| 1.22.3		| https://ftp.gnu.org/gnu/groff/
 | text/less				| 487			| https://ftp.gnu.org/gnu/less/
-| web/curl				| 7.54.1		| https://curl.haxx.se/download.html
+| web/curl				| 7.55.1		| https://curl.haxx.se/download.html
 | web/wget				| 1.19.1		| https://savannah.gnu.org/news/?group=wget
 | library/glib2				| 2.34.3		| https://www.gtk.org/download/linux.php | 2.50 had possible problem
 | developer/gnu-binutils		| 2.25			| https://www.gnu.org/software/binutils/ | On hold pending illumos fix https://www.illumos.org/issues/6653


### PR DESCRIPTION
```
bloody# curl -V
curl 7.55.1 (i386-pc-solaris2.11) libcurl/7.55.1 OpenSSL/1.0.2l zlib/1.2.11 nghttp2/1.24.0
Release-Date: 2017-08-14
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy
```