### PR TITLE
six: update to version 1.11.0

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -81,7 +81,7 @@ library/python-2/pyrex-27		0.9.9
 library/python-2/pytz-27		2017
 library/python-2/setuptools-27		36
 library/python-2/simplejson-27		3.11
-library/python-2/six-27			1.10
+library/python-2/six-27			1.11
 library/python-2/tempora-27		1.9
 library/python-2/typing-27		3.6
 library/readline			7.0

--- a/build/python27/six/build.sh
+++ b/build/python27/six/build.sh
@@ -29,7 +29,7 @@
 
 PKG=library/python-2/six-27
 PROG=six
-VER=1.10.0
+VER=1.11.0
 SUMMARY="six - a Python 2 and 3 compatibility library"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -111,7 +111,7 @@
 | library/python-2/pytz-27		| 2017.2		| https://pypi.python.org/pypi/pytz
 | library/python-2/setuptools-27	| 36.5.0		| https://pypi.python.org/pypi/setuptools
 | library/python-2/simplejson-27	| 3.11.1		| https://pypi.python.org/pypi/simplejson
-| library/python-2/six-27		| 1.10.0		| https://pypi.python.org/pypi/six
+| library/python-2/six-27		| 1.11.0		| https://pypi.python.org/pypi/six
 | library/python-2/tempora-27		| 1.9			| https://pypi.python.org/pypi/tempora
 | library/python-2/typing-27		| 3.6.2			| https://pypi.python.org/pypi/typing
 


### PR DESCRIPTION
`pkg(5)` test suite ran with no changes against bloody baseline for all components shipped in OmniOS.