### PR TITLE
illumos-gate build updates

### DIFF
--- a/build/illumos/build.sh
+++ b/build/illumos/build.sh
@@ -25,11 +25,6 @@
 # Use is subject to license terms.
 #
 
-SHELL=/usr/bin/bash
-export SHELL
-
-RELEASE_DATE=nightly # This is overridden by the checkout
-
 # Load support functions
 . ../../lib/functions.sh
 
@@ -41,132 +36,11 @@ PKG=illumos-gate # Package name (without prefix)
 SUMMARY="$PROG" # A short summary of what the app is, starting with its name
 DESC="$SUMMARY -- Illumos and some special sauce." # Longer description
 
-#all of the ips depends should be available from OmniTI repos
 BUILD_DEPENDS_IPS="developer/illumos-tools"
-
-GIT=git
-
-USE_SYSTEM_SSL_HEADERS="TRUE"
 
 PKGPREFIX=""
 PREFIX=""
 BUILDDIR=$USER-$PROG-$VER
-
-#Since these variables are used in a sed statment make sure to escape properly
-ILLUMOS_NO="NIGHTLY\_OPTIONS=\'\-nDCmpr\'"
-ILLUMOS_CODEMGR_WS="CODEMGR\_WS=/code/$BUILDDIR/illumos\-omnios"
-ILLUMOS_CLONE_WS="CLONE\_WS=\'https:\/\/github.com\/omniosorg/illumos\-omnios'"
-
-ILLUMOS_PKG_REDIST="PKGPUBLISHER\_REDIST=\'omnios\'"
-
-#these variables are appended to the end of the script so no need to escape
-ILLUMOS_GNUC="export __GNUC=''"
-ILLUMOS_GNUC4="export __GNUC4=''"
-ILLUMOS_NO_SHADOW="export CW_NO_SHADOW=1"
-ILLUMOS_GCC_ROOT='export GCC_ROOT="/opt/gcc-4.4.4"'
-ILLUMOS_CW_GCC_DIR='export CW_GCC_DIR="$GCC_ROOT/bin"'
-ILLUMOS_BUILDNUM="ONNV_BUILDNUM=$VER; export ONNV_BUILDNUM;"
-ILLUMOS_MULTI_PROTO="export MULTI_PROTO=yes"
-
-sunstudio_location() {
-    logmsg "Ensuring that Sun Studio is where Illumos thinks it is..."
-    if [[ -L /opt/SUNWspro ]]; then
-	logmsg "--- fake SUNWspro link exists, good"
-    else
-	logmsg "--- making fake SUNWspro directory"
-	logcmd sudo ln -s /opt/sunstudio12.1 /opt/SUNWspro || \
-	    logerr "--- Error: failed to make link"
-    fi
-}
-
-#In order for the clone to work while running as root, you must have ssh'ed into the box with agent forwarding turned on.  Also the sudo'er file must either have the default, group, or user set to allow SSL_AUTH_SOCK.
-
-clone_source(){
-    logmsg "Creating build dir $TMPDIR/$BUILDDIR"
-    logcmd mkdir -p $TMPDIR/$BUILDDIR || \
-        logerr "--- Failed to create build dir $TMPDIR/$BUILDDIR"
-    logmsg "Entering $TMPDIR/$BUILDDIR"
-    pushd $TMPDIR/$BUILDDIR > /dev/null 
-    if [ -d illumos-omnios ]; then
-        logmsg "OMNI Illumos Source in place. Using existing workspace."
-    else
-        logmsg "Cloning OMNI Illumos Source..."
-        logcmd  $GIT clone https://github.com/omniosorg/illumos-omnios.git || \
-            logerr "--- Failed to clone source"
-    fi
-    pushd illumos-omnios 
-    OMNIOS_BRANCH=`$GIT branch | awk '{print $2}'`
-    OMNIOS_HEAD=`$GIT log --pretty=format:'%h' -n 1`
-    ILLUMOS_VERSION="VERSION='omnios-${OMNIOS_BRANCH}-${OMNIOS_HEAD}'" 
-    RELEASE_DATE=`$GIT show --format=format:%ai | awk '{print $1; exit;}' | tr - .` 
-    echo $ILLUMOS_VERSION
-    popd > /dev/null 
-    logmsg "Leaving $TMPDIR/$BUILDDIR"
-    popd > /dev/null 
-}
-
-build_tools(){
-    logmsg "Entering $CODEMGR_WS"
-    pushd $CODEMGR_WS > /dev/null
-    logmsg "Building extra tools needed for illumos pkgs..."
-    logcmd ln -s usr/src/tools/scripts/bldenv.sh .
-    logcmd ksh93 bldenv.sh -d illumos.sh -c "cd usr/src && dmake setup" 
-    logmsg "Leaving $CODEMGR_WS"
-    popd > /dev/null
-}
-
-modify_build_script() {
-    logmsg "Entering $CODEMGR_WS"
-    pushd $CODEMGR_WS > /dev/null
-    logmsg "Changing illumos.sh variables to what we want them to be..."
-    logcmd cp usr/src/tools/env/illumos.sh .    
-
-    logcmd /usr/bin/gsed -i -e 's|^.*export NIGHTLY_OPTIONS.*|export '$ILLUMOS_NO'|g' illumos.sh || logerr "/usr/bin/gsed failed nightly"
-    logcmd /usr/bin/gsed -i -e 's|^.*export CODEMGR_WS=.*|export '$ILLUMOS_CODEMGR_WS'|g' illumos.sh || logerr "/usr/bin/gsed failed codemgr"
-    logcmd /usr/bin/gsed -i -e 's|^.*export CLONE_WS=.*|export '$ILLUMOS_CLONE_WS'|g' illumos.sh || logerr "/usr/bin/gsed failed clone"
-    logcmd /usr/bin/gsed -i -e 's|^.*export PKGPUBLISHER_REDIST=.*|export '$ILLUMOS_PKG_REDIST'|g' illumos.sh || logerr "/usr/bin/gsed failed publisher"
-    logcmd /usr/bin/gsed -i -e 's|^.*export VERSION=.*|export '$ILLUMOS_VERSION'|g' illumos.sh || logerr "/usr/bin/gsed failed version"
-    logcmd /usr/bin/gsed -i -e '/^.*GNUC=.*/d' illumos.sh || logerr "/usr/bin/gsed failed gnuc"
-    logcmd /usr/bin/gsed -i -e '/^.*CW_NO_SHADOW=.*/d' illumos.sh || logerr "/usr/bin/gsed failed cwnoshadow"
-    logcmd /usr/bin/gsed -i -e '/^.*ONNV_BUILDNUM=.*/d' illumos.sh || logerr "/usr/bin/gsed failed buildnum"
-
-    logcmd `echo $ILLUMOS_GNUC >> illumos.sh` 
-    logcmd `echo $ILLUMOS_GNUC4 >> illumos.sh` 
-    logcmd `echo $ILLUMOS_GCC_ROOT >> illumos.sh` 
-    logcmd `echo $ILLUMOS_CW_GCC_DIR >> illumos.sh`
-    logcmd `echo $ILLUMOS_NO_SHADOW >> illumos.sh`
-    logcmd `echo $ILLUMOS_BUILDNUM >> illumos.sh`
-    logcmd `echo $ILLUMOS_MULTI_PROTO >> illumos.sh`
-    logcmd `echo RELEASE_DATE=$RELEASE_DATE >> illumos.sh`
-    logmsg "Leaving $CODEMGR_WS"
-    popd > /dev/null
-
-}
-
-closed_bins() {
-    logmsg "Entering $CODEMGR_WS"
-    pushd $CODEMGR_WS > /dev/null
-    logmsg "Getting Closed Source Bins..."
-    for bin in on-closed-bins.i386.tar.bz2 on-closed-bins-nd.i386.tar.bz2 ; do
-	if [[ ! -f $bin ]]; then
-            logcmd curl -s -O $MIRROR/illumos-gate/$bin
-	fi
-    	logcmd tar xvpf $bin
-    done
-    logmsg "Leaving $CODEMGR_WS"
-    popd > /dev/null 
-}
-
-build_pkgs() {
-    logmsg "Entering $CODEMGR_WS"
-    pushd $CODEMGR_WS > /dev/null
-    logmsg "Building illumos pkgs..."
-    logcmd cp usr/src/tools/scripts/nightly.sh .
-    logcmd chmod +x nightly.sh
-    logcmd ./nightly.sh illumos.sh || logerr "Nightly failed"
-    logmsg "Leaving $CODEMGR_WS"
-    popd > /dev/null
-}
 
 push_pkgs() {
     logmsg "Entering $CODEMGR_WS"
@@ -198,7 +72,8 @@ push_pkgs() {
     logmsg "Staging illumos packages to $STAGE_REPO"
     logcmd pkgmerge -d $STAGE_REPO \
 	-s debug.illumos=false,packages/i386/nightly-nd/repo.redist/ \
-	-s debug.illumos=true,packages/i386/nightly/repo.redist/
+	-s debug.illumos=true,packages/i386/nightly/repo.redist/ \
+	$FLAVOR
 
     logmsg "Staging repository information"
     pkgrepo -s $STAGE_REPO info
@@ -226,14 +101,6 @@ if [ -d ${PREBUILT_ILLUMOS:-/dev/null} ]; then
         fi
     fi
 else
-    TMPDIR=/code	# This directory must be writable as your non-root user
-    CODEMGR_WS=$TMPDIR/$BUILDDIR/illumos-omnios
-    sunstudio_location
-    clone_source
-    modify_build_script
-    closed_bins
-    build_tools
-    build_pkgs
-    push_pkgs
+    logerr "No prebuilt-illumos defined, check site.sh"
 fi
 clean_up


### PR DESCRIPTION
The illumos-gate supports either pulling packages from a pre-built illumos environment (via PREBUILT_ILLUMOS), or checking out and performing a full illumos build automatically.

The second option does not currently work and predates the addition of support for PREBUILT_ILLUMOS which is now being used for builds.

This PR removes the legacy 'fetch-and-build' code.

There's one other change in here - it's possible to pick a single package for publication via the `-f` flag.

```
bloody:omnios-build:master% ./build.sh -f runtime/perl/module/sun-solaris
===== Build started at Tue Aug 29 20:54:23 GMT 2017 =====
Package name: illumos-gate
Selected Flavor: runtime/perl/module/sun-solaris
Selected build arch: both
Extra dependency: None (use -d to specify a version)
Verifying dependencies
Preparing for build
--- Creating temporary install dir
/data/omnios-build/omniosorg/omnios.bloody already built (no nightly.lock present...)
Using illumos-omnios pre-compiled at /data/omnios-build/omniosorg/omnios.bloody
Entering /data/omnios-build/omniosorg/omnios.bloody
Pushing illumos pkgs to file:///data/omnios-build/omniosorg/_repo...
Intentional pause: Last chance to sanity-check before publication!
Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
Creating staging repo at /data/omnios-build/omniosorg/_build/af-omnios-151023
Staging illumos packages to /data/omnios-build/omniosorg/_build/af-omnios-151023
Staging repository information
PUBLISHER  PACKAGES STATUS           UPDATED
on-nightly 1        online           2017-08-29T20:54:27.820466Z
omnios     0        online           2017-08-29T20:54:26.984769Z
Republishing packages from /data/omnios-build/omniosorg/_build/af-omnios-151023
    Receiving pkg://on-nightly/runtime/perl/module/sun-solaris@0.5.11-0.151023:20170829T203808Z
    Processing /data/omnios-build/omniosorg/_build/af-omnios-151023/incoming/runtime%2Fperl%2Fmodule%2Fsun-solaris/0.5.11%2C5.11-0.151023%3A20170829T203808Z
Leaving /data/omnios-build/omniosorg/omnios.bloody
Cleaning up
--- Removing temporary install directory /data/omnios-build/omniosorg/_build/illumos-gate_pkg
--- Cleaning up temporary manifest and transform files
Done.
```