### PR TITLE
tmux/libevent - update to 2.1.8

### DIFF
--- a/build/tmux/build.sh
+++ b/build/tmux/build.sh
@@ -33,7 +33,7 @@ VERHUMAN=$VER
 PKG=terminal/tmux
 SUMMARY="terminal multiplexer"
 DESC="$SUMMARY"
-LIBEVENT_VER=2.0.22
+LIBEVENT_VER=2.1.8
 LDIR=libevent-${LIBEVENT_VER}-stable
 
 BUILDARCH=32
@@ -50,10 +50,15 @@ configure32(){
   logcmd ./configure --disable-static --disable-libevent-install || \
     logerr "failed libevent configure"
   logmsg "building a static libevent"
-  # Ewww, we have to patch libevent as well. Change PATCHDIR for now...
+
+  # We have to patch libevent as well. Change PATCHDIR for now...
+  oBUILDDIR=$BUILDDIR
+  BUILDDIR+="/$LDIR"
   PATCHDIR=patches-libevent
   patch_source
   PATCHDIR=patches
+  BUILDDIR=$oBUILDDIR
+
   logcmd make || logerr "failed libevent build"
   popd > /dev/null
   configure32_orig

--- a/build/tmux/patches-libevent/no-arc4random-addrandom.patch
+++ b/build/tmux/patches-libevent/no-arc4random-addrandom.patch
@@ -1,5 +1,5 @@
---- tmux-2.1/libevent-2.0.22-stable/evutil_rand.c.orig	Fri Apr 24 13:55:50 2015
-+++ tmux-2.1/libevent-2.0.22-stable/evutil_rand.c	Fri Apr 24 13:58:04 2015
+--- libevent/evutil_rand.c.orig	Fri Apr 24 13:55:50 2015
++++ libevent/evutil_rand.c	Fri Apr 24 13:58:04 2015
 @@ -153,7 +153,14 @@
  void
  evutil_secure_rng_add_bytes(const char *buf, size_t n)

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -29,7 +29,7 @@
 | file/gnu-coreutils			| 8.28			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags
 | file/gnu-findutils			| 4.6.0			| https://ftp.gnu.org/pub/gnu/findutils/
 | library/c++/sigcpp			| 2.99.9		| https://download.gnome.org/sources/libsigc++/cache.json
-| library/libevent			| 2.0.22		| https://github.com/libevent/libevent/releases | Used solely by tmux
+| library/libevent			| 2.1.8			| https://github.com/libevent/libevent/releases | Used solely by tmux
 | library/expat				| 2.2.4			| https://sourceforge.net/projects/expat/files/expat
 | library/gmp				| 6.1.2			| https://gmplib.org/
 | library/idnkit			| 1.0			| https://jprs.co.jp/idn/index-e.html


### PR DESCRIPTION
Straightforward upgrade but also changed build.sh so that the patch is not reliant on the path to libevent, easing future upgrades.