### PR TITLE
cdrecord: use package-specific security profile

### DIFF
--- a/build/cdrtools/build.sh
+++ b/build/cdrtools/build.sh
@@ -50,7 +50,7 @@ make_install() {
     mkdir -p $DESTDIR/etc/security/exec_attr.d
     mkdir -p $DESTDIR/usr/bin
     mkdir -p $DESTDIR/usr/share/man/man1
-    cp $SRCDIR/files/exec_attr $DESTDIR/etc/security/exec_attr.d
+    cp $SRCDIR/files/exec_attr $DESTDIR/etc/security/exec_attr.d/cdrecord
     cp $TMPDIR/$BUILDDIR/mkisofs/OBJ/i386-sunos5-gcc/mkisofs $DESTDIR/usr/bin/mkisofs
     mkdir -p $DESTDIR/usr/share/man/man8
     cp $TMPDIR/$BUILDDIR/mkisofs/mkisofs.8 $DESTDIR/usr/share/man/man8/mkisofs.8


### PR DESCRIPTION
cdrecord installs the security profiles that it needs as `DESTDIR/etc/security/exec_attr.d/exec_attr` instead of using a package-specific name like `cdrecord`
This doesn't currently conflict with anything else but the name should be changed to reflect the purpose of the profiles.