### PR TITLE
m2crypto: update to version 0.26.2

### DIFF
--- a/build/python27/m2crypto/build.sh
+++ b/build/python27/m2crypto/build.sh
@@ -30,7 +30,7 @@
 
 PKG=library/python-2/m2crypto-27
 PROG=M2Crypto
-VER=0.26.0
+VER=0.26.2
 SUMMARY="Python interface for openssl"
 DESC="M2Crypto provides a python interface to the openssl library."
 

--- a/build/python27/m2crypto/patches/M2Crypto-crl.patch
+++ b/build/python27/m2crypto/patches/M2Crypto-crl.patch
@@ -68,12 +68,12 @@ diff -ru M2Crypto-0.26.0/M2Crypto/X509.py M2Crypto-0.26.0.patched/M2Crypto/X509.
      """
      Load CRL from file.
  
-     @param file: Name of file containing CRL in PEM format.
+     :param file: Name of file containing CRL in PEM format.
  
 +    @type format: int, either FORMAT_PEM or FORMAT_DER
 +    @param format: Describes the format of the file to be loaded, either PEM or DER.
 +
-     @return: M2Crypto.X509.CRL object.
+     :return: M2Crypto.X509.CRL object.
      """
      with BIO.openfile(file) as f:
 -        cptr = m2.x509_crl_read_pem(f.bio_ptr())

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -100,7 +100,7 @@
 | library/python-2/jsonrpclib-27	| 0.1.7			| https://pypi.python.org/pypi/jsonrpclib
 | library/python-2/jsonschema-27	| 2.6.0			| https://pypi.python.org/pypi/jsonschema
 | library/python-2/lxml-27		| 4.0.0			| https://pypi.python.org/pypi/lxml/
-| library/python-2/m2crypto-27		| 0.26.0		| https://pypi.python.org/pypi/M2Crypto
+| library/python-2/m2crypto-27		| 0.26.2		| https://pypi.python.org/pypi/M2Crypto
 | library/python-2/mako-27		| 1.0.7			| https://pypi.python.org/pypi/Mako
 | library/python-2/numpy-27		| 1.13.1		| https://pypi.python.org/pypi/numpy
 | library/python-2/ply-27		| 3.10			| https://pypi.python.org/pypi/ply


### PR DESCRIPTION
`pkg(5)` test suite ran with no changes against bloody baseline for all components shipped in OmniOS.