### PR TITLE
libxml2: fix build with newer automake

### DIFF
--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -101,6 +101,14 @@ init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
+
+# The patch for CVE-2017-9049 & CVE-2017-9050 modifies Makefile.am
+# so it is necessary to re-run automake. Since automake in bloody is newer
+# than that originally used for packaging libxml2, aclocal is also required.
+# Once libxml2 is updated and the patch is no longer necessary, the following
+# line can be removed.
+run_aclocal; run_automake
+
 build
 make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
 fix_python_install

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -383,23 +383,25 @@ verify_depends() {
 }
 
 #############################################################################
-# People that need this should call it explicitly
+# People that need these should call them explicitly
 #############################################################################
-run_autoconf() {
-    logmsg "Running autoconf"
+run_inbuild() {
+    logmsg "Running $*"
     pushd $TMPDIR/$BUILDDIR > /dev/null
-    logcmd autoconf || logerr "Failed to run autoconf"
+    logcmd "$@" || logerr "Failed to run $*"
     popd > /dev/null
 }
 
-#############################################################################
-# People that need this should call it explicitly
-#############################################################################
+run_autoconf() {
+    run_inbuild autoconf
+}
+
 run_automake() {
-    logmsg "Running automake"
-    pushd $TMPDIR/$BUILDDIR > /dev/null
-    logcmd automake || logerr "Failed to run automake"
-    popd > /dev/null
+    run_inbuild automake
+}
+
+run_aclocal() {
+    run_inbuild aclocal
 }
 
 #############################################################################


### PR DESCRIPTION
Building libxml2 on bloody now fails because it was originally packaged with automake 1.15 and bloody has 1.15.1. The patch for CVEs VE-2017-9049 & CVE-2017-9050 updates Makefile.pm which causes automake to be run as part of the build and this fails due to the automake version mismatch.

This PR fixes that along with an explanatory comment.