### PR TITLE
drop minor version on libxslt requirement

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -138,7 +138,7 @@ depend fmri=library/libidn@1.33,5.11-@PVER@ type=require
 depend fmri=library/libtecla@1.6.0,5.11-@PVER@ type=require
 depend fmri=library/libtool/libltdl@2.4,5.11-@PVER@ type=require
 depend fmri=library/libxml2@2.9,5.11-@PVER@ type=require
-depend fmri=library/libxslt@1.1.29,5.11-@PVER@ type=require
+depend fmri=library/libxslt@1.1,5.11-@PVER@ type=require
 depend fmri=library/ncurses@6,5.11-@PVER@ type=require
 depend fmri=library/nghttp2@1.24,5.11-@PVER@ type=require
 depend fmri=library/nspr@4.16,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -49,7 +49,7 @@ library/libffi				3.2
 library/libidn				1.33
 library/libtool/libltdl			2.4
 library/libxml2				2.9
-library/libxslt				1.1.29
+library/libxslt				1.1
 library/ncurses				6
 library/nghttp2				1.25
 library/nspr/header-nspr		4.16


### PR DESCRIPTION
libxslt has been updated to 1.1.30 so can no longer be installed due to the consolidation.
Rather than just increasing the version by one, drop the minor part of the revision entirely
(It's the main release, e.g. .151023, that we really want to constrain on)