### PR TITLE
Enable __cxa_atexit in C++ build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 built.cache
 build.log
-build.log.1
+build.log.*
 tmp.repo/
 *.p5m.final

--- a/build/gcc5/build-libgcc_s.sh
+++ b/build/gcc5/build-libgcc_s.sh
@@ -36,6 +36,8 @@ PKG=system/library/gcc-5-runtime
 SUMMARY="gcc $VER runtime"
 DESC="$SUMMARY"
 
+LOGFILE+=".$PROG"
+
 PATH=$OPT/bin:$PATH
 export LD_LIBRARY_PATH=$OPT/lib
 

--- a/build/gcc5/build-libgmp.sh
+++ b/build/gcc5/build-libgmp.sh
@@ -39,6 +39,8 @@ PKG=developer/gcc5/libgmp-gcc5
 SUMMARY="$PKGV - private libgmp"
 DESC="$SUMMARY" # Longer description
 
+LOGFILE+=".$PROG"
+
 # This stuff is in its own domain
 PKGPREFIX=""
 

--- a/build/gcc5/build-libmpc.sh
+++ b/build/gcc5/build-libmpc.sh
@@ -36,6 +36,8 @@ PKG=developer/gcc5/libmpc-gcc5
 SUMMARY="$PKGV - private libmpc"
 DESC="$SUMMARY"
 
+LOGFILE+=".$PROG"
+
 DEPENDS_IPS="developer/$PKGV/libgmp-$PKGV developer/$PKGV/libmpfr-$PKGV"
 
 # This stuff is in its own domain

--- a/build/gcc5/build-libmpfr.sh
+++ b/build/gcc5/build-libmpfr.sh
@@ -37,6 +37,8 @@ SUMMARY="$PKGV - private libmpfr"
 DESC="$SUMMARY"
 DEPENDS_IPS="developer/$PKGV/libgmp-$PKGV"
 
+LOGFILE+=".$PROG"
+
 # This stuff is in its own domain
 PKGPREFIX=""
 

--- a/build/gcc5/build-libstdc++.sh
+++ b/build/gcc5/build-libstdc++.sh
@@ -36,6 +36,8 @@ PKG=system/library/g++-5-runtime
 SUMMARY="g++ runtime dependencies libstc++/libssp"
 DESC="$SUMMARY"
 
+LOGFILE+=".$PROG"
+
 PATH=$OPT/bin:$PATH
 export LD_LIBRARY_PATH=$OPT/lib
 

--- a/build/gcc5/build.sh
+++ b/build/gcc5/build.sh
@@ -68,6 +68,7 @@ CONFIGURE_OPTS="\
 	--with-mpfr=$OPT \
 	--with-mpc=$OPT \
 	--enable-languages=c,c++,fortran,lto \
+	--enable-__cxa_atexit \
 	--without-gnu-ld --with-ld=/bin/ld \
 	--with-as=/usr/bin/gas --with-gnu-as \
 	--with-build-time-tools=/usr/gnu/i386-pc-solaris2.11/bin"


### PR DESCRIPTION
illumos has had __cxa_atexit since 2013 (https://github.com/illumos/illumos-gate/commit/5c069a6c4b95a7360294695998bf1d3b12473abf) but the gcc configure only enables it by default on systems with SunOS 5.12+ in their uname.

Explicitly enable this at gcc build time to provide fully standards-compliant handling of static destructors in C++.

Also use a distinct build log file for each component of gcc to avoid clobbering.