### PR TITLE
python: update to 2.7.14

### DIFF
--- a/build/python27/build.sh
+++ b/build/python27/build.sh
@@ -31,7 +31,7 @@ CC=gcc
 CXX=g++
 
 PROG=Python
-VER=2.7.13
+VER=2.7.14
 PKG=runtime/python-27
 SUMMARY="$PROG"
 DESC="$SUMMARY"


### PR DESCRIPTION
`pkg(5)` test suite ran with no changes against r151022 baseline.

`Total tests:1045 Tests run:1045 Errors:64 Failures:11 Skips:2`