### PR TITLE
Update copyrights for OmniOSce

### DIFF
--- a/build/python27/asn1crypto/build.sh
+++ b/build/python27/asn1crypto/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/cffi/build.sh
+++ b/build/python27/cffi/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/cheroot/build.sh
+++ b/build/python27/cheroot/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/coverage/build.sh
+++ b/build/python27/coverage/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/cryptography/build.sh
+++ b/build/python27/cryptography/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/enum/build.sh
+++ b/build/python27/enum/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/functools32/build.sh
+++ b/build/python27/functools32/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/idna/build.sh
+++ b/build/python27/idna/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/ipaddress/build.sh
+++ b/build/python27/ipaddress/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/jsonrpclib/build.sh
+++ b/build/python27/jsonrpclib/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/jsonschema/build.sh
+++ b/build/python27/jsonschema/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/lxml/build.sh
+++ b/build/python27/lxml/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/m2crypto/build.sh
+++ b/build/python27/m2crypto/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/mako/build.sh
+++ b/build/python27/mako/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/numpy/build.sh
+++ b/build/python27/numpy/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/ply/build.sh
+++ b/build/python27/ply/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/portend/build.sh
+++ b/build/python27/portend/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pybonjour/build.sh
+++ b/build/python27/pybonjour/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pycurl/build.sh
+++ b/build/python27/pycurl/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pylint/build.sh
+++ b/build/python27/pylint/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pyopenssl/build.sh
+++ b/build/python27/pyopenssl/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pyrex/build.sh
+++ b/build/python27/pyrex/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/pytz/build.sh
+++ b/build/python27/pytz/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/setuptools/build.sh
+++ b/build/python27/setuptools/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/simplejson/build.sh
+++ b/build/python27/simplejson/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/six/build.sh
+++ b/build/python27/six/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/tempora/build.sh
+++ b/build/python27/tempora/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions

--- a/build/python27/typing/build.sh
+++ b/build/python27/typing/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions


### PR DESCRIPTION
Fix copyright messages following the recent mass python update. New modules should have OmniOSce only, updated modules should have OmniOSce added.