### PR TITLE
libxslt: fix build and remove HTML docs

### DIFF
--- a/build/libxslt/local.mog
+++ b/build/libxslt/local.mog
@@ -23,6 +23,7 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-<transform dir  path=usr/include/amd64.* -> drop>
-<transform file path=usr/include/amd64.* -> drop>
 license COPYING license=MIT
+<transform file dir path=usr/include/amd64 -> drop>
+<transform file dir path=usr/share/doc -> drop>
+


### PR DESCRIPTION
libxslt 1.1.30 was not properly finding the libxml2 config script in `/usr/bin/xml2-config` resulting in a broken `xslt-config` script. This is fixed through adding `--with-libxml-prefix=/usr` to the configure options.

I've also added a test to catch this if it happens in future and removed the deprecated --with-threads option which is no longer supported.

There was also a problem in that it wasn't possible to build libxslt without cleaning out the build environment, see new comment in build.sh. That is fixed by setting a flag to always clean out the build directory.

Lastly, I've removed the HTML documentation that is installed under /usr/share/doc - this is something that is done for most other packages.