### PR TITLE
python27: Exclude compiled .pyc files from packages

### DIFF
--- a/build/python27/asn1crypto/build.sh
+++ b/build/python27/asn1crypto/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/build.sh
+++ b/build/python27/build.sh
@@ -157,5 +157,5 @@ run_testsuite
 make_isa_stub
 strip_install -x
 install_license
-make_package
+make_package local.mog final.mog
 clean_up

--- a/build/python27/cffi/build.sh
+++ b/build/python27/cffi/build.sh
@@ -42,5 +42,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/cheroot/build.sh
+++ b/build/python27/cheroot/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -48,5 +48,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/coverage/build.sh
+++ b/build/python27/coverage/build.sh
@@ -40,5 +40,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/cryptography/build.sh
+++ b/build/python27/cryptography/build.sh
@@ -49,5 +49,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/enum/build.sh
+++ b/build/python27/enum/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/final.mog
+++ b/build/python27/final.mog
@@ -1,0 +1,4 @@
+
+# Drop compiled python files
+<transform file path=.*\.pyc$ -> drop>
+

--- a/build/python27/functools32/build.sh
+++ b/build/python27/functools32/build.sh
@@ -44,5 +44,5 @@ prep_build
 #NOTE: Uncomment these IFF we have a version w/o -X on it...
 VER=${VER//-/.}
 python_build
-make_package
+make_package ../final.mog
 clean_up

--- a/build/python27/idna/build.sh
+++ b/build/python27/idna/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/ipaddress/build.sh
+++ b/build/python27/ipaddress/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/jsonrpclib/build.sh
+++ b/build/python27/jsonrpclib/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/jsonschema/build.sh
+++ b/build/python27/jsonschema/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/lxml/build.sh
+++ b/build/python27/lxml/build.sh
@@ -44,5 +44,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/m2crypto/build.sh
+++ b/build/python27/m2crypto/build.sh
@@ -45,5 +45,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/mako/build.sh
+++ b/build/python27/mako/build.sh
@@ -43,5 +43,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/numpy/build.sh
+++ b/build/python27/numpy/build.sh
@@ -55,5 +55,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/ply/build.sh
+++ b/build/python27/ply/build.sh
@@ -48,5 +48,5 @@ patch_source
 prep_build
 python_build
 make_license
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/portend/build.sh
+++ b/build/python27/portend/build.sh
@@ -40,5 +40,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package ../final.mog
 clean_up

--- a/build/python27/pybonjour/build.sh
+++ b/build/python27/pybonjour/build.sh
@@ -47,5 +47,5 @@ patch_source
 prep_build
 python_build
 make_license
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/pycurl/build.sh
+++ b/build/python27/pycurl/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/pylint/build.sh
+++ b/build/python27/pylint/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/pyopenssl/build.sh
+++ b/build/python27/pyopenssl/build.sh
@@ -43,5 +43,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/pyrex/build.sh
+++ b/build/python27/pyrex/build.sh
@@ -42,5 +42,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/pytz/build.sh
+++ b/build/python27/pytz/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/setuptools/build.sh
+++ b/build/python27/setuptools/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/simplejson/build.sh
+++ b/build/python27/simplejson/build.sh
@@ -41,5 +41,5 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 python_build
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/six/build.sh
+++ b/build/python27/six/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up

--- a/build/python27/tempora/build.sh
+++ b/build/python27/tempora/build.sh
@@ -43,5 +43,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package ../final.mog
 clean_up

--- a/build/python27/typing/build.sh
+++ b/build/python27/typing/build.sh
@@ -41,5 +41,5 @@ patch_source
 prep_build
 python_build
 strip_install -x
-make_package
+make_package local.mog ../final.mog
 clean_up


### PR DESCRIPTION
We should not ship .pyc files as part of our python packages. Amongst other things, this causes `pkg verify` failures such as:

```
% pkg verify python-27
PACKAGE                                                                 STATUS
pkg://omnios/runtime/python-27                                           ERROR
     file: usr/lib/python2.7/_sysconfigdata.pyc
        ERROR: Group: 'zabbix (98)' should be 'bin (2)'
        ERROR: Size: 24985 bytes should be 18868
        ERROR: Hash: 07440c16257d98edf555b9ac5f03ace922891871 should be c9872826aab44394ef0a220b55d8707df904f117
```

I've run a full `pkg(5)` regression test following this change and it matches our baseline.