### PR TITLE
swig: update to version 3.0.12

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -30,7 +30,7 @@ developer/macro/cpp			0.5.11
 developer/macro/gnu-m4			1.4.18
 developer/parser/bison			3.0
 developer/sunstudio12.1			12.1
-developer/swig				2.0.12
+developer/swig				3.0
 developer/versioning/git		2.14
 developer/versioning/mercurial		4
 developer/versioning/sccs		0.5.11

--- a/build/swig/build.sh
+++ b/build/swig/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=swig
-VER=2.0.12
+VER=3.0.12
 PKG=developer/swig
 SUMMARY="The Simplified Wrapper and Interface Generator (swig)"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -83,7 +83,7 @@
 | developer/gnu-binutils		| 2.25			| https://ftp.gnu.org/gnu/binutils | On hold pending illumos fix https://www.illumos.org/issues/6653
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
 | system/virtualization/open-vm-tools	| 9.4.0			| https://sourceforge.net/projects/open-vm-tools/files/open-vm-tools/stable-9.4.x/ | Stuck on 9.4.0
-| developer/swig			| 2.0.12		| http://www.swig.org/download.html | Stuck on 2.0.12 (3.0.x breaks M2Crypto, among other things)
+| developer/swig			| 3.0.12		| http://www.swig.org/download.html
 | library/security/trousers		| 0.3.14		| https://sourceforge.net/projects/trousers/files/trousers
 | library/python-2/asn1crypto-27	| 0.22.0		| https://pypi.python.org/pypi/asn1crypto
 | library/python-2/cffi-27		| 1.11.0		| https://pypi.python.org/pypi/cffi


### PR DESCRIPTION
- `m2crypto` and `numpy` built successfully
- `pkg(5)` test suite ran with no changes against bloody baseline for all components shipped in OmniOS.