### PR TITLE
sqlite3: update to 3.20.1

### DIFF
--- a/build/sqlite3/build.sh
+++ b/build/sqlite3/build.sh
@@ -28,8 +28,8 @@
 . ../../lib/functions.sh
 
 PROG=sqlite-autoconf
-VER=3200000
-VERHUMAN=3.20.0
+VER=3200100
+VERHUMAN=3.20.1
 PKG=database/sqlite-3
 SUMMARY="SQL database engine library"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -9,7 +9,7 @@
 | compress/xz				| 5.2.3			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| http://www.info-zip.org/Zip.html
 | data/iso-codes			| 3.75			| http://pkg-isocodes.alioth.debian.org/downloads/
-| database/sqlite-3			| 3.20.0		| https://www.sqlite.org/
+| database/sqlite-3			| 3.20.1		| https://www.sqlite.org/
 | developer/bmake			| 20160926		| http://www.crufty.net/ftp/pub/sjg/
 | developer/build/autoconf		| 2.69			| https://savannah.gnu.org/news/?group=autoconf
 | developer/build/automake		| 1.15.1		| https://savannah.gnu.org/news/?group=automake


### PR DESCRIPTION
```
% ./sqlite3
SQLite version 3.20.1 2017-08-24 16:21:36
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite>
```

Performed basic testing against a database created with 3.20.0