### PR TITLE
Always create local repo, even for plain manifest imports.

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -174,7 +174,8 @@ build() {
             . environment
         fi
         SCRIPT=$(basename ${targets[$1]})
-        if [[ -n $(echo $SCRIPT | grep ".p5m$") ]]; then
+        if [[ "$SCRIPT" = *.p5m ]]; then
+            init_repo
             echo "Found a manifest file. Preparing it for publishing."
             sed -e "s/@PKGPUBLISHER@/$PKGPUBLISHER/g; s/@RELVER@/$RELVER/g; s/@PVER@/$PVER/g;" < $SCRIPT > $SCRIPT.final
             if [[ -f root.tar.bz2 ]]; then
@@ -193,15 +194,6 @@ build() {
             # Else we just have a manifest to import
             else
                 echo "Simple manifest to import... importing to $PKGSRVR"
-		RPATH=`echo $PKGSRVR | sed -e 's/^file:\/*/\//'`
-		if [[ "$RPATH" != "$PKGSRVR" ]]; then
-		    if [[ ! -d $RPATH ]]; then
-			pkgrepo create -s $RPATH || \
-			    logerr "Could not create publisher $RPATH"
-			pkgrepo add-publisher -s $RPATH $PKGPUBLISHER || \
-			    logerr "Could not set publisher $PKGPUBLISHER on repo $RPATH"
-		    fi
-		fi
                 pkgsend -s $PKGSRVR publish $SCRIPT.final || \
                     bail "pkgsend failed"
                 rm $SCRIPT.final

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -315,6 +315,19 @@ libtool_nostdlib() {
 #############################################################################
 # Initialization function
 #############################################################################
+
+init_repo() {
+    if [[ "$PKGSRVR" == file:/* ]]; then
+        RPATH="`echo $PKGSRVR | sed 's^file:/*^/^'`"
+        if [ ! -d "$RPATH" ]; then
+            logmsg "-- Initialising local repo at $RPATH"
+            pkgrepo create $RPATH || logerr "Could not create local repo"
+            pkgrepo add-publisher -s $RPATH $PKGPUBLISHER || \
+                logerr "Could not set publisher on local repo"
+        fi
+    fi
+}
+
 init() {
     # Print out current settings
     logmsg "Package name: $PKG"
@@ -354,15 +367,7 @@ init() {
         BUILDDIR=$PROG-$VER
     fi
 
-    RPATH=`echo $PKGSRVR | sed -e 's/^file:\/*/\//'`
-    if [[ "$RPATH" != "$PKGSRVR" ]]; then
-        if [[ ! -d $RPATH ]]; then
-            pkgrepo create $RPATH || \
-                logerr "Could not local repo"
-            pkgrepo add-publisher -s $RPATH $PKGPUBLISHER || \
-                logerr "Could not set publisher on repo"
-        fi
-    fi
+    init_repo
     pkgrepo get -s $PKGSRVR > /dev/null 2>&1 || \
         logerr "The PKGSRVR ($PKGSRVR) isn't available. All is doomed."
     verify_depends


### PR DESCRIPTION
Always create local repo, even for plain manifest imports.
Centralise duplicated repository initialisation logic to new function.

Previously, building a package like `release/name` which contains a small amount of filesystem content from within the build directory would fail if the local staging repository was absent.

This corrects that by initialising the repository for all manifest packages. I also moved the initialisation logic into a new function in lib/functions.sh
