### PR TITLE
glib: Link with -zignore

### DIFF
--- a/build/glib/build.sh
+++ b/build/glib/build.sh
@@ -41,6 +41,8 @@ DEPENDS_IPS="
 # Use old gcc4 standards level for this.
 CFLAGS+=" -std=gnu89"
 
+LDFLAGS+=" -Wl,-z,ignore"
+
 CONFIGURE_OPTS="
 	--disable-fam
 	--disable-dtrace

--- a/build/glib/local.mog
+++ b/build/glib/local.mog
@@ -39,4 +39,6 @@
 <transform dir path=usr/lib/gdbus-2.0$ -> drop>
 <transform dir path=usr/lib/glib-2.0$ -> drop>
 
+<transform dir file path=usr/share/gdb -> drop>
+
 license COPYING license=LGPLv2

--- a/build/glib/patches/series
+++ b/build/glib/patches/series
@@ -1,1 +1,3 @@
+threadlib.patch
+zignore.patch
 types.patch

--- a/build/glib/patches/threadlib.patch
+++ b/build/glib/patches/threadlib.patch
@@ -1,0 +1,24 @@
+diff -ru glib~/configure glib/configure
+--- glib~/configure	2017-09-11 00:18:49.000000000 +0000
++++ glib/configure	2017-09-20 09:09:36.556218408 +0000
+@@ -26928,7 +26928,7 @@
+       # Sun Studio expands -mt to -D_REENTRANT and -lthread
+       # gcc expands -pthreads to -D_REENTRANT -D_PTHREADS -lpthread
+       G_THREAD_CFLAGS="-D_REENTRANT -D_PTHREADS"
+-      G_THREAD_LIBS="-lpthread -lthread"
++      G_THREAD_LIBS=""
+       ;;
+     *)
+       for flag in pthread pthreads mt; do
+diff -ru glib~/configure.ac glib/configure.ac
+--- glib~/configure.ac	2017-09-11 00:17:54.000000000 +0000
++++ glib/configure.ac	2017-09-20 09:09:41.067395474 +0000
+@@ -1927,7 +1927,7 @@
+       # Sun Studio expands -mt to -D_REENTRANT and -lthread
+       # gcc expands -pthreads to -D_REENTRANT -D_PTHREADS -lpthread
+       G_THREAD_CFLAGS="-D_REENTRANT -D_PTHREADS"
+-      G_THREAD_LIBS="-lpthread -lthread"
++      G_THREAD_LIBS=""
+       ;;
+     *)
+       for flag in pthread pthreads mt; do

--- a/build/glib/patches/zignore.patch
+++ b/build/glib/patches/zignore.patch
@@ -1,0 +1,30 @@
+diff -ru glib-2.54.0~/configure glib-2.54.0/configure
+--- glib-2.54.0~/configure	2017-09-11 00:18:49.000000000 +0000
++++ glib-2.54.0/configure	2017-09-20 12:30:03.725642407 +0000
+@@ -14729,9 +14729,9 @@
+       no_undefined_flag=' -z defs'
+       if test yes = "$GCC"; then
+ 	wlarc='$wl'
+-	archive_cmds='$CC -shared $pic_flag $wl-z ${wl}text $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_cmds='$CC -shared $pic_flag $wl-z ${wl}text $wl-z ${wl}ignore $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	archive_expsym_cmds='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-          $CC -shared $pic_flag $wl-z ${wl}text $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++          $CC -shared $pic_flag $wl-z ${wl}text $wl-z ${wl}ignore $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+       else
+ 	case `$CC -V 2>&1` in
+ 	*"Compilers 5.0"*)
+diff -ru glib-2.54.0~/m4macros/libtool.m4 glib-2.54.0/m4macros/libtool.m4
+--- glib-2.54.0~/m4macros/libtool.m4	2017-09-11 00:18:43.000000000 +0000
++++ glib-2.54.0/m4macros/libtool.m4	2017-09-20 12:30:13.686428249 +0000
+@@ -5901,9 +5901,9 @@
+       _LT_TAGVAR(no_undefined_flag, $1)=' -z defs'
+       if test yes = "$GCC"; then
+ 	wlarc='$wl'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl-z ${wl}text $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl-z ${wl}text $wl-z ${wl}ignore $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	_LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-          $CC -shared $pic_flag $wl-z ${wl}text $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++          $CC -shared $pic_flag $wl-z ${wl}text $wl-z ${wl}ignore $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+       else
+ 	case `$CC -V 2>&1` in
+ 	*"Compilers 5.0"*)


### PR DESCRIPTION
Link with -zignore so that unreferenced objects are removed from libraries during the link phase. Without this the illumos elf check reports errors like:

`unreferenced object=/usr/lib/libpcre.so.1; unused dependency of /usr/lib/libgobject-2.0.so.0.5400.0`