### PR TITLE
No longer need to use old gcc4 standards level for some packages

### DIFF
--- a/build/pkg-config/build.sh
+++ b/build/pkg-config/build.sh
@@ -38,9 +38,6 @@ DESC="pkg-config is a helper tool used when compiling applications and libraries
 BUILD_DEPENDS_IPS=
 RUN_DEPENDS_IPS=
 
-# Use old gcc4 standards level for this.
-CFLAGS="$CFLAGS -std=gnu89"
-
 init
 download_source $PROG $PROG $VER
 prep_build

--- a/build/wget/build.sh
+++ b/build/wget/build.sh
@@ -43,9 +43,6 @@ CONFIGURE_OPTS="
 	POD2MAN=/usr/perl5/bin/pod2man
 "
 
-# Use old gcc4 standards level for this.
-CFLAGS="$CFLAGS -std=gnu89"
-
 BUILDARCH=32
 
 make_sfw_links() {


### PR DESCRIPTION
Due to updates of underlying software, we no longer need to build `wget` and `pkg-config` using old gcc4 standards.