### PR TITLE
remove superfluous cleanup

### DIFF
--- a/build/pkg/build.sh
+++ b/build/pkg/build.sh
@@ -112,18 +112,10 @@ package(){
     popd > /dev/null
 }
 
-cleanup(){
-    logmsg "--- cleaning up"
-    if [[ "$PKGSRVR" = file:* ]]; then
-        logcmd pkgrepo remove-publisher -s $PKGSRVR pkg5-localizable
-    fi
-}
-
 init
 clone_source
 build
 package
-cleanup
 
 # Vim hints
 # vim:ts=4:sw=4:et:


### PR DESCRIPTION
https://github.com/omniosorg/pkg5/commit/f799808053163175ee402f967616b4821bd18184 removed `pkg5-localizable` from being published to the repo; thus `remove-publisher` would fail.