### PR TITLE
gcc5: fix libgmp dependency

### DIFF
--- a/build/gcc5/build.sh
+++ b/build/gcc5/build.sh
@@ -79,6 +79,6 @@ download_source $PROG/releases/$PROG-$VER $PROG $VER
 patch_source
 prep_build
 build
-make_package gcc.mog
+make_package gcc.mog gcc-final.mog
 clean_up
 

--- a/build/gcc5/gcc-final.mog
+++ b/build/gcc5/gcc-final.mog
@@ -1,0 +1,8 @@
+
+# Automatic dependency resolution adds a 'require-any' for the two
+# libgmp packages. Remove that and add an explicit dependency on the
+# gcc5 private version.
+
+<transform depend type=require-any -> drop>
+depend fmri=pkg:/developer/gcc5/libgmp-gcc5 type=require
+


### PR DESCRIPTION
When building the `gcc5` package, automatic dependency resolution adds a require-any dependency for either the system libgmp or the internal gcc5 private version. This PR removes that and adds an explicit dependency for the private version.

### Before:
```
bloody:omnios-build:master% pkg contents -t depend -o fmri,type gcc5 | grep gmp
['pkg:/developer/gcc5/libgmp-gcc5@6.1.2-0.151023', 'pkg:/library/gmp@6.1.2-0.151023'] require-any
```
### After
```
bloody:omnios-build:master% pkg contents -g ../_repo -t depend -o fmri,type gcc5 | grep gmp
pkg:/developer/gcc5/libgmp-gcc5                  require
```