### PR TITLE
python and modules update

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -57,7 +57,7 @@ library/nspr				4.16
 library/pcre				8.41
 library/perl-5/xml-parser		2.44
 library/python-2/asn1crypto-27		0.22
-library/python-2/cffi-27		1.10
+library/python-2/cffi-27		1.11
 library/python-2/cheroot-27		5.8
 library/python-2/cherrypy-27		11
 library/python-2/coverage-27		4.4

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -67,7 +67,7 @@ library/python-2/functools32-27		3.2
 library/python-2/idna-27		2.6
 library/python-2/ipaddress-27		1.0
 library/python-2/jsonschema-27		2.6
-library/python-2/lxml-27		3.8
+library/python-2/lxml-27		4.0
 library/python-2/m2crypto-27		0.26
 library/python-2/mako-27		1.0
 library/python-2/numpy-27		1.13

--- a/build/python27/build.sh
+++ b/build/python27/build.sh
@@ -31,7 +31,7 @@ CC=gcc
 CXX=g++
 
 PROG=Python
-VER=2.7.13
+VER=2.7.14
 PKG=runtime/python-27
 SUMMARY="$PROG"
 DESC="$SUMMARY"

--- a/build/python27/cffi/build.sh
+++ b/build/python27/cffi/build.sh
@@ -30,7 +30,7 @@
 
 PKG=library/python-2/cffi-27
 PROG=cffi
-VER=1.10.0
+VER=1.11.0
 SUMMARY="cffi - Foreign Function Interface for Python calling C code"
 DESC="$SUMMARY"
 

--- a/build/python27/lxml/build.sh
+++ b/build/python27/lxml/build.sh
@@ -30,7 +30,7 @@
 
 PKG=library/python-2/lxml-27
 PROG=lxml
-VER=3.8.0
+VER=4.0.0
 SUMMARY="lxml - Powerful and Pythonic XML processing library"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -51,7 +51,7 @@
 | network/test/iperf			| 3.1.3			| https://iperf.fr/iperf-download.php#source
 | network/test/netperf			| 2.7.0			| https://github.com/HewlettPackard/netperf/releases
 | runtime/perl				| 5.24.2		| http://www.cpan.org/src/README.html
-| runtime/python-27			| 2.7.13		| https://www.python.org/downloads/source/
+| runtime/python-27			| 2.7.14		| https://www.python.org/downloads/source/
 | security/sudo				| 1.8.21p2		| https://www.sudo.ws/
 | service/network/ntp			| 4.2.8p10		| http://www.ntp.org/downloads.html
 | service/network/ssh			| 7.5p1			| https://mirrors.evowise.com/pub/OpenBSD/OpenSSH/portable/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -97,7 +97,7 @@
 | library/python-2/ipaddress-27		| 1.0.18		| https://pypi.python.org/pypi/ipaddress
 | library/python-2/jsonrpclib-27	| 0.1.7			| https://pypi.python.org/pypi/jsonrpclib
 | library/python-2/jsonschema-27	| 2.6.0			| https://pypi.python.org/pypi/jsonschema
-| library/python-2/lxml-27		| 3.8.0			| https://pypi.python.org/pypi/lxml/
+| library/python-2/lxml-27		| 4.0.0			| https://pypi.python.org/pypi/lxml/
 | library/python-2/m2crypto-27		| 0.26.0		| https://pypi.python.org/pypi/M2Crypto
 | library/python-2/mako-27		| 1.0.7			| https://pypi.python.org/pypi/Mako
 | library/python-2/numpy-27		| 1.13.1		| https://pypi.python.org/pypi/numpy

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -86,7 +86,7 @@
 | developer/swig			| 2.0.12		| http://www.swig.org/download.html | Stuck on 2.0.12 (3.0.x breaks M2Crypto, among other things)
 | library/security/trousers		| 0.3.8			| https://sourceforge.net/projects/trousers/files/trousers | Stuck on 0.3.8 (no idea wht)
 | library/python-2/asn1crypto-27	| 0.22.0		| https://pypi.python.org/pypi/asn1crypto
-| library/python-2/cffi-27		| 1.10.0		| https://pypi.python.org/pypi/cffi
+| library/python-2/cffi-27		| 1.11.0		| https://pypi.python.org/pypi/cffi
 | library/python-2/cheroot-27		| 5.8.3			| https://pypi.python.org/pypi/cheroot
 | library/python-2/cherrypy-27		| 11.0.0		| https://pypi.python.org/pypi/cherrypy
 | library/python-2/coverage-27		| 4.4.1			| https://pypi.python.org/pypi/coverage


### PR DESCRIPTION
`pkg(5)` test suite ran with no changes against bloody baseline for all components shipped in OmniOS.

see also: https://github.com/omniosorg/omnios-build/pull/212