### PR TITLE
Add patch rebase function and rebase python patches

### DIFF
--- a/build/python27/patches/00-bits.patch
+++ b/build/python27/patches/00-bits.patch
@@ -1,9 +1,10 @@
 #
 # This patch makes the pyconfig.h header file 32/64 bit friendly.
 #
---- Python-2.7.6/configure.ac.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/configure.ac	2014-05-14 11:47:47.888887846 -0700
-@@ -5,7 +5,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/configure.ac Python-2.7.14/configure.ac
+--- Python-2.7.14~/configure.ac	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/configure.ac	2017-09-23 22:33:27.770433096 +0000
+@@ -5,7 +5,7 @@ dnl ************************************
  # Set VERSION so we only need to edit in one place (i.e., here)
  m4_define(PYTHON_VERSION, 2.7)
  
@@ -11,8 +12,8 @@
 +AC_PREREQ(2.68)
  
  AC_REVISION($Revision$)
- AC_INIT(python, PYTHON_VERSION, http://bugs.python.org/)
-@@ -2086,12 +2086,6 @@
+ AC_INIT(python, PYTHON_VERSION, https://bugs.python.org/)
+@@ -2269,12 +2269,6 @@ AC_MSG_CHECKING(CCSHARED)
  if test -z "$CCSHARED"
  then
  	case $ac_sys_system/$ac_sys_release in

--- a/build/python27/patches/01-ext-stdio.patch
+++ b/build/python27/patches/01-ext-stdio.patch
@@ -1,7 +1,8 @@
---- Python-2.7.1/Modules/python.c.orig	Tue Jun 21 21:35:45 2011
-+++ Python-2.7.1/Modules/python.c	Tue Jun 21 21:39:29 2011
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/python.c Python-2.7.14/Modules/python.c
+--- Python-2.7.14~/Modules/python.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/python.c	2017-09-23 22:33:28.270473428 +0000
 @@ -6,6 +6,13 @@
- #include <floatingpoint.h>
+ #include <fenv.h>
  #endif
  
 +#if defined(sun) && defined(__SVR4) && !defined(_LP64)
@@ -14,13 +15,13 @@
  int
  main(int argc, char **argv)
  {
-@@ -20,5 +27,18 @@
- 	m = fpgetmask();
- 	fpsetmask(m & ~FP_X_OFL);
+@@ -17,5 +24,18 @@ main(int argc, char **argv)
+ #ifdef __FreeBSD__
+ 	fedisableexcept(FE_OVERFLOW);
  #endif
 +#ifdef USE_EXTENDED_FILE_STDIO
 +	/*
-+	 * enable extended FILE facility on Solaris so that Python
++	 * enable extended FILE facility on OmniOS so that Python
 +	 * apps can keep more than 256 file descriptors open
 +	 */
 +	struct rlimit rlp;

--- a/build/python27/patches/02-setup.patch
+++ b/build/python27/patches/02-setup.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/setup.py.~1~	2013-11-10 11:36:41.000000000 +0400
-+++ Python-2.7.6/setup.py	2014-06-04 10:11:58.356029565 +0400
-@@ -437,9 +437,9 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:28.700380145 +0000
+@@ -455,9 +455,9 @@ class PyBuildExt(build_ext):
  
      def detect_modules(self):
          # Ensure that /usr/local is always used
@@ -13,7 +14,7 @@
          if cross_compiling:
              self.add_gcc_paths()
          self.add_multiarch_paths()
-@@ -761,6 +761,13 @@
+@@ -785,6 +785,13 @@ class PyBuildExt(build_ext):
                                                       ['/usr/lib/termcap'],
                                                       'termcap'):
                  readline_libs.append('termcap')
@@ -27,7 +28,7 @@
              exts.append( Extension('readline', ['readline.c'],
                                     library_dirs=['/usr/lib/termcap'],
                                     extra_link_args=readline_extra_link_args,
-@@ -780,9 +787,10 @@
+@@ -804,9 +811,10 @@ class PyBuildExt(build_ext):
          exts.append( Extension('_csv', ['_csv.c']) )
  
          # socket(2)
@@ -39,7 +40,7 @@
          # Detect SSL support for the socket module (via _ssl)
          search_for_ssl_incs_in = [
                                '/usr/local/ssl/include',
-@@ -1579,9 +1587,14 @@
+@@ -1610,9 +1618,14 @@ class PyBuildExt(build_ext):
                  sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED')):
                  multiprocessing_srcs.append('_multiprocessing/semaphore.c')
  
@@ -54,7 +55,7 @@
                                      include_dirs=["Modules/_multiprocessing"]))
          else:
              missing.append('_multiprocessing')
-@@ -2075,7 +2088,8 @@
+@@ -2106,7 +2119,8 @@ class PyBuildExt(build_ext):
              # this option. If you want to compile ctypes with the Sun
              # compiler, please research a proper solution, instead of
              # finding some -z option for the Sun compiler.

--- a/build/python27/patches/03-vendor-packages.patch
+++ b/build/python27/patches/03-vendor-packages.patch
@@ -1,6 +1,6 @@
 diff --git Python-2.7.1/Lib/site-packages/vendor-packages.pth Python2.7.1/Lib/site-packages/vendor-packages.pth
---- /dev/null   Sat Feb 12 00:21:26 2011
-+++ Python-2.7.1/Lib/site-packages/vendor-packages.pth  Sat Feb 12 00:47:05 2011
-@@ -0,0 +1,1 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/site-packages/vendor-packages.pth Python-2.7.14/Lib/site-packages/vendor-packages.pth
+--- Python-2.7.14~/Lib/site-packages/vendor-packages.pth	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Lib/site-packages/vendor-packages.pth	2017-09-23 22:33:29.135584766 +0000
+@@ -0,0 +1 @@
 +import site; site.addsitedir('/usr/lib/python2.7/vendor-packages')
-

--- a/build/python27/patches/04-solaris-64-bit.patch
+++ b/build/python27/patches/04-solaris-64-bit.patch
@@ -1,17 +1,18 @@
---- Python-2.7.6/Lib/distutils/command/build_ext.py.~1~	2013-11-09 23:36:40.000000000 -0800
-+++ Python-2.7.6/Lib/distutils/command/build_ext.py	2014-05-14 12:47:04.342901439 -0700
-@@ -634,6 +634,10 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/distutils/command/build_ext.py Python-2.7.14/Lib/distutils/command/build_ext.py
+--- Python-2.7.14~/Lib/distutils/command/build_ext.py	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Lib/distutils/command/build_ext.py	2017-09-23 22:33:29.574160778 +0000
+@@ -637,6 +637,10 @@ class build_ext (Command):
          filename = self.get_ext_filename(ext_name)
          filename = os.path.split(filename)[-1]
  
-+        # on Solaris we put 64-bit python objects under .../64
++        # on OmniOS we put 64-bit python objects under .../64
 +        if sys.maxint != 2147483647L:
 +            filename = os.path.join("64", filename)
 +
          if not self.inplace:
              # no further work needed
              # returning :
-@@ -674,7 +678,14 @@
+@@ -677,7 +681,14 @@ class build_ext (Command):
          so_ext = get_config_var('SO')
          if os.name == 'nt' and self.debug:
              return os.path.join(*ext_path) + '_d' + so_ext
@@ -27,9 +28,10 @@
  
      def get_export_symbols (self, ext):
          """Return the list of symbols that a shared extension has to
---- Python-2.7.6/Python/import.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Python/import.c	2014-05-14 12:53:34.233016586 -0700
-@@ -1288,6 +1288,57 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Python/import.c Python-2.7.14/Python/import.c
+--- Python-2.7.14~/Python/import.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Python/import.c	2017-09-23 22:33:29.574956629 +0000
+@@ -1310,6 +1310,57 @@ static int case_ok(char *, Py_ssize_t, P
  static int find_init_module(char *); /* Forward */
  static struct filedescr importhookdescr = {"", "", IMP_HOOK};
  
@@ -87,7 +89,7 @@
  static struct filedescr *
  find_module(char *fullname, char *subname, PyObject *path, char *buf,
              size_t buflen, FILE **p_fp, PyObject **p_loader)
-@@ -1302,11 +1353,10 @@
+@@ -1324,11 +1375,10 @@ find_module(char *fullname, char *subnam
      static struct filedescr fd_builtin = {"", "", C_BUILTIN};
      static struct filedescr fd_package = {"", "", PKG_DIRECTORY};
      char *name;
@@ -100,7 +102,7 @@
      if (p_loader != NULL)
          *p_loader = NULL;
  
-@@ -1513,15 +1563,17 @@
+@@ -1535,15 +1585,17 @@ find_module(char *fullname, char *subnam
                  }
              }
          }
@@ -120,7 +122,7 @@
  #if defined(PYOS_OS2) && defined(HAVE_DYNAMIC_LOADING)
              /* OS/2 limits DLLs to 8 character names (w/o
                 extension)
-@@ -1562,21 +1614,20 @@
+@@ -1584,21 +1636,20 @@ find_module(char *fullname, char *subnam
                      fp = NULL;
                  }
              }
@@ -145,9 +147,10 @@
          Py_XDECREF(copy);
          if (fp != NULL)
              break;
---- Python-2.7.1/Python/importdl.h.orig	Fri Jul 15 15:48:16 2011
-+++ Python-2.7.1/Python/importdl.h	Fri Jul 15 15:49:10 2011
-@@ -31,8 +31,9 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Python/importdl.h Python-2.7.14/Python/importdl.h
+--- Python-2.7.14~/Python/importdl.h	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Python/importdl.h	2017-09-23 22:33:29.575072640 +0000
+@@ -31,8 +31,9 @@ extern const struct filedescr _PyImport_
  extern PyObject *_PyImport_LoadDynamicModule(char *name, char *pathname,
                                               FILE *);
  

--- a/build/python27/patches/05-dtrace.patch
+++ b/build/python27/patches/05-dtrace.patch
@@ -2,17 +2,41 @@ This patch adds Python dtrace support.  Note it is necessary to modify
 test_sys.py to add an integer to the frameobject structure size since this
 patch adds "int f_calllineno" to the structure, so this test does not fail.
 
---- Python-2.7.6/Makefile.pre.in.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Makefile.pre.in	2014-05-14 12:54:43.824219677 -0700
-@@ -218,6 +218,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Include/frameobject.h Python-2.7.14/Include/frameobject.h
+--- Python-2.7.14~/Include/frameobject.h	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Include/frameobject.h	2017-09-23 22:33:30.033721692 +0000
+@@ -44,6 +44,7 @@ typedef struct _frame {
+        PyCode_Addr2Line to calculate the line from the current
+        bytecode index. */
+     int f_lineno;		/* Current line number */
++    int f_calllineno;		/* line number of call site */
+     int f_iblock;		/* index in f_blockstack */
+     PyTryBlock f_blockstack[CO_MAXBLOCKS]; /* for try and loop blocks */
+     PyObject *f_localsplus[1];	/* locals+stack, dynamically sized */
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/test/test_sys.py Python-2.7.14/Lib/test/test_sys.py
+--- Python-2.7.14~/Lib/test/test_sys.py	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Lib/test/test_sys.py	2017-09-23 22:33:30.036032504 +0000
+@@ -646,7 +646,7 @@ class SizeofTest(unittest.TestCase):
+         nfrees = len(x.f_code.co_freevars)
+         extras = x.f_code.co_stacksize + x.f_code.co_nlocals +\
+                  ncells + nfrees - 1
+-        check(x, vsize('12P3i' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
++        check(x, vsize('12P4i' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
+         # function
+         def func(): pass
+         check(func, size('9P'))
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Makefile.pre.in Python-2.7.14/Makefile.pre.in
+--- Python-2.7.14~/Makefile.pre.in	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Makefile.pre.in	2017-09-23 22:33:30.033406887 +0000
+@@ -232,6 +232,7 @@ MODULE_OBJS=	\
  # Used of signalmodule.o is not available
  SIGNAL_OBJS=	@SIGNAL_OBJS@
  
 +DTRACE_OBJS=Python/dtrace.o Python/phelper.o
  
  ##########################################################################
- # Grammar
-@@ -341,6 +342,7 @@
+ 
+@@ -337,6 +338,7 @@ PYTHON_OBJS=	\
  		Python/formatter_unicode.o \
  		Python/formatter_string.o \
  		Python/$(DYNLOADFILE) \
@@ -20,7 +44,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
  		$(LIBOBJS) \
  		$(MACHDEP_OBJS) \
  		$(THREADOBJ)
-@@ -664,6 +666,18 @@
+@@ -739,6 +741,18 @@ Python/formatter_unicode.o: $(srcdir)/Py
  Python/formatter_string.o: $(srcdir)/Python/formatter_string.c \
  				$(STRINGLIB_HEADERS)
  
@@ -39,19 +63,10 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
  ############################################################################
  # Header files
  
---- Python-2.7.6/Include/frameobject.h.~1~	2013-11-09 23:36:39.000000000 -0800
-+++ Python-2.7.6/Include/frameobject.h	2014-05-14 13:03:19.938777249 -0700
-@@ -44,6 +44,7 @@
-        PyCode_Addr2Line to calculate the line from the current
-        bytecode index. */
-     int f_lineno;		/* Current line number */
-+    int f_calllineno;		/* line number of call site */
-     int f_iblock;		/* index in f_blockstack */
-     PyTryBlock f_blockstack[CO_MAXBLOCKS]; /* for try and loop blocks */
-     PyObject *f_localsplus[1];	/* locals+stack, dynamically sized */
---- Python-2.7.6/Objects/frameobject.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Objects/frameobject.c	2014-05-14 12:56:06.970076859 -0700
-@@ -738,6 +738,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Objects/frameobject.c Python-2.7.14/Objects/frameobject.c
+--- Python-2.7.14~/Objects/frameobject.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Objects/frameobject.c	2017-09-23 22:33:30.033987579 +0000
+@@ -736,6 +736,7 @@ PyFrame_New(PyThreadState *tstate, PyCod
      f->f_tstate = tstate;
  
      f->f_lasti = -1;
@@ -59,8 +74,9 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
      f->f_lineno = code->co_firstlineno;
      f->f_iblock = 0;
  
---- Python-2.7.6/Python/ceval.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Python/ceval.c	2014-05-14 13:04:01.334853206 -0700
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Python/ceval.c Python-2.7.14/Python/ceval.c
+--- Python-2.7.14~/Python/ceval.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Python/ceval.c	2017-09-23 22:33:30.035564841 +0000
 @@ -19,6 +19,11 @@
  
  #include <ctype.h>
@@ -73,7 +89,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
  #ifndef WITH_TSC
  
  #define READ_TIMESTAMP(var)
-@@ -672,6 +677,55 @@
+@@ -674,6 +679,55 @@ PyEval_EvalCode(PyCodeObject *co, PyObje
                        NULL);
  }
  
@@ -129,7 +145,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
  
  /* Interpreter main loop */
  
-@@ -683,9 +737,84 @@
+@@ -685,9 +739,84 @@ PyEval_EvalFrame(PyFrameObject *f) {
      return PyEval_EvalFrameEx(f, 0);
  }
  
@@ -212,9 +228,9 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
 +#endif /* HAVE_DTRACE */
 +
  #ifdef DYNAMIC_EXECUTION_PROFILE
-     #undef USE_COMPUTED_GOTOS
+   #undef USE_COMPUTED_GOTOS
  #endif
-@@ -910,6 +1039,11 @@
+@@ -1009,6 +1138,11 @@ PyEval_EvalFrameEx(PyFrameObject *f, int
          }
      }
  
@@ -226,7 +242,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
      co = f->f_code;
      names = co->co_names;
      consts = co->co_consts;
-@@ -2660,6 +2794,9 @@
+@@ -2988,6 +3122,9 @@ PyEval_EvalFrameEx(PyFrameObject *f, int
              PyObject **sp;
              PCALL(PCALL_ALL);
              sp = stack_pointer;
@@ -236,7 +252,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
  #ifdef WITH_TSC
              x = call_function(&sp, oparg, &intr0, &intr1);
  #else
-@@ -2701,6 +2838,9 @@
+@@ -3029,6 +3166,9 @@ PyEval_EvalFrameEx(PyFrameObject *f, int
              } else
                  Py_INCREF(func);
              sp = stack_pointer;
@@ -246,7 +262,7 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
              READ_TIMESTAMP(intr0);
              x = ext_do_call(func, &sp, flags, na, nk);
              READ_TIMESTAMP(intr1);
-@@ -3001,6 +3141,10 @@
+@@ -3338,6 +3478,10 @@ fast_yield:
  
      /* pop frame */
  exit_eval_frame:
@@ -257,8 +273,9 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
      Py_LeaveRecursiveCall();
      tstate->frame = f->f_back;
  
---- /dev/null
-+++ Python-2.6.4/Python/phelper.d
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Python/phelper.d Python-2.7.14/Python/phelper.d
+--- Python-2.7.14~/Python/phelper.d	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Python/phelper.d	2017-09-23 22:33:30.035717637 +0000
 @@ -0,0 +1,139 @@
 +
 +/*
@@ -399,10 +416,9 @@ patch adds "int f_calllineno" to the structure, so this test does not fail.
 +{
 +	NULL;
 +}
-diff --git Python-2.6.4/Python/python.d Python-2.6.4/Python/python.d
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Python/python.d
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Python/python.d Python-2.7.14/Python/python.d
+--- Python-2.7.14~/Python/python.d	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Python/python.d	2017-09-23 22:33:30.035788757 +0000
 @@ -0,0 +1,10 @@
 +provider python {
 +	probe function__entry(const char *, const char *, int);
@@ -414,14 +430,3 @@ new file mode 100644
 +#pragma D attributes Private/Private/Common provider python function
 +#pragma D attributes Evolving/Evolving/Common provider python name
 +#pragma D attributes Evolving/Evolving/Common provider python args
---- Python-2.7.6/Lib/test/test_sys.py.~1~	2013-11-09 23:36:40.000000000 -0800
-+++ Python-2.7.6/Lib/test/test_sys.py	2014-05-14 13:07:05.332748121 -0700
-@@ -612,7 +612,7 @@
-         nfrees = len(x.f_code.co_freevars)
-         extras = x.f_code.co_stacksize + x.f_code.co_nlocals +\
-                  ncells + nfrees - 1
--        check(x, vsize('12P3i' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
-+        check(x, vsize('12P4i' + CO_MAXBLOCKS*'3i' + 'P' + extras*'P'))
-         # function
-         def func(): pass
-         check(func, size('9P'))

--- a/build/python27/patches/06-ucred.patch
+++ b/build/python27/patches/06-ucred.patch
@@ -2,8 +2,58 @@ This patch provides Python ucred support.
 
 diff --git Python-2.6.4/Modules/ucred.c Python-2.6.4/Modules/ucred.c
 new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/ucred.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/test/ucredtest.py Python-2.7.14/Lib/test/ucredtest.py
+--- Python-2.7.14~/Lib/test/ucredtest.py	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Lib/test/ucredtest.py	2017-09-23 22:33:30.481128584 +0000
+@@ -0,0 +1,45 @@
++#!/usr/bin/python2.7
++
++import ucred
++import os
++
++uc = ucred.get(os.getpid())
++
++print "pid = %d" % uc.getpid()
++print "euid = %d" % uc.geteuid()
++print "ruid = %d" % uc.getruid()
++print "suid = %d" % uc.getsuid()
++print "egid = %d" % uc.getegid()
++print "rgid = %d" % uc.getrgid()
++print "sgid = %d" % uc.getsgid()
++print "zoneid = %d" % uc.getzoneid()
++print "projid = %d" % uc.getprojid()
++print "groups = %s" % uc.getgroups()
++print "label = %s" % uc.getlabel()
++
++print "getpflags(0x1) = %d" % uc.getpflags(0x1)
++print "getpflags(0x2) = %d" % uc.getpflags(0x2)
++print "has_priv(Effective, proc_fork) = %d" % uc.has_priv("Effective", "proc_fork")
++print "has_priv(Permitted, proc_fork) = %d" % uc.has_priv("Permitted", "proc_fork")
++print "has_priv(Inheritable, proc_fork) = %d" % uc.has_priv("Inheritable", "proc_fork")
++print "has_priv(Limit, file_setid) = %d" % uc.has_priv("Limit", "file_setid")
++print "has_priv(Effective, file_setid) = %d" % uc.has_priv("Effective", "file_setid")
++try:
++    uc.has_priv("Effective", "proc_bork")
++except OSError, e:
++    print e
++try:
++    uc.has_priv("Defective", "proc_fork")
++except OSError, e:
++    print e
++try:
++    uc.has_priv("Defective", "proc_bork")
++except OSError, e:
++    print e
++
++del uc
++uc = ucred.ucred()
++try:
++    uc.getpid()
++except OSError, e:
++    print e
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/ucred.c Python-2.7.14/Modules/ucred.c
+--- Python-2.7.14~/Modules/ucred.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/ucred.c	2017-09-23 22:33:30.481391123 +0000
 @@ -0,0 +1,390 @@
 +/*
 + * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -395,13 +445,14 @@ new file mode 100644
 +
 +	PyModule_AddObject(m, "ucred", (PyObject *)&pyucred_type);
 +}
---- Python-2.7.6/setup.py.~2~	2014-05-14 13:07:52.803164982 -0700
-+++ Python-2.7.6/setup.py	2014-05-14 13:07:52.917214713 -0700
-@@ -1536,6 +1536,13 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:28.700380145 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:30.481978327 +0000
+@@ -1568,6 +1568,13 @@ class PyBuildExt(build_ext):
          else:
              missing.append('dl')
  
-+        # ucred module (Solaris)
++        # ucred module (OmniOS)
 +        ucred_inc = find_file('ucred.h', [], inc_dirs)
 +        tsol_inc = find_file('tsol/label.h', [], inc_dirs)
 +        if ucred_inc is not None and tsol_inc is not None:
@@ -411,51 +462,3 @@ new file mode 100644
          # Thomas Heller's _ctypes module
          self.detect_ctypes(inc_dirs, lib_dirs)
  
---- /dev/null	2011-02-12 03:14:16.000000000 -0600
-+++ Python-2.6.4/Lib/test/ucredtest.py	2011-01-20 13:52:42.945657919 -0600
-@@ -0,0 +1,45 @@
-+#!/usr/bin/python2.7
-+
-+import ucred
-+import os
-+
-+uc = ucred.get(os.getpid())
-+
-+print "pid = %d" % uc.getpid()
-+print "euid = %d" % uc.geteuid()
-+print "ruid = %d" % uc.getruid()
-+print "suid = %d" % uc.getsuid()
-+print "egid = %d" % uc.getegid()
-+print "rgid = %d" % uc.getrgid()
-+print "sgid = %d" % uc.getsgid()
-+print "zoneid = %d" % uc.getzoneid()
-+print "projid = %d" % uc.getprojid()
-+print "groups = %s" % uc.getgroups()
-+print "label = %s" % uc.getlabel()
-+
-+print "getpflags(0x1) = %d" % uc.getpflags(0x1)
-+print "getpflags(0x2) = %d" % uc.getpflags(0x2)
-+print "has_priv(Effective, proc_fork) = %d" % uc.has_priv("Effective", "proc_fork")
-+print "has_priv(Permitted, proc_fork) = %d" % uc.has_priv("Permitted", "proc_fork")
-+print "has_priv(Inheritable, proc_fork) = %d" % uc.has_priv("Inheritable", "proc_fork")
-+print "has_priv(Limit, file_setid) = %d" % uc.has_priv("Limit", "file_setid")
-+print "has_priv(Effective, file_setid) = %d" % uc.has_priv("Effective", "file_setid")
-+try:
-+    uc.has_priv("Effective", "proc_bork")
-+except OSError, e:
-+    print e
-+try:
-+    uc.has_priv("Defective", "proc_fork")
-+except OSError, e:
-+    print e
-+try:
-+    uc.has_priv("Defective", "proc_bork")
-+except OSError, e:
-+    print e
-+
-+del uc
-+uc = ucred.ucred()
-+try:
-+    uc.getpid()
-+except OSError, e:
-+    print e

--- a/build/python27/patches/07-dlpi.patch
+++ b/build/python27/patches/07-dlpi.patch
@@ -2,8 +2,109 @@ This patch provides Python dlpi support.
 
 diff --git Python-2.6.4/Modules/dlpimodule.c Python-2.6.4/Modules/dlpimodule.c
 new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/dlpimodule.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/test/dlpitest.py Python-2.7.14/Lib/test/dlpitest.py
+--- Python-2.7.14~/Lib/test/dlpitest.py	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Lib/test/dlpitest.py	2017-09-23 22:33:30.916663897 +0000
+@@ -0,0 +1,96 @@
++#!/usr/bin/python2.7
++
++import dlpi
++import sys
++import time
++import struct
++
++#test listlink
++linklist = dlpi.listlink()
++print "Found %d links:" % len(linklist)
++print linklist
++
++#pick up the first data link for below testing
++linkname = linklist[0]
++
++#open link
++print "opening link: " + linkname + "..."
++testlink = dlpi.link(linkname)
++
++#read some info of testlink
++print "linkname is %s" % testlink.get_linkname()
++print "link fd is %d" % testlink.get_fd()
++mactype = testlink.get_mactype()
++print "dlpi mactype is %d" % mactype
++print "after convert:"
++print "\tmactype is %s" % dlpi.mactype(mactype)
++print "\tiftype is %d" % dlpi.iftype(mactype)
++print "\tarptype is %d" % dlpi.arptype(mactype)
++bcastaddr = testlink.get_bcastaddr()
++print "broadcast addr is: ",
++print struct.unpack("BBBBBB",bcastaddr)
++physaddr = testlink.get_physaddr(dlpi.FACT_PHYS_ADDR)
++print "factory physical address is: ",
++print struct.unpack("BBBBBB",physaddr)
++print "current timeout value is %d" % testlink.get_timeout()
++print "sdu is:",
++print testlink.get_sdu()
++print "qos select is:",
++print testlink.get_qos_select()
++print "qos range is:",
++print testlink.get_qos_range()
++
++#set some config value of testlink and read them again
++print "setting current physiacal addr to aa:0:10:13:27:5"
++testlink.set_physaddr('\xaa\0\x10\x13\x27\5')
++physaddr = testlink.get_physaddr(dlpi.CURR_PHYS_ADDR)
++print "current physical addr is: ",
++print struct.unpack("BBBBBB",physaddr)
++print "set timeout value to 6..."
++testlink.set_timeout(6)
++print "timeout value is %d" % testlink.get_timeout()
++
++#test enable/disable multicast
++print "enable/disable multicast address 1:0:5e:0:0:5"
++testlink.enabmulti('\1\0\x5e\0\0\5')
++testlink.disabmulti('\1\0\x5e\0\0\5')
++
++#test bind
++print "binding to SAP 0x9000..."
++testlink.bind(0x9000)
++print "sap is %x" % testlink.get_sap()
++print "state is: %d"  % testlink.get_state()
++
++#test send
++print "sending broadcast loopback packet..."
++testlink.send(bcastaddr, '\0\1\2\3\4\5')
++
++#test notify functionality
++arg = "notification callback arg"
++def notify(arg, notes, value):
++	print "NOTE_PROMISC_ON_PHYS notification received with arg: '%s'" % arg
++print "enabled notification on NOTE_PROMISC_ON_PHYS"
++id = testlink.enabnotify(dlpi.NOTE_PROMISC_ON_PHYS, notify, arg) #enable notification
++testlink.promiscon() #trigger the event (will be seen while receiving pkt below)
++
++#test receive
++print "testing receiving..."
++try:
++	testlink.recv(0, 0) #should see NOTE_PROMISC_ON_PHYS event here
++except dlpi.error, err:
++	errnum, errinfo = err
++	if errnum == 10006:
++		pass #timeout error is expected here
++	else: #test fails if reach here
++		print "test failed",
++		print errnum,
++		print err
++
++testlink.promiscoff()
++testlink.disabnotify(id) #disable notification
++
++#test unbind
++print "unbinding..."
++testlink.unbind()
++print "sap is %x" % testlink.get_sap()
++print "state is: %d"  % testlink.get_state()
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/dlpimodule.c Python-2.7.14/Modules/dlpimodule.c
+--- Python-2.7.14~/Modules/dlpimodule.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/dlpimodule.c	2017-09-23 22:33:30.917289705 +0000
 @@ -0,0 +1,1205 @@
 +/*
 + * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1210,13 +1311,14 @@ new file mode 100644
 +	PyModule_AddIntConstant(mod, "IDLE", DL_IDLE);
 +	PyModule_AddIntConstant(mod, "SYSERR", DL_SYSERR);
 +}
---- Python-2.7.6/setup.py.~3~	2014-05-14 13:10:30.979598710 -0700
-+++ Python-2.7.6/setup.py	2014-05-14 13:10:31.006864446 -0700
-@@ -1543,6 +1543,12 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:30.481978327 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:30.917896422 +0000
+@@ -1575,6 +1575,12 @@ class PyBuildExt(build_ext):
              exts.append( Extension('ucred', ['ucred.c'],
                                     libraries = ['tsol']) )
  
-+        # dlpi module (Solaris)
++        # dlpi module (OmniOS)
 +        dlpi_inc = find_file('libdlpi.h', [], inc_dirs)
 +        if dlpi_inc is not None:
 +            exts.append( Extension('dlpi', ['dlpimodule.c'],
@@ -1225,102 +1327,3 @@ new file mode 100644
          # Thomas Heller's _ctypes module
          self.detect_ctypes(inc_dirs, lib_dirs)
  
---- /dev/null	2011-02-12 03:13:26.000000000 -0600
-+++ Python-2.6.4/Lib/test/dlpitest.py	2011-01-20 13:52:42.895865414 -0600
-@@ -0,0 +1,96 @@
-+#!/usr/bin/python2.7
-+
-+import dlpi
-+import sys
-+import time
-+import struct
-+
-+#test listlink
-+linklist = dlpi.listlink()
-+print "Found %d links:" % len(linklist)
-+print linklist
-+
-+#pick up the first data link for below testing
-+linkname = linklist[0]
-+
-+#open link
-+print "opening link: " + linkname + "..."
-+testlink = dlpi.link(linkname)
-+
-+#read some info of testlink
-+print "linkname is %s" % testlink.get_linkname()
-+print "link fd is %d" % testlink.get_fd()
-+mactype = testlink.get_mactype()
-+print "dlpi mactype is %d" % mactype
-+print "after convert:"
-+print "\tmactype is %s" % dlpi.mactype(mactype)
-+print "\tiftype is %d" % dlpi.iftype(mactype)
-+print "\tarptype is %d" % dlpi.arptype(mactype)
-+bcastaddr = testlink.get_bcastaddr()
-+print "broadcast addr is: ",
-+print struct.unpack("BBBBBB",bcastaddr)
-+physaddr = testlink.get_physaddr(dlpi.FACT_PHYS_ADDR)
-+print "factory physical address is: ",
-+print struct.unpack("BBBBBB",physaddr)
-+print "current timeout value is %d" % testlink.get_timeout()
-+print "sdu is:",
-+print testlink.get_sdu()
-+print "qos select is:",
-+print testlink.get_qos_select()
-+print "qos range is:",
-+print testlink.get_qos_range()
-+
-+#set some config value of testlink and read them again
-+print "setting current physiacal addr to aa:0:10:13:27:5"
-+testlink.set_physaddr('\xaa\0\x10\x13\x27\5')
-+physaddr = testlink.get_physaddr(dlpi.CURR_PHYS_ADDR)
-+print "current physical addr is: ",
-+print struct.unpack("BBBBBB",physaddr)
-+print "set timeout value to 6..."
-+testlink.set_timeout(6)
-+print "timeout value is %d" % testlink.get_timeout()
-+
-+#test enable/disable multicast
-+print "enable/disable multicast address 1:0:5e:0:0:5"
-+testlink.enabmulti('\1\0\x5e\0\0\5')
-+testlink.disabmulti('\1\0\x5e\0\0\5')
-+
-+#test bind
-+print "binding to SAP 0x9000..."
-+testlink.bind(0x9000)
-+print "sap is %x" % testlink.get_sap()
-+print "state is: %d"  % testlink.get_state()
-+
-+#test send
-+print "sending broadcast loopback packet..."
-+testlink.send(bcastaddr, '\0\1\2\3\4\5')
-+
-+#test notify functionality
-+arg = "notification callback arg"
-+def notify(arg, notes, value):
-+	print "NOTE_PROMISC_ON_PHYS notification received with arg: '%s'" % arg
-+print "enabled notification on NOTE_PROMISC_ON_PHYS"
-+id = testlink.enabnotify(dlpi.NOTE_PROMISC_ON_PHYS, notify, arg) #enable notification
-+testlink.promiscon() #trigger the event (will be seen while receiving pkt below)
-+
-+#test receive
-+print "testing receiving..."
-+try:
-+	testlink.recv(0, 0) #should see NOTE_PROMISC_ON_PHYS event here
-+except dlpi.error, err:
-+	errnum, errinfo = err
-+	if errnum == 10006:
-+		pass #timeout error is expected here
-+	else: #test fails if reach here
-+		print "test failed",
-+		print errnum,
-+		print err
-+
-+testlink.promiscoff()
-+testlink.disabnotify(id) #disable notification
-+
-+#test unbind
-+print "unbinding..."
-+testlink.unbind()
-+print "sap is %x" % testlink.get_sap()
-+print "state is: %d"  % testlink.get_state()

--- a/build/python27/patches/08-encoding-alias.patch
+++ b/build/python27/patches/08-encoding-alias.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/Lib/encodings/aliases.py.~1~	2013-11-09 23:36:40.000000000 -0800
-+++ Python-2.7.6/Lib/encodings/aliases.py	2014-05-14 13:12:20.046910463 -0700
-@@ -73,6 +73,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/encodings/aliases.py Python-2.7.14/Lib/encodings/aliases.py
+--- Python-2.7.14~/Lib/encodings/aliases.py	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Lib/encodings/aliases.py	2017-09-23 22:33:31.352277636 +0000
+@@ -73,6 +73,7 @@ aliases = {
  
      # cp1251 codec
      '1251'               : 'cp1251',
@@ -8,7 +9,7 @@
      'windows_1251'       : 'cp1251',
  
      # cp1252 codec
-@@ -222,6 +223,7 @@
+@@ -222,6 +223,7 @@ aliases = {
      'u_jis'              : 'euc_jp',
  
      # euc_kr codec
@@ -16,7 +17,7 @@
      'euckr'              : 'euc_kr',
      'korean'             : 'euc_kr',
      'ksc5601'            : 'euc_kr',
-@@ -462,6 +464,7 @@
+@@ -462,6 +464,7 @@ aliases = {
      'shiftjis'           : 'shift_jis',
      'sjis'               : 'shift_jis',
      's_jis'              : 'shift_jis',
@@ -24,7 +25,7 @@
  
      # shift_jis_2004 codec
      'shiftjis2004'       : 'shift_jis_2004',
-@@ -481,6 +484,7 @@
+@@ -481,6 +484,7 @@ aliases = {
      'tis_620_0'          : 'tis_620',
      'tis_620_2529_0'     : 'tis_620',
      'tis_620_2529_1'     : 'tis_620',

--- a/build/python27/patches/09-rbac.patch
+++ b/build/python27/patches/09-rbac.patch
@@ -2,8 +2,302 @@ This patch provides Python RBAC support.
 
 diff --git Python-2.6.4/Modules/authattr.c Python-2.6.4/Modules/authattr.c
 new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/authattr.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/test/privrbactest.py Python-2.7.14/Lib/test/privrbactest.py
+--- Python-2.7.14~/Lib/test/privrbactest.py	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Lib/test/privrbactest.py	2017-09-23 22:33:31.781995146 +0000
+@@ -0,0 +1,289 @@
++#!/usr/bin/python2.7
++#
++# CDDL HEADER START
++#
++# The contents of this file are subject to the terms of the
++# Common Development and Distribution License (the "License").
++# You may not use this file except in compliance with the License.
++#
++# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
++# or http://www.opensolaris.org/os/licensing.
++# See the License for the specific language governing permissions
++# and limitations under the License.
++#
++# When distributing Covered Code, include this CDDL HEADER in each
++# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
++# If applicable, add the following below this CDDL HEADER, with the
++# fields enclosed by brackets "[]" replaced with your own identifying
++# information: Portions Copyright [yyyy] [name of copyright owner]
++#
++# CDDL HEADER END
++#
++
++# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
++
++import privileges
++import rbac
++import os
++import sys
++import tempfile
++
++# privileges tests
++
++def test_setppriv():
++    amchild = os.fork()
++    if amchild == 0:
++        if privileges.setppriv(privileges.PRIV_OFF, privileges.PRIV_EFFECTIVE, 
++            ['proc_fork']):
++            try:
++                os.fork()
++                sys.exit(1)
++            except OSError, e:
++                sys.exit(0)
++
++    child = os.wait()
++    if child[1] is not 0:
++        print "setppriv. Bad exit status from pid %i\n" % child[0]
++        return False
++    return True
++
++def test_getppriv():
++    if 'proc_fork' in privileges.getppriv(privileges.PRIV_LIMIT):
++        return True
++    print "getppriv or PRIV_PROC_FORK not in PRIV_LIMIT.\n"
++    return False
++
++def test_priv_ineffect():
++    if privileges.priv_ineffect('proc_fork'):
++        return True
++    print "priv_ineffect or PRIV_PROC_FORK not in effect\n"
++    return False
++
++# authattr tests
++
++def test_chkauthattr():
++    try:
++        a = rbac.authattr()
++    except Exception, e:
++        print "Could not instantiate authattr object: %s\n" % e
++        return False
++    try:
++        res = a.chkauthattr('solaris.*', 'root')
++    except Exception, e:
++        print "chkauthattr failed: %s\n" % e
++        return False
++    if not res:
++        print "chkauthattr failed or \'root\' lacks \'solaris.*\'\n"
++        return False
++    return True
++
++def test_getauthattr():
++    try:
++        a = rbac.authattr()
++    except Exception, e:
++        print "Could not instantiate authattr object: %s\n" % e
++        return False
++    try:
++        res = a.getauthattr()
++    except Exception, e:
++        print "getauthattr failed: %s\n" % e
++        return False
++    if not 'name' in res.keys():
++        print "getauthattr failed\n"
++        return False
++    return True
++
++def test_getauthnam():
++    try:
++        a = rbac.authattr()
++    except Exception, e:
++        print "Could not instantiate authattr object: %s\n" % e
++        return False
++    try:
++        res = a.getauthnam('solaris.')
++    except Exception, e:
++        print "getauthnam failed: %s\n" % e
++        return False
++    if not res:
++        print "getauthnam failed or \'solaris.\' not in auth_attr(4)\n"
++        return False
++    return True
++
++def test_authattr_iter():
++    try:
++        a = rbac.authattr()
++    except Exception, e:
++        print "Could not instantiate authattr object: %s\n" % e
++        return False
++    res = a.next()
++    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
++        print "authattr object is not an iterable\n"
++        return False
++    return True
++
++# execattr tests
++
++def test_getexecattr():
++    try:
++        a = rbac.execattr()
++    except Exception, e:
++        print "Could not instantiate execattr object: %s\n" % e
++        return False
++    try:
++        res = a.getexecattr()
++    except Exception, e:
++        print "getexecattr failed: %s\n" % e
++        return False
++    if not 'name' in res.keys():
++        print "getexecattr failed\n"
++        return False
++    return True
++
++def test_getexecuser():
++    try:
++        a = rbac.execattr()
++    except Exception, e:
++        print "Could not instantiate execattr object: %s\n" % e
++        return False
++    try:
++        res = a.getexecuser("root", "act", "*;*;*;*;*")
++    except Exception, e:
++        print "getexecuser failed: %s\n" % e
++        return False
++    if not res:
++        print "getexecuser failed or \'root\' not assigned to \'act\', " \
++            "\'*;*;*;*;*\' \n"
++        return False
++    return True
++
++
++def test_getexecprof():
++    try:
++        a = rbac.execattr()
++    except Exception, e:
++        print "Could not instantiate execattr object: %s\n" % e
++        return False
++    try:
++        res = a.getexecprof("All", "cmd", "*")
++    except Exception, e:
++        print "getexecprof failed: %s\n" % e
++        return False
++    if not res:
++        print "getexecprof failed or \'All\' not granted \'cmd\' : \'*\'\n"
++        return False
++    return True
++
++def test_execattr_iter():
++    try:
++        a = rbac.execattr()
++    except Exception, e:
++        print "Could not instantiate execattr object: %s\n" % e
++        return False
++    res = a.next()
++    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
++        print "execattr object is not an iterable\n"
++        return False
++    return True
++
++# userattr tests
++
++def test_getuserattr():
++    try:
++        a = rbac.userattr()
++    except Exception, e:
++        print "Could not instantiate userattr object: %s\n" % e
++        return False
++    try:
++        res = a.getuserattr()
++    except Exception, e:
++        print "getuserattr failed: %s\n" % e
++        return False
++    if not 'name' in res.keys():
++        print "getuserattr failed\n"
++        return False
++    return True
++
++def test_fgetuserattr():
++    temp = tempfile.NamedTemporaryFile()
++    temp.write("user::::profiles=Software Installation;roles=foo;"\
++        "auths=solaris.foo.bar")
++    temp.seek(0)
++    try:
++        a = rbac.userattr()
++    except Exception, e:
++        print "Could not instantiate userattr object: %s\n" % e
++        return False
++    try:
++        res = a.fgetuserattr(temp.name)
++        temp.close()    
++    except Exception, e:
++        print "fgetuserattr failed: %s\n" % e
++        temp.close()
++        return False
++    if not 'name' in res.keys():
++        print "fgetuserattr failed\n"
++        return False
++    return True
++
++def test_getuseruid():
++    try:
++        a = rbac.userattr()
++    except Exception, e:
++        print "Could not instantiate userattr object: %s\n" % e
++        return False
++    try:
++        res = a.getuseruid(0)
++    except Exception, e:
++        print "getusernam failed: %s\n" % e
++        return False
++    if not 'name' in res:
++        print "getusernam failed or no uid 0\n"
++        return False
++    return True
++
++def test_getusernam():
++    try:
++        a = rbac.userattr()
++    except Exception, e:
++        print "Could not instantiate userattr object: %s\n" % e
++        return False
++    try:
++        res = a.getusernam('root')
++    except Exception, e:
++        print "getusernam failed: %s\n" % e
++        return False
++    if not 'name' in res:
++        print "getusernam failed or no \'root\' user\n"
++        return False
++    return True
++
++def test_userattr_iter():
++    try:
++        a = rbac.userattr()
++    except Exception, e:
++        print "Could not instantiate userattr object: %s\n" % e
++        return False
++    res = a.next()
++    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
++        print "userattr object is not an iterable\n"
++        return False
++    return True
++
++if not test_setppriv() or not test_getppriv() or not test_priv_ineffect():
++    print "*** Failures detected in privileges module\n"    
++    sys.exit(1)
++
++if not test_getauthattr() or not test_chkauthattr() or not test_getauthnam() \
++    or not test_authattr_iter:
++    print "*** Failures detected in rbac.authattr\n"
++    sys.exit(1)
++
++if not test_getexecattr() or not test_getexecuser() or not test_getexecprof() \
++    or not test_execattr_iter():
++    print "*** Failures detected in rbac.execattr\n"
++    sys.exit(1)
++
++if not test_getuserattr() or not test_fgetuserattr() or not test_getusernam()\
++    or not test_getuseruid() or not test_userattr_iter():
++    print "*** Failures detected in rbac.userattr\n"
++    sys.exit(1)
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/authattr.c Python-2.7.14/Modules/authattr.c
+--- Python-2.7.14~/Modules/authattr.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/authattr.c	2017-09-23 22:33:31.782215675 +0000
 @@ -0,0 +1,261 @@
 +/*
 + * CDDL HEADER START
@@ -266,10 +560,9 @@ new file mode 100644
 +	0,                         /* tp_alloc */
 +	Authattr_new,                 /* tp_new */
 +};
-diff --git Python-2.6.4/Modules/execattr.c Python-2.6.4/Modules/execattr.c
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/execattr.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/execattr.c Python-2.7.14/Modules/execattr.c
+--- Python-2.7.14~/Modules/execattr.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/execattr.c	2017-09-23 22:33:31.782420466 +0000
 @@ -0,0 +1,313 @@
 +/*
 + * CDDL HEADER START
@@ -584,10 +877,9 @@ new file mode 100644
 +	0,                         /* tp_alloc */
 +	Execattr_new,                 /* tp_new */
 +};
-diff --git Python-2.6.4/Modules/privileges.c Python-2.6.4/Modules/privileges.c
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/privileges.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/privileges.c Python-2.7.14/Modules/privileges.c
+--- Python-2.7.14~/Modules/privileges.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/privileges.c	2017-09-23 22:33:31.782585000 +0000
 @@ -0,0 +1,229 @@
 +/*
 + * CDDL HEADER START
@@ -749,7 +1041,7 @@ new file mode 100644
 +
 +static char pyprivileges__doc__[];
 +PyDoc_STRVAR(pyprivileges__doc__, 
-+"Provides functions for interacting with the Solaris privileges(5) framework\n\
++"Provides functions for interacting with the OmniOS privileges(5) framework\n\
 +Functions provided:\n\
 +setppriv\n\
 +getppriv\n\
@@ -818,10 +1110,9 @@ new file mode 100644
 +	PyDict_SetItemString(d, "PRIV_LIMIT", PyInt_FromLong((long)PRIV_LIMIT));
 +	PyDict_SetItemString(d, "PRIV_EFFECTIVE", PyInt_FromLong((long)PRIV_EFFECTIVE));
 +}
-diff --git Python-2.6.4/Modules/pyrbac.c Python-2.6.4/Modules/pyrbac.c
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/pyrbac.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/pyrbac.c Python-2.7.14/Modules/pyrbac.c
+--- Python-2.7.14~/Modules/pyrbac.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/pyrbac.c	2017-09-23 22:33:31.782680195 +0000
 @@ -0,0 +1,68 @@
 +/*
 + * CDDL HEADER START
@@ -859,7 +1150,7 @@ new file mode 100644
 +static char pyrbac__doc__[];
 +
 +PyDoc_STRVAR(pyrbac__doc__, "provides access to some objects \
-+for interaction with the Solaris Role-Based Access Control \
++for interaction with the OmniOS Role-Based Access Control \
 +framework.\n\nDynamic objects:\n\
 +userattr -- for interacting with user_attr(4)\n\
 +authattr -- for interacting with auth_attr(4)\n\
@@ -891,10 +1182,9 @@ new file mode 100644
 +
 +}
 +
-diff --git Python-2.6.4/Modules/pyrbac.h Python-2.6.4/Modules/pyrbac.h
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/pyrbac.h
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/pyrbac.h Python-2.7.14/Modules/pyrbac.h
+--- Python-2.7.14~/Modules/pyrbac.h	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/pyrbac.h	2017-09-23 22:33:31.782763084 +0000
 @@ -0,0 +1,45 @@
 +/*
 + * CDDL HEADER START
@@ -941,10 +1231,9 @@ new file mode 100644
 +PyTypeObject UserattrType;
 +
 +#endif
-diff --git Python-2.6.4/Modules/userattr.c Python-2.6.4/Modules/userattr.c
-new file mode 100644
---- /dev/null
-+++ Python-2.6.4/Modules/userattr.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/userattr.c Python-2.7.14/Modules/userattr.c
+--- Python-2.7.14~/Modules/userattr.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/Modules/userattr.c	2017-09-23 22:33:31.782950832 +0000
 @@ -0,0 +1,308 @@
 +/*
 + * CDDL HEADER START
@@ -1254,18 +1543,19 @@ new file mode 100644
 +	0,                         /* tp_alloc */
 +	Userattr_new,                 /* tp_new */
 +};
---- Python-2.7.6/setup.py.~4~	2014-05-14 13:16:33.749494047 -0700
-+++ Python-2.7.6/setup.py	2014-05-14 13:16:33.803607449 -0700
-@@ -1549,6 +1549,22 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:30.917896422 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:31.783529834 +0000
+@@ -1581,6 +1581,22 @@ class PyBuildExt(build_ext):
              exts.append( Extension('dlpi', ['dlpimodule.c'],
                                     libraries = ['dlpi']) )
  
-+        # privileges module (Solaris)
++        # privileges module (OmniOS)
 +        priv_inc = find_file('priv.h', [], inc_dirs)
 +        if priv_inc is not None:
 +            exts.append( Extension('privileges', ['privileges.c']))
 +
-+        # rbac module (Solaris)
++        # rbac module (OmniOS)
 +        secdb_inc = find_file('secdb.h', [], inc_dirs)
 +        aa_inc = find_file('auth_attr.h', [], inc_dirs)
 +        ea_inc = find_file('exec_attr.h', [], inc_dirs)
@@ -1279,295 +1569,3 @@ new file mode 100644
          # Thomas Heller's _ctypes module
          self.detect_ctypes(inc_dirs, lib_dirs)
  
---- /dev/null	2011-02-12 03:13:57.000000000 -0600
-+++ Python-2.6.4/Lib/test/privrbactest.py	2011-01-20 13:52:42.862305331 -0600
-@@ -0,0 +1,289 @@
-+#!/usr/bin/python2.7
-+#
-+# CDDL HEADER START
-+#
-+# The contents of this file are subject to the terms of the
-+# Common Development and Distribution License (the "License").
-+# You may not use this file except in compliance with the License.
-+#
-+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-+# or http://www.opensolaris.org/os/licensing.
-+# See the License for the specific language governing permissions
-+# and limitations under the License.
-+#
-+# When distributing Covered Code, include this CDDL HEADER in each
-+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-+# If applicable, add the following below this CDDL HEADER, with the
-+# fields enclosed by brackets "[]" replaced with your own identifying
-+# information: Portions Copyright [yyyy] [name of copyright owner]
-+#
-+# CDDL HEADER END
-+#
-+
-+# Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
-+
-+import privileges
-+import rbac
-+import os
-+import sys
-+import tempfile
-+
-+# privileges tests
-+
-+def test_setppriv():
-+    amchild = os.fork()
-+    if amchild == 0:
-+        if privileges.setppriv(privileges.PRIV_OFF, privileges.PRIV_EFFECTIVE, 
-+            ['proc_fork']):
-+            try:
-+                os.fork()
-+                sys.exit(1)
-+            except OSError, e:
-+                sys.exit(0)
-+
-+    child = os.wait()
-+    if child[1] is not 0:
-+        print "setppriv. Bad exit status from pid %i\n" % child[0]
-+        return False
-+    return True
-+
-+def test_getppriv():
-+    if 'proc_fork' in privileges.getppriv(privileges.PRIV_LIMIT):
-+        return True
-+    print "getppriv or PRIV_PROC_FORK not in PRIV_LIMIT.\n"
-+    return False
-+
-+def test_priv_ineffect():
-+    if privileges.priv_ineffect('proc_fork'):
-+        return True
-+    print "priv_ineffect or PRIV_PROC_FORK not in effect\n"
-+    return False
-+
-+# authattr tests
-+
-+def test_chkauthattr():
-+    try:
-+        a = rbac.authattr()
-+    except Exception, e:
-+        print "Could not instantiate authattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.chkauthattr('solaris.*', 'root')
-+    except Exception, e:
-+        print "chkauthattr failed: %s\n" % e
-+        return False
-+    if not res:
-+        print "chkauthattr failed or \'root\' lacks \'solaris.*\'\n"
-+        return False
-+    return True
-+
-+def test_getauthattr():
-+    try:
-+        a = rbac.authattr()
-+    except Exception, e:
-+        print "Could not instantiate authattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getauthattr()
-+    except Exception, e:
-+        print "getauthattr failed: %s\n" % e
-+        return False
-+    if not 'name' in res.keys():
-+        print "getauthattr failed\n"
-+        return False
-+    return True
-+
-+def test_getauthnam():
-+    try:
-+        a = rbac.authattr()
-+    except Exception, e:
-+        print "Could not instantiate authattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getauthnam('solaris.')
-+    except Exception, e:
-+        print "getauthnam failed: %s\n" % e
-+        return False
-+    if not res:
-+        print "getauthnam failed or \'solaris.\' not in auth_attr(4)\n"
-+        return False
-+    return True
-+
-+def test_authattr_iter():
-+    try:
-+        a = rbac.authattr()
-+    except Exception, e:
-+        print "Could not instantiate authattr object: %s\n" % e
-+        return False
-+    res = a.next()
-+    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
-+        print "authattr object is not an iterable\n"
-+        return False
-+    return True
-+
-+# execattr tests
-+
-+def test_getexecattr():
-+    try:
-+        a = rbac.execattr()
-+    except Exception, e:
-+        print "Could not instantiate execattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getexecattr()
-+    except Exception, e:
-+        print "getexecattr failed: %s\n" % e
-+        return False
-+    if not 'name' in res.keys():
-+        print "getexecattr failed\n"
-+        return False
-+    return True
-+
-+def test_getexecuser():
-+    try:
-+        a = rbac.execattr()
-+    except Exception, e:
-+        print "Could not instantiate execattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getexecuser("root", "act", "*;*;*;*;*")
-+    except Exception, e:
-+        print "getexecuser failed: %s\n" % e
-+        return False
-+    if not res:
-+        print "getexecuser failed or \'root\' not assigned to \'act\', " \
-+            "\'*;*;*;*;*\' \n"
-+        return False
-+    return True
-+
-+
-+def test_getexecprof():
-+    try:
-+        a = rbac.execattr()
-+    except Exception, e:
-+        print "Could not instantiate execattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getexecprof("All", "cmd", "*")
-+    except Exception, e:
-+        print "getexecprof failed: %s\n" % e
-+        return False
-+    if not res:
-+        print "getexecprof failed or \'All\' not granted \'cmd\' : \'*\'\n"
-+        return False
-+    return True
-+
-+def test_execattr_iter():
-+    try:
-+        a = rbac.execattr()
-+    except Exception, e:
-+        print "Could not instantiate execattr object: %s\n" % e
-+        return False
-+    res = a.next()
-+    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
-+        print "execattr object is not an iterable\n"
-+        return False
-+    return True
-+
-+# userattr tests
-+
-+def test_getuserattr():
-+    try:
-+        a = rbac.userattr()
-+    except Exception, e:
-+        print "Could not instantiate userattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getuserattr()
-+    except Exception, e:
-+        print "getuserattr failed: %s\n" % e
-+        return False
-+    if not 'name' in res.keys():
-+        print "getuserattr failed\n"
-+        return False
-+    return True
-+
-+def test_fgetuserattr():
-+    temp = tempfile.NamedTemporaryFile()
-+    temp.write("user::::profiles=Software Installation;roles=foo;"\
-+        "auths=solaris.foo.bar")
-+    temp.seek(0)
-+    try:
-+        a = rbac.userattr()
-+    except Exception, e:
-+        print "Could not instantiate userattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.fgetuserattr(temp.name)
-+        temp.close()    
-+    except Exception, e:
-+        print "fgetuserattr failed: %s\n" % e
-+        temp.close()
-+        return False
-+    if not 'name' in res.keys():
-+        print "fgetuserattr failed\n"
-+        return False
-+    return True
-+
-+def test_getuseruid():
-+    try:
-+        a = rbac.userattr()
-+    except Exception, e:
-+        print "Could not instantiate userattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getuseruid(0)
-+    except Exception, e:
-+        print "getusernam failed: %s\n" % e
-+        return False
-+    if not 'name' in res:
-+        print "getusernam failed or no uid 0\n"
-+        return False
-+    return True
-+
-+def test_getusernam():
-+    try:
-+        a = rbac.userattr()
-+    except Exception, e:
-+        print "Could not instantiate userattr object: %s\n" % e
-+        return False
-+    try:
-+        res = a.getusernam('root')
-+    except Exception, e:
-+        print "getusernam failed: %s\n" % e
-+        return False
-+    if not 'name' in res:
-+        print "getusernam failed or no \'root\' user\n"
-+        return False
-+    return True
-+
-+def test_userattr_iter():
-+    try:
-+        a = rbac.userattr()
-+    except Exception, e:
-+        print "Could not instantiate userattr object: %s\n" % e
-+        return False
-+    res = a.next()
-+    if not 'name' in res.keys() or type(a) != type(a.__iter__()):
-+        print "userattr object is not an iterable\n"
-+        return False
-+    return True
-+
-+if not test_setppriv() or not test_getppriv() or not test_priv_ineffect():
-+    print "*** Failures detected in privileges module\n"    
-+    sys.exit(1)
-+
-+if not test_getauthattr() or not test_chkauthattr() or not test_getauthnam() \
-+    or not test_authattr_iter:
-+    print "*** Failures detected in rbac.authattr\n"
-+    sys.exit(1)
-+
-+if not test_getexecattr() or not test_getexecuser() or not test_getexecprof() \
-+    or not test_execattr_iter():
-+    print "*** Failures detected in rbac.execattr\n"
-+    sys.exit(1)
-+
-+if not test_getuserattr() or not test_fgetuserattr() or not test_getusernam()\
-+    or not test_getuseruid() or not test_userattr_iter():
-+    print "*** Failures detected in rbac.userattr\n"
-+    sys.exit(1)

--- a/build/python27/patches/10-cflags.patch
+++ b/build/python27/patches/10-cflags.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/configure.ac.~2~	2014-05-14 13:20:24.767295632 -0700
-+++ Python-2.7.6/configure.ac	2014-05-14 13:20:25.052695991 -0700
-@@ -1083,7 +1083,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/configure.ac Python-2.7.14/configure.ac
+--- Python-2.7.14~/configure.ac	2017-09-23 22:33:27.770433096 +0000
++++ Python-2.7.14/configure.ac	2017-09-23 22:33:32.227425851 +0000
+@@ -1091,7 +1091,7 @@ then
  	;;
  
      *)

--- a/build/python27/patches/10-gethostname.patch
+++ b/build/python27/patches/10-gethostname.patch
@@ -1,7 +1,8 @@
 diff --git Python-2.6.4/Include/pyport.h Python-2.6.4/Include/pyport.h
---- Python-2.6.4/Include/pyport.h
-+++ Python-2.6.4/Include/pyport.h
-@@ -449,11 +449,6 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Include/pyport.h Python-2.7.14/Include/pyport.h
+--- Python-2.7.14~/Include/pyport.h	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Include/pyport.h	2017-09-23 22:33:32.666006639 +0000
+@@ -640,11 +640,6 @@ Please be conservative with adding new o
  in platform-specific #ifdefs.
  **************************************************************************/
  

--- a/build/python27/patches/11-closerange.patch
+++ b/build/python27/patches/11-closerange.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/Modules/posixmodule.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Modules/posixmodule.c	2014-05-14 13:22:52.461187524 -0700
-@@ -6603,16 +6603,34 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/posixmodule.c Python-2.7.14/Modules/posixmodule.c
+--- Python-2.7.14~/Modules/posixmodule.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/posixmodule.c	2017-09-23 22:33:33.108838327 +0000
+@@ -6663,16 +6663,34 @@ PyDoc_STRVAR(posix_closerange__doc__,
  "closerange(fd_low, fd_high)\n\n\
  Closes all file descriptors in [fd_low, fd_high), ignoring errors.");
  

--- a/build/python27/patches/13-pic-compile.patch
+++ b/build/python27/patches/13-pic-compile.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/Lib/distutils/sysconfig.py.~1~	2013-11-09 23:36:40.000000000 -0800
-+++ Python-2.7.6/Lib/distutils/sysconfig.py	2014-05-14 13:33:21.453593946 -0700
-@@ -208,6 +208,15 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Lib/distutils/sysconfig.py Python-2.7.14/Lib/distutils/sysconfig.py
+--- Python-2.7.14~/Lib/distutils/sysconfig.py	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Lib/distutils/sysconfig.py	2017-09-23 22:33:33.544975500 +0000
+@@ -209,6 +209,15 @@ def customize_compiler(compiler):
          else:
              archiver = ar + ' ' + ar_flags
  

--- a/build/python27/patches/14-py_db.patch
+++ b/build/python27/patches/14-py_db.patch
@@ -1,9 +1,10 @@
 This patch adds Python debugger support.  It may be contributed upstream at
 some point, but the suitability (or lack thereof) has not yet been determined.
 
---- Python-2.7.13/Makefile.pre.in.~2~	2016-12-19 19:45:55.359307641 +0300
-+++ Python-2.7.13/Makefile.pre.in	2016-12-19 19:46:55.550550819 +0300
-@@ -431,7 +431,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Makefile.pre.in Python-2.7.14/Makefile.pre.in
+--- Python-2.7.14~/Makefile.pre.in	2017-09-23 22:33:30.033406887 +0000
++++ Python-2.7.14/Makefile.pre.in	2017-09-23 22:33:33.975232643 +0000
+@@ -403,7 +403,7 @@ LIBRARY_OBJS=	\
  
  # Default target
  all:		@DEF_MAKE_ALL_RULE@
@@ -12,7 +13,7 @@ some point, but the suitability (or lack thereof) has not yet been determined.
  
  # Compile a binary with profile guided optimization.
  profile-opt:
-@@ -856,6 +856,15 @@
+@@ -844,6 +844,15 @@ PYTHON_HEADERS= \
  
  $(LIBRARY_OBJS) $(MODOBJS) Modules/python.o: $(PYTHON_HEADERS)
  
@@ -28,7 +29,7 @@ some point, but the suitability (or lack thereof) has not yet been determined.
  
  ######################################################################
  
-@@ -920,7 +929,7 @@
+@@ -913,7 +922,7 @@ memtest:	@DEF_MAKE_RULE@ platform
  		$(TESTPYTHON) $(TESTPROG) $(MEMTESTOPTS)
  
  # Install everything
@@ -37,8 +38,9 @@ some point, but the suitability (or lack thereof) has not yet been determined.
  	if test "x$(ENSUREPIP)" != "xno"  ; then \
  		case $(ENSUREPIP) in \
  			upgrade) ensurepip="--upgrade" ;; \
---- /dev/null
-+++ Python-2.7.1/py_db/libpython27_db.c
+diff -pruN '--exclude=*.orig' Python-2.7.14~/py_db/libpython27_db.c Python-2.7.14/py_db/libpython27_db.c
+--- Python-2.7.14~/py_db/libpython27_db.c	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/py_db/libpython27_db.c	2017-09-23 22:33:33.975781153 +0000
 @@ -0,0 +1,654 @@
 +/*
 + * CDDL HEADER START
@@ -694,10 +696,9 @@ some point, but the suitability (or lack thereof) has not yet been determined.
 +
 +	free(iter);
 +}
-diff --git Python-2.7.1/py_db/libpython27_db.h Python-2.7.1/py_db/libpython27_db.h
-new file mode 100644
---- /dev/null
-+++ Python-2.7.1/py_db/libpython27_db.h
+diff -pruN '--exclude=*.orig' Python-2.7.14~/py_db/libpython27_db.h Python-2.7.14/py_db/libpython27_db.h
+--- Python-2.7.14~/py_db/libpython27_db.h	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/py_db/libpython27_db.h	2017-09-23 22:33:33.975886274 +0000
 @@ -0,0 +1,73 @@
 +/*
 + * CDDL HEADER START
@@ -772,10 +773,9 @@ new file mode 100644
 +#endif
 +
 +#endif	/* _LIBPYTHON27_DB_H */
-diff --git Python-2.7.1/py_db/libpython27_db_32.h Python-2.7.1/py_db/libpython27_db_32.h
-new file mode 100644
---- /dev/null
-+++ Python-2.7.1/py_db/libpython27_db_32.h
+diff -pruN '--exclude=*.orig' Python-2.7.14~/py_db/libpython27_db_32.h Python-2.7.14/py_db/libpython27_db_32.h
+--- Python-2.7.14~/py_db/libpython27_db_32.h	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/py_db/libpython27_db_32.h	2017-09-23 22:33:33.975993171 +0000
 @@ -0,0 +1,121 @@
 +/*
 + * CDDL HEADER START
@@ -898,10 +898,9 @@ new file mode 100644
 +#endif
 +
 +#endif	/* _LIBPYTHON27_DB_32_H */
-diff --git Python-2.7.1/py_db/mapfile-vers Python-2.7.1/py_db/mapfile-vers
-new file mode 100644
---- /dev/null
-+++ Python-2.7.1/py_db/mapfile-vers
+diff -pruN '--exclude=*.orig' Python-2.7.14~/py_db/mapfile-vers Python-2.7.14/py_db/mapfile-vers
+--- Python-2.7.14~/py_db/mapfile-vers	1970-01-01 00:00:00.000000000 +0000
++++ Python-2.7.14/py_db/mapfile-vers	2017-09-23 22:33:33.976071285 +0000
 @@ -0,0 +1,39 @@
 +#
 +# CDDL HEADER START

--- a/build/python27/patches/15-get_wch.patch
+++ b/build/python27/patches/15-get_wch.patch
@@ -1,6 +1,7 @@
---- Python-2.7.6/Modules/_cursesmodule.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Modules/_cursesmodule.c	2014-05-14 13:36:59.388642793 -0700
-@@ -861,6 +861,37 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/_cursesmodule.c Python-2.7.14/Modules/_cursesmodule.c
+--- Python-2.7.14~/Modules/_cursesmodule.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/_cursesmodule.c	2017-09-23 22:33:34.410720954 +0000
+@@ -863,6 +863,37 @@ PyCursesWindow_GetCh(PyCursesWindowObjec
  }
  
  static PyObject *
@@ -38,7 +39,7 @@
  PyCursesWindow_GetKey(PyCursesWindowObject *self, PyObject *args)
  {
      int x, y;
-@@ -1572,6 +1603,7 @@
+@@ -1590,6 +1621,7 @@ static PyMethodDef PyCursesWindow_Method
      {"getbegyx",        (PyCFunction)PyCursesWindow_getbegyx, METH_NOARGS},
      {"getbkgd",         (PyCFunction)PyCursesWindow_GetBkgd, METH_NOARGS},
      {"getch",           (PyCFunction)PyCursesWindow_GetCh, METH_VARARGS},

--- a/build/python27/patches/16-ossaudiodev.patch
+++ b/build/python27/patches/16-ossaudiodev.patch
@@ -1,9 +1,10 @@
 This patch is needed to make Python understand it can build the OSS plugin.  
-Some OSS ioctls are not supported on Solaris, so they are commented out.
+Some OSS ioctls are not supported on OmniOS, so they are commented out.
 
---- Python-2.7.3/Modules/ossaudiodev.c-orig	2012-12-20 12:26:23.028233427 -0600
-+++ Python-2.7.3/Modules/ossaudiodev.c	2012-12-20 12:26:33.130986175 -0600
-@@ -1044,6 +1044,7 @@ initossaudiodev(void)
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/ossaudiodev.c Python-2.7.14/Modules/ossaudiodev.c
+--- Python-2.7.14~/Modules/ossaudiodev.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/ossaudiodev.c	2017-09-23 22:33:34.850335424 +0000
+@@ -1037,6 +1037,7 @@ initossaudiodev(void)
      _EXPORT_INT(m, SOUND_MIXER_MONITOR);
  #endif
  
@@ -11,7 +12,7 @@ Some OSS ioctls are not supported on Solaris, so they are commented out.
      /* Expose all the ioctl numbers for masochists who like to do this
         stuff directly. */
      _EXPORT_INT(m, SNDCTL_COPR_HALT);
-@@ -1056,6 +1057,7 @@ initossaudiodev(void)
+@@ -1049,6 +1050,7 @@ initossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_COPR_SENDMSG);
      _EXPORT_INT(m, SNDCTL_COPR_WCODE);
      _EXPORT_INT(m, SNDCTL_COPR_WDATA);
@@ -19,7 +20,7 @@ Some OSS ioctls are not supported on Solaris, so they are commented out.
  #ifdef SNDCTL_DSP_BIND_CHANNEL
      _EXPORT_INT(m, SNDCTL_DSP_BIND_CHANNEL);
  #endif
-@@ -1077,8 +1079,12 @@ initossaudiodev(void)
+@@ -1070,8 +1072,12 @@ initossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_DSP_GETSPDIF);
  #endif
      _EXPORT_INT(m, SNDCTL_DSP_GETTRIGGER);
@@ -32,7 +33,7 @@ Some OSS ioctls are not supported on Solaris, so they are commented out.
      _EXPORT_INT(m, SNDCTL_DSP_NONBLOCK);
      _EXPORT_INT(m, SNDCTL_DSP_POST);
  #ifdef SNDCTL_DSP_PROFILE
-@@ -1098,6 +1104,7 @@ initossaudiodev(void)
+@@ -1091,6 +1097,7 @@ initossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_DSP_STEREO);
      _EXPORT_INT(m, SNDCTL_DSP_SUBDIVIDE);
      _EXPORT_INT(m, SNDCTL_DSP_SYNC);
@@ -40,15 +41,16 @@ Some OSS ioctls are not supported on Solaris, so they are commented out.
      _EXPORT_INT(m, SNDCTL_FM_4OP_ENABLE);
      _EXPORT_INT(m, SNDCTL_FM_LOAD_INSTR);
      _EXPORT_INT(m, SNDCTL_MIDI_INFO);
-@@ -1139,4 +1146,5 @@ initossaudiodev(void)
+@@ -1132,4 +1139,5 @@ initossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_TMR_STOP);
      _EXPORT_INT(m, SNDCTL_TMR_TEMPO);
      _EXPORT_INT(m, SNDCTL_TMR_TIMEBASE);
 +#endif
  }
---- Python-2.7.6/setup.py.~5~	2014-05-14 13:37:59.287142508 -0700
-+++ Python-2.7.6/setup.py	2014-05-14 13:40:01.472280298 -0700
-@@ -1632,8 +1632,8 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:31.783529834 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:34.850956604 +0000
+@@ -1669,8 +1669,8 @@ class PyBuildExt(build_ext):
          else:
              missing.append('linuxaudiodev')
  

--- a/build/python27/patches/18-osconf-long.patch
+++ b/build/python27/patches/18-osconf-long.patch
@@ -1,9 +1,10 @@
 # http://bugs.python.org/issue17964 was fixed in 3.4 but not back-ported so we
 # need this patch for 2.7 .
 
---- Python-2.7.6/Modules/posixmodule.c.~2~	2014-05-14 13:45:28.562707441 -0700
-+++ Python-2.7.6/Modules/posixmodule.c	2014-05-14 13:45:28.718886370 -0700
-@@ -8469,7 +8469,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/posixmodule.c Python-2.7.14/Modules/posixmodule.c
+--- Python-2.7.14~/Modules/posixmodule.c	2017-09-23 22:33:33.108838327 +0000
++++ Python-2.7.14/Modules/posixmodule.c	2017-09-23 22:33:35.290845498 +0000
+@@ -8566,7 +8566,7 @@ posix_sysconf(PyObject *self, PyObject *
      int name;
  
      if (PyArg_ParseTuple(args, "O&:sysconf", conv_sysconf_confname, &name)) {

--- a/build/python27/patches/19-recvfrom_into.patch
+++ b/build/python27/patches/19-recvfrom_into.patch
@@ -1,9 +1,10 @@
 # Fix from upstream: http://bugs.python.org/issue20246
 
---- Python-2.7.6/Modules/socketmodule.c.~1~	2013-11-09 23:36:41.000000000 -0800
-+++ Python-2.7.6/Modules/socketmodule.c	2014-05-14 13:48:12.538122707 -0700
-@@ -2744,6 +2744,13 @@
-         recvlen = buflen;
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/socketmodule.c Python-2.7.14/Modules/socketmodule.c
+--- Python-2.7.14~/Modules/socketmodule.c	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/socketmodule.c	2017-09-23 22:33:35.732989166 +0000
+@@ -2768,6 +2768,13 @@ sock_recvfrom_into(PySocketSockObject *s
+         goto error;
      }
  
 +    /* Check if the buffer is large enough */

--- a/build/python27/patches/20-bsddb-harmful.patch
+++ b/build/python27/patches/20-bsddb-harmful.patch
@@ -3,9 +3,10 @@ Starting with 2.7.4, the behavior is different, and it causes tests to
 dump core.  So skip it.  The module is removed in Python 3, so this patch
 is not being submitted upstream.
 
---- Python-2.7.13/Makefile.pre.in.~3~	2016-12-19 19:49:29.882892296 +0300
-+++ Python-2.7.13/Makefile.pre.in	2016-12-19 19:49:29.987869375 +0300
-@@ -1073,7 +1073,7 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Makefile.pre.in Python-2.7.14/Makefile.pre.in
+--- Python-2.7.14~/Makefile.pre.in	2017-09-23 22:33:33.975232643 +0000
++++ Python-2.7.14/Makefile.pre.in	2017-09-23 22:33:36.173108438 +0000
+@@ -1067,7 +1067,7 @@ LIBSUBDIRS=	lib-tk lib-tk/test lib-tk/te
  		ensurepip ensurepip/_bundled \
  		json json/tests \
  		sqlite3 sqlite3/test \
@@ -14,9 +15,10 @@ is not being submitted upstream.
  		lib2to3 lib2to3/fixes lib2to3/pgen2 lib2to3/tests \
  		lib2to3/tests/data lib2to3/tests/data/fixers lib2to3/tests/data/fixers/myfixes \
  		ctypes ctypes/test ctypes/macholib \
---- Python-2.7.6/setup.py.~6~	2014-05-14 17:15:45.315760008 -0700
-+++ Python-2.7.6/setup.py	2014-05-14 17:16:27.440642039 -0700
-@@ -1065,7 +1065,8 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:34.850956604 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:36.173762596 +0000
+@@ -1090,7 +1090,8 @@ class PyBuildExt(build_ext):
                                      db_dirs_to_check + lib_dirs, dblib )
                      if dblib_file:
                          dblib_dir = [ os.path.abspath(os.path.dirname(dblib_file)) ]

--- a/build/python27/patches/multiprocessing-hack.patch
+++ b/build/python27/patches/multiprocessing-hack.patch
@@ -1,5 +1,6 @@
---- Python-2.7.13/Modules/_multiprocessing/multiprocessing.h.orig	Wed Dec 21 18:38:23 2016
-+++ Python-2.7.13/Modules/_multiprocessing/multiprocessing.h	Wed Dec 21 18:38:27 2016
+diff -pruN '--exclude=*.orig' Python-2.7.14~/Modules/_multiprocessing/multiprocessing.h Python-2.7.14/Modules/_multiprocessing/multiprocessing.h
+--- Python-2.7.14~/Modules/_multiprocessing/multiprocessing.h	2017-09-16 17:38:35.000000000 +0000
++++ Python-2.7.14/Modules/_multiprocessing/multiprocessing.h	2017-09-23 22:33:37.051074204 +0000
 @@ -7,6 +7,7 @@
  /* The control message API is only available on Solaris 
     if XPG 4.2 or later is requested. */

--- a/build/python27/patches/ncurses-setup.patch
+++ b/build/python27/patches/ncurses-setup.patch
@@ -1,6 +1,7 @@
---- Python-2.7.8/setup.py.~7~	2014-07-09 10:01:47.977524330 +0400
-+++ Python-2.7.8/setup.py	2014-07-09 10:06:22.690906040 +0400
-@@ -1349,20 +1349,37 @@
+diff -pruN '--exclude=*.orig' Python-2.7.14~/setup.py Python-2.7.14/setup.py
+--- Python-2.7.14~/setup.py	2017-09-23 22:33:36.173762596 +0000
++++ Python-2.7.14/setup.py	2017-09-23 22:33:36.609931190 +0000
+@@ -1371,20 +1371,37 @@ class PyBuildExt(build_ext):
  
          # Curses support, requiring the System V version of curses, often
          # provided by the ncurses library.
@@ -8,7 +9,7 @@
 +        curses_inc_dirs = []
 +        curses_incs = []
 +        if host_platform == 'sunos5':
-+            # look for ncurses in /usr/gnu on Solaris
++            # look for ncurses in /usr/gnu on OmniOS
 +            curses_inc_dirs.append('/usr/include/ncurses')
 +            curses_lib_dirs.append('/usr/gnu/lib')
 +            if os.path.exists('/usr/gnu/lib/sparcv9'):
@@ -46,7 +47,7 @@
                  # OSX has an old Berkeley curses, not good enough for
                  # the _curses module.
              if (self.compiler.find_library_file(lib_dirs, 'terminfo')):
-@@ -1379,10 +1396,12 @@
+@@ -1401,10 +1418,12 @@ class PyBuildExt(build_ext):
  
          # If the curses module is enabled, check for the panel module
          if (module_enabled(exts, '_curses') and

--- a/build/python27/patches/series
+++ b/build/python27/patches/series
@@ -3,7 +3,7 @@
 02-setup.patch 
 03-vendor-packages.patch 
 04-solaris-64-bit.patch 
-05-dtrace.patch 
+05-dtrace.patch
 06-ucred.patch 
 07-dlpi.patch 
 08-encoding-alias.patch 

--- a/build/python27/testsuite.log
+++ b/build/python27/testsuite.log
@@ -6,266 +6,269 @@ dl                 gdbm               imageop
 linuxaudiodev                                         
 To find the necessary bits, look in setup.py in detect_modules() for the module's name.
 
-== CPython 2.7.13 (default, Sep 1 2017, 10:58:39) [GCC 5.4.0]
+== CPython 2.7.14 (default, Sep 23 2017, 16:34:57) [GCC 5.4.0]
 ==   Solaris-2.11-i86pc-i386-64bit-ELF little-endian
-==   /data/omnios-build/omniosorg/_build/Python-2.7.13/build/test_python_19743
-Testing with flags: sys.flags(debug=0, py3k_warning=1, division_warning=1, division_new=0, inspect=0, interactive=0, optimize=0, dont_write_bytecode=0, no_user_site=0, no_site=0, ignore_environment=1, tabcheck=2, verbose=0, unicode=0, bytes_warning=0, hash_randomization=0)
-[  1/401] test_grammar
-[  2/401] test_opcodes
-[  3/401] test_dict
-[  4/401] test_builtin
-[  5/401] test_exceptions
-[  6/401] test_types
-[  7/401] test_unittest
-[  8/401] test_doctest
-[  9/401] test_doctest2
-[ 10/401] test_MimeWriter
-[ 11/401] test_SimpleHTTPServer
-[ 12/401] test_StringIO
-[ 13/401] test___all__
-[ 14/401] test___future__
-[ 15/401] test__locale
-[ 16/401] test__osx_support
-[ 17/401] test_abc
-[ 18/401] test_abstract_numbers
-[ 19/401] test_aepack
+==   /data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/build/test_python_5316
+== CPU count: 8
+Run tests sequentially
+0:00:00 load avg: 0.00 [  1/403] test_grammar
+0:00:00 load avg: 0.00 [  2/403] test_opcodes
+0:00:00 load avg: 0.00 [  3/403] test_dict
+0:00:00 load avg: 0.00 [  4/403] test_builtin
+0:00:00 load avg: 0.00 [  5/403] test_exceptions
+0:00:00 load avg: 0.00 [  6/403] test_types
+0:00:00 load avg: 0.00 [  7/403] test_unittest
+0:00:00 load avg: 0.00 [  8/403] test_doctest
+0:00:00 load avg: 0.00 [  9/403] test_doctest2
+0:00:00 load avg: 0.00 [ 10/403] test_MimeWriter
+0:00:00 load avg: 0.00 [ 11/403] test_SimpleHTTPServer
+0:00:00 load avg: 0.00 [ 12/403] test_StringIO
+0:00:01 load avg: 0.00 [ 13/403] test___all__
+0:00:02 load avg: 0.00 [ 14/403] test___future__
+0:00:02 load avg: 0.00 [ 15/403] test__locale
+0:00:02 load avg: 0.00 [ 16/403] test__osx_support
+0:00:02 load avg: 0.00 [ 17/403] test_abc
+0:00:02 load avg: 0.00 [ 18/403] test_abstract_numbers
+0:00:02 load avg: 0.00 [ 19/403] test_aepack
 test_aepack skipped -- No module named aetypes
-[ 20/401] test_aifc
-[ 21/401] test_al
+0:00:02 load avg: 0.00 [ 20/403] test_aifc -- test_aepack skipped
+0:00:02 load avg: 0.00 [ 21/403] test_al
 test_al skipped -- No module named al
-[ 22/401] test_anydbm
-[ 23/401] test_applesingle
+0:00:02 load avg: 0.00 [ 22/403] test_anydbm -- test_al skipped
+0:00:02 load avg: 0.00 [ 23/403] test_applesingle
 test_applesingle skipped -- No module named MacOS
-[ 24/401] test_argparse
-[ 25/401] test_array
-[ 26/401] test_ascii_formatd
-[ 27/401] test_ast
-[ 28/401] test_asynchat
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:02 load avg: 0.00 [ 24/403] test_argparse -- test_applesingle skipped
+0:00:03 load avg: 0.01 [ 25/403] test_array
+0:00:04 load avg: 0.02 [ 26/403] test_ascii_formatd
+0:00:04 load avg: 0.02 [ 27/403] test_ast
+0:00:04 load avg: 0.02 [ 28/403] test_asynchat
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 29/401] test_asyncore
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:12 load avg: 0.07 [ 29/403] test_asyncore
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 30/401] test_atexit
-[ 31/401] test_audioop
-[ 32/401] test_augassign
-[ 33/401] test_base64
-[ 34/401] test_bastion
-[ 35/401] test_bigaddrspace
-[ 36/401] test_bigmem
-[ 37/401] test_binascii
-[ 38/401] test_binhex
-[ 39/401] test_binop
-[ 40/401] test_bisect
-[ 41/401] test_bool
-[ 42/401] test_bsddb
+0:00:13 load avg: 0.07 [ 30/403] test_atexit
+0:00:13 load avg: 0.07 [ 31/403] test_audioop
+0:00:13 load avg: 0.07 [ 32/403] test_augassign
+0:00:13 load avg: 0.07 [ 33/403] test_base64
+0:00:14 load avg: 0.07 [ 34/403] test_bastion
+0:00:14 load avg: 0.07 [ 35/403] test_bigaddrspace
+0:00:14 load avg: 0.07 [ 36/403] test_bigmem
+0:00:14 load avg: 0.07 [ 37/403] test_binascii
+0:00:14 load avg: 0.07 [ 38/403] test_binhex
+0:00:14 load avg: 0.07 [ 39/403] test_binop
+0:00:14 load avg: 0.07 [ 40/403] test_bisect
+0:00:14 load avg: 0.07 [ 41/403] test_bool
+0:00:14 load avg: 0.07 [ 42/403] test_bsddb
 test_bsddb skipped -- No module named _bsddb
-[ 43/401] test_bsddb185
+0:00:14 load avg: 0.07 [ 43/403] test_bsddb185 -- test_bsddb skipped
 test_bsddb185 skipped -- No module named bsddb185
-[ 44/401] test_bsddb3
+0:00:14 load avg: 0.07 [ 44/403] test_bsddb3 -- test_bsddb185 skipped
 test_bsddb3 skipped -- No module named _bsddb
-[ 45/401] test_buffer
-[ 46/401] test_bufio
-[ 47/401] test_bytes
-[ 48/401] test_bz2
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:14 load avg: 0.07 [ 45/403] test_buffer -- test_bsddb3 skipped
+0:00:14 load avg: 0.07 [ 46/403] test_bufio
+0:00:15 load avg: 0.08 [ 47/403] test_bytes
+0:00:16 load avg: 0.08 [ 48/403] test_bz2
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 49/401] test_calendar
-[ 50/401] test_call
-[ 51/401] test_capi
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:16 load avg: 0.08 [ 49/403] test_calendar
+0:00:19 load avg: 0.10 [ 50/403] test_call
+0:00:19 load avg: 0.10 [ 51/403] test_capi
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 52/401] test_cd
+0:00:22 load avg: 0.12 [ 52/403] test_cd
 test_cd skipped -- No module named cd
-[ 53/401] test_cfgparser
-[ 54/401] test_cgi
-[ 55/401] test_charmapcodec
-[ 56/401] test_cl
+0:00:22 load avg: 0.12 [ 53/403] test_cfgparser -- test_cd skipped
+0:00:22 load avg: 0.12 [ 54/403] test_cgi
+0:00:22 load avg: 0.12 [ 55/403] test_charmapcodec
+0:00:22 load avg: 0.12 [ 56/403] test_cl
 test_cl skipped -- No module named cl
-[ 57/401] test_class
-[ 58/401] test_cmath
-[ 59/401] test_cmd
-[ 60/401] test_cmd_line
-[ 61/401] test_cmd_line_script
-[ 62/401] test_code
-[ 63/401] test_codeccallbacks
-[ 64/401] test_codecencodings_cn
-[ 65/401] test_codecencodings_hk
-[ 66/401] test_codecencodings_iso2022
-[ 67/401] test_codecencodings_jp
-[ 68/401] test_codecencodings_kr
-[ 69/401] test_codecencodings_tw
-[ 70/401] test_codecmaps_cn
+0:00:22 load avg: 0.12 [ 57/403] test_class -- test_cl skipped
+0:00:22 load avg: 0.12 [ 58/403] test_cmath
+0:00:22 load avg: 0.12 [ 59/403] test_cmd
+0:00:22 load avg: 0.12 [ 60/403] test_cmd_line
+0:00:23 load avg: 0.13 [ 61/403] test_cmd_line_script
+0:00:24 load avg: 0.14 [ 62/403] test_code
+0:00:24 load avg: 0.14 [ 63/403] test_codeccallbacks
+0:00:24 load avg: 0.14 [ 64/403] test_codecencodings_cn
+0:00:24 load avg: 0.14 [ 65/403] test_codecencodings_hk
+0:00:24 load avg: 0.14 [ 66/403] test_codecencodings_iso2022
+0:00:25 load avg: 0.15 [ 67/403] test_codecencodings_jp
+0:00:25 load avg: 0.15 [ 68/403] test_codecencodings_kr
+0:00:25 load avg: 0.15 [ 69/403] test_codecencodings_tw
+0:00:25 load avg: 0.15 [ 70/403] test_codecmaps_cn
 test_codecmaps_cn skipped -- Use of the `urlfetch' resource not enabled
-[ 71/401] test_codecmaps_hk
+0:00:25 load avg: 0.15 [ 71/403] test_codecmaps_hk -- test_codecmaps_cn skipped (resource denied)
 test_codecmaps_hk skipped -- Use of the `urlfetch' resource not enabled
-[ 72/401] test_codecmaps_jp
+0:00:25 load avg: 0.15 [ 72/403] test_codecmaps_jp -- test_codecmaps_hk skipped (resource denied)
 test_codecmaps_jp skipped -- Use of the `urlfetch' resource not enabled
-[ 73/401] test_codecmaps_kr
+0:00:25 load avg: 0.15 [ 73/403] test_codecmaps_kr -- test_codecmaps_jp skipped (resource denied)
 test_codecmaps_kr skipped -- Use of the `urlfetch' resource not enabled
-[ 74/401] test_codecmaps_tw
+0:00:26 load avg: 0.15 [ 74/403] test_codecmaps_tw -- test_codecmaps_kr skipped (resource denied)
 test_codecmaps_tw skipped -- Use of the `urlfetch' resource not enabled
-[ 75/401] test_codecs
-[ 76/401] test_codeop
-[ 77/401] test_coercion
-[ 78/401] test_collections
-[ 79/401] test_colorsys
-[ 80/401] test_commands
-[ 81/401] test_compare
-[ 82/401] test_compile
-[ 83/401] test_compileall
-[ 84/401] test_compiler
-[ 85/401] test_complex
-[ 86/401] test_complex_args
-[ 87/401] test_contains
-[ 88/401] test_contextlib
-[ 89/401] test_cookie
-[ 90/401] test_cookielib
-[ 91/401] test_copy
-[ 92/401] test_copy_reg
-[ 93/401] test_cpickle
-[ 94/401] test_cprofile
-[ 95/401] test_crypt
-[ 96/401] test_csv
-[ 97/401] test_ctypes
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:26 load avg: 0.16 [ 75/403] test_codecs -- test_codecmaps_tw skipped (resource denied)
+0:00:27 load avg: 0.17 [ 76/403] test_codeop
+0:00:27 load avg: 0.17 [ 77/403] test_coercion
+0:00:27 load avg: 0.17 [ 78/403] test_collections
+0:00:27 load avg: 0.17 [ 79/403] test_colorsys
+0:00:27 load avg: 0.17 [ 80/403] test_commands
+0:00:27 load avg: 0.17 [ 81/403] test_compare
+0:00:27 load avg: 0.17 [ 82/403] test_compile
+0:00:27 load avg: 0.17 [ 83/403] test_compileall
+0:00:27 load avg: 0.17 [ 84/403] test_compiler
+0:00:28 load avg: 0.17 [ 85/403] test_complex
+0:00:28 load avg: 0.18 [ 86/403] test_complex_args
+0:00:28 load avg: 0.18 [ 87/403] test_contains
+0:00:28 load avg: 0.18 [ 88/403] test_contextlib
+0:00:28 load avg: 0.18 [ 89/403] test_cookie
+0:00:28 load avg: 0.18 [ 90/403] test_cookielib
+0:00:28 load avg: 0.18 [ 91/403] test_copy
+0:00:28 load avg: 0.18 [ 92/403] test_copy_reg
+0:00:28 load avg: 0.18 [ 93/403] test_cpickle
+0:00:30 load avg: 0.20 [ 94/403] test_cprofile
+0:00:30 load avg: 0.20 [ 95/403] test_crypt
+0:00:30 load avg: 0.20 [ 96/403] test_csv
+0:00:30 load avg: 0.20 [ 97/403] test_ctypes
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 98/401] test_curses
+0:00:31 load avg: 0.21 [ 98/403] test_curses
 test_curses skipped -- Use of the `curses' resource not enabled
-[ 99/401] test_datetime
-[100/401] test_dbm
-[101/401] test_decimal
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:31 load avg: 0.21 [ 99/403] test_datetime -- test_curses skipped (resource denied)
+0:00:32 load avg: 0.23 [100/403] test_dbm
+0:00:32 load avg: 0.23 [101/403] test_decimal
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[102/401] test_decorators
-[103/401] test_defaultdict
-[104/401] test_deque
-[105/401] test_descr
-[106/401] test_descrtut
-[107/401] test_dictcomps
-[108/401] test_dictviews
-[109/401] test_difflib
-[110/401] test_dircache
-[111/401] test_dis
-[112/401] test_distutils
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/distutils/command/build_ext.py:686: DeprecationWarning: apply() not supported in 3.x; use func(*args, **kwargs)
+0:00:33 load avg: 0.24 [102/403] test_decorators
+0:00:33 load avg: 0.24 [103/403] test_defaultdict
+0:00:33 load avg: 0.24 [104/403] test_deque
+0:00:35 load avg: 0.26 [105/403] test_descr
+0:00:36 load avg: 0.27 [106/403] test_descrtut
+0:00:36 load avg: 0.27 [107/403] test_dictcomps
+0:00:36 load avg: 0.27 [108/403] test_dictviews
+0:00:36 load avg: 0.27 [109/403] test_difflib
+0:00:37 load avg: 0.29 [110/403] test_dircache
+0:00:38 load avg: 0.30 [111/403] test_dis
+0:00:38 load avg: 0.30 [112/403] test_distutils
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/distutils/command/build_ext.py:686: DeprecationWarning: apply() not supported in 3.x; use func(*args, **kwargs)
   path = apply(os.path.join, ext_path)
 test test_distutils failed -- multiple errors occurred; run in verbose mode for details
-[113/401/1] test_dl
+0:00:39 load avg: 0.30 [113/403/1] test_dl -- test_distutils failed
 test_dl skipped -- No module named dl
-[114/401/1] test_docxmlrpc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:39 load avg: 0.30 [114/403/1] test_docxmlrpc -- test_dl skipped
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[115/401/1] test_dumbdbm
-[116/401/1] test_dummy_thread
-[117/401/1] test_dummy_threading
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:42 load avg: 0.33 [115/403/1] test_dumbdbm
+0:00:43 load avg: 0.33 [116/403/1] test_dummy_thread
+0:00:43 load avg: 0.33 [117/403/1] test_dummy_threading
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[118/401/1] test_email
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:43 load avg: 0.33 [118/403/1] test_email
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[119/401/1] test_email_codecs
-[120/401/1] test_email_renamed
-[121/401/1] test_ensurepip
-[122/401/1] test_enumerate
-[123/401/1] test_eof
-[124/401/1] test_epoll
-[125/401/1] test_errno
-[126/401/1] test_exception_variations
-[127/401/1] test_extcall
-[128/401/1] test_fcntl
-[129/401/1] test_file
-[130/401/1] test_file2k
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:46 load avg: 0.36 [119/403/1] test_email_codecs
+0:00:46 load avg: 0.36 [120/403/1] test_email_renamed
+0:00:47 load avg: 0.38 [121/403/1] test_ensurepip
+0:00:47 load avg: 0.38 [122/403/1] test_enumerate
+0:00:47 load avg: 0.38 [123/403/1] test_eof
+0:00:47 load avg: 0.38 [124/403/1] test_epoll
+0:00:49 load avg: 0.41 [125/403/1] test_errno
+0:00:49 load avg: 0.41 [126/403/1] test_exception_variations
+0:00:49 load avg: 0.41 [127/403/1] test_extcall
+0:00:49 load avg: 0.41 [128/403/1] test_fcntl
+0:00:49 load avg: 0.41 [129/403/1] test_file
+0:00:49 load avg: 0.41 [130/403/1] test_file2k
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[131/401/1] test_file_eintr
-[132/401/1] test_filecmp
-[133/401/1] test_fileinput
-[134/401/1] test_fileio
-[135/401/1] test_float
-[136/401/1] test_fnmatch
-[137/401/1] test_fork1
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:57 load avg: 0.59 [131/403/1] test_file_eintr
+0:00:58 load avg: 0.61 [132/403/1] test_filecmp
+0:00:58 load avg: 0.61 [133/403/1] test_fileinput
+0:00:58 load avg: 0.61 [134/403/1] test_fileio
+0:00:58 load avg: 0.61 [135/403/1] test_float
+0:00:58 load avg: 0.61 [136/403/1] test_fnmatch
+0:00:58 load avg: 0.61 [137/403/1] test_fork1
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[138/401/1] test_format
-[139/401/1] test_fpformat
-[140/401/1] test_fractions
-[141/401/1] test_frozen
-[142/401/1] test_ftplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:05 load avg: 0.64 [138/403/1] test_format
+0:01:06 load avg: 0.64 [139/403/1] test_fpformat
+0:01:06 load avg: 0.64 [140/403/1] test_fractions
+0:01:06 load avg: 0.64 [141/403/1] test_frozen
+0:01:06 load avg: 0.64 [142/403/1] test_ftplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[143/401/1] test_funcattrs
-[144/401/1] test_functools
-[145/401/1] test_future
-[146/401/1] test_future3
-[147/401/1] test_future4
-[148/401/1] test_future5
-[149/401/1] test_future_builtins
-[150/401/1] test_gc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:07 load avg: 0.63 [143/403/1] test_funcattrs
+0:01:07 load avg: 0.63 [144/403/1] test_functools
+0:01:07 load avg: 0.63 [145/403/1] test_future
+0:01:07 load avg: 0.63 [146/403/1] test_future3
+0:01:07 load avg: 0.63 [147/403/1] test_future4
+0:01:07 load avg: 0.63 [148/403/1] test_future5
+0:01:07 load avg: 0.63 [149/403/1] test_future_builtins
+0:01:07 load avg: 0.63 [150/403/1] test_gc
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[151/401/1] test_gdb
+0:01:09 load avg: 0.62 [151/403/1] test_gdb
 test_gdb skipped -- Couldn't find gdb on the path
-[152/401/1] test_gdbm
+0:01:09 load avg: 0.62 [152/403/1] test_gdbm -- test_gdb skipped
 test_gdbm skipped -- No module named gdbm
-[153/401/1] test_generators
-[154/401/1] test_genericpath
-[155/401/1] test_genexps
-[156/401/1] test_getargs
-[157/401/1] test_getargs2
-[158/401/1] test_getopt
-[159/401/1] test_gettext
-[160/401/1] test_gl
+0:01:10 load avg: 0.62 [153/403/1] test_generators -- test_gdbm skipped
+0:01:10 load avg: 0.62 [154/403/1] test_genericpath
+0:01:10 load avg: 0.62 [155/403/1] test_genexps
+0:01:10 load avg: 0.62 [156/403/1] test_getargs
+0:01:10 load avg: 0.62 [157/403/1] test_getargs2
+0:01:10 load avg: 0.62 [158/403/1] test_getopt
+0:01:10 load avg: 0.62 [159/403/1] test_gettext
+0:01:10 load avg: 0.62 [160/403/1] test_gl
 test_gl skipped -- No module named gl
-[161/401/1] test_glob
-[162/401/1] test_global
-[163/401/1] test_grp
-[164/401/1] test_gzip
-[165/401/1] test_hash
-[166/401/1] test_hashlib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:10 load avg: 0.62 [161/403/1] test_glob -- test_gl skipped
+0:01:10 load avg: 0.62 [162/403/1] test_global
+0:01:10 load avg: 0.62 [163/403/1] test_grp
+0:01:10 load avg: 0.62 [164/403/1] test_gzip
+0:01:12 load avg: 0.61 [165/403/1] test_hash
+0:01:13 load avg: 0.61 [166/403/1] test_hashlib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[167/401/1] test_heapq
-[168/401/1] test_hmac
-[169/401/1] test_hotshot
-[170/401/1] test_htmllib
-[171/401/1] test_htmlparser
-[172/401/1] test_httplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:13 load avg: 0.61 [167/403/1] test_heapq
+0:01:14 load avg: 0.61 [168/403/1] test_hmac
+0:01:14 load avg: 0.61 [169/403/1] test_hotshot
+0:01:14 load avg: 0.61 [170/403/1] test_htmllib
+0:01:14 load avg: 0.61 [171/403/1] test_htmlparser
+0:01:14 load avg: 0.61 [172/403/1] test_httplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[173/401/1] test_httpservers
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:14 load avg: 0.61 [173/403/1] test_httpservers
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[174/401/1] test_idle
+0:01:17 load avg: 0.61 [174/403/1] test_idle
 test_idle skipped -- No module named _tkinter
-[175/401/1] test_imageop
+0:01:17 load avg: 0.61 [175/403/1] test_imageop -- test_idle skipped
 test_imageop skipped -- No module named imageop
-[176/401/1] test_imaplib
-[177/401/1] test_imgfile
+0:01:17 load avg: 0.61 [176/403/1] test_imaplib -- test_imageop skipped
+0:01:17 load avg: 0.61 [177/403/1] test_imgfile
 test_imgfile skipped -- No module named imgfile
-[178/401/1] test_imghdr
-[179/401/1] test_imp
-[180/401/1] test_import
-Warning -- sys.path was modified by test_import
-[181/401/1] test_importhooks
-[182/401/1] test_importlib
-[183/401/1] test_index
-[184/401/1] test_inspect
-[185/401/1] test_int
-[186/401/1] test_int_literal
-[187/401/1] test_io
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:17 load avg: 0.61 [178/403/1] test_imghdr -- test_imgfile skipped
+0:01:17 load avg: 0.61 [179/403/1] test_imp
+0:01:17 load avg: 0.61 [180/403/1] test_import
+0:01:18 load avg: 0.61 [181/403/1] test_import_magic
+0:01:18 load avg: 0.61 [182/403/1] test_importhooks
+0:01:18 load avg: 0.61 [183/403/1] test_importlib
+0:01:18 load avg: 0.61 [184/403/1] test_index
+0:01:18 load avg: 0.61 [185/403/1] test_inspect
+0:01:18 load avg: 0.61 [186/403/1] test_int
+0:01:19 load avg: 0.61 [187/403/1] test_int_literal
+0:01:19 load avg: 0.61 [188/403/1] test_io
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[188/401/1] test_ioctl
-[189/401/1] test_isinstance
-[190/401/1] test_iter
-[191/401/1] test_iterlen
-[192/401/1] test_itertools
-[193/401/1] test_json
-[194/401/1] test_kqueue
+0:01:53 load avg: 0.50 [189/403/1] test_ioctl -- test_io passed in 34 sec
+0:01:53 load avg: 0.50 [190/403/1] test_isinstance
+0:01:53 load avg: 0.50 [191/403/1] test_iter
+0:01:54 load avg: 0.49 [192/403/1] test_iterlen
+0:01:54 load avg: 0.49 [193/403/1] test_itertools
+0:01:57 load avg: 0.48 [194/403/1] test_json
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/json/tests/test_speedups.py:6: DeprecationWarning: classic int division
+  1/0
+0:01:59 load avg: 0.48 [195/403/1] test_kqueue
 test_kqueue skipped -- test works only on BSD
-[195/401/1] test_largefile
-[196/401/1] test_lib2to3
+0:01:59 load avg: 0.48 [196/403/1] test_largefile -- test_kqueue skipped
+0:02:02 load avg: 0.49 [197/403/1] test_lib2to3
 No differences encountered
 No differences encountered
 No differences encountered
@@ -364,279 +367,281 @@ No differences encountered
 No differences encountered
 No differences encountered
 No differences encountered
-[197/401/1] test_linecache
-[198/401/1] test_linuxaudiodev
+0:02:20 load avg: 0.59 [198/403/1] test_linecache
+0:02:20 load avg: 0.59 [199/403/1] test_linuxaudiodev
 test_linuxaudiodev skipped -- Use of the `audio' resource not enabled
-[199/401/1] test_list
-[200/401/1] test_locale
-[201/401/1] test_logging
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:02:20 load avg: 0.59 [200/403/1] test_list -- test_linuxaudiodev skipped (resource denied)
+0:02:20 load avg: 0.59 [201/403/1] test_locale
+0:02:20 load avg: 0.59 [202/403/1] test_logging
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[202/401/1] test_long
-[203/401/1] test_long_future
-[204/401/1] test_longexp
-[205/401/1] test_macos
+0:02:32 load avg: 0.56 [203/403/1] test_long
+0:02:33 load avg: 0.55 [204/403/1] test_long_future
+0:02:35 load avg: 0.54 [205/403/1] test_longexp
+0:02:35 load avg: 0.54 [206/403/1] test_macos
 test_macos skipped -- No module named MacOS
-[206/401/1] test_macostools
+0:02:35 load avg: 0.54 [207/403/1] test_macostools -- test_macos skipped
 test_macostools skipped -- No module named MacOS
-[207/401/1] test_macpath
-[208/401/1] test_macurl2path
-[209/401/1] test_mailbox
-[210/401/1] test_marshal
-[211/401/1] test_math
-[212/401/1] test_md5
-[213/401/1] test_memoryio
-[214/401/1] test_memoryview
-[215/401/1] test_mhlib
-[216/401/1] test_mimetools
-[217/401/1] test_mimetypes
-[218/401/1] test_minidom
-[219/401/1] test_mmap
-[220/401/1] test_module
-[221/401/1] test_modulefinder
-[222/401/1] test_msilib
+0:02:35 load avg: 0.54 [208/403/1] test_macpath -- test_macostools skipped
+0:02:35 load avg: 0.54 [209/403/1] test_macurl2path
+0:02:35 load avg: 0.54 [210/403/1] test_mailbox
+0:02:46 load avg: 0.50 [211/403/1] test_marshal
+0:02:46 load avg: 0.50 [212/403/1] test_math
+0:02:47 load avg: 0.49 [213/403/1] test_md5
+0:02:47 load avg: 0.49 [214/403/1] test_memoryio
+0:02:47 load avg: 0.49 [215/403/1] test_memoryview
+0:02:47 load avg: 0.49 [216/403/1] test_mhlib
+0:02:48 load avg: 0.48 [217/403/1] test_mimetools
+0:02:48 load avg: 0.48 [218/403/1] test_mimetypes
+0:02:48 load avg: 0.48 [219/403/1] test_minidom
+0:02:48 load avg: 0.48 [220/403/1] test_mmap
+0:02:51 load avg: 0.47 [221/403/1] test_module
+0:02:51 load avg: 0.47 [222/403/1] test_modulefinder
+0:02:51 load avg: 0.47 [223/403/1] test_msilib
 test_msilib skipped -- No module named _msi
-[223/401/1] test_multibytecodec
-[224/401/1] test_multibytecodec_support
-[225/401/1] test_multifile
-[226/401/1] test_multiprocessing
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:02:51 load avg: 0.47 [224/403/1] test_multibytecodec -- test_msilib skipped
+0:02:53 load avg: 0.47 [225/403/1] test_multifile
+0:02:53 load avg: 0.47 [226/403/1] test_multiprocessing
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[227/401/1] test_mutants
-[228/401/1] test_mutex
-[229/401/1] test_netrc
-[230/401/1] test_new
-[231/401/1] test_nis
-[232/401/1] test_nntplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:23 load avg: 0.53 [227/403/1] test_mutants -- test_multiprocessing passed in 30 sec
+0:03:23 load avg: 0.53 [228/403/1] test_mutex
+0:03:23 load avg: 0.53 [229/403/1] test_netrc
+0:03:24 load avg: 0.53 [230/403/1] test_new
+0:03:24 load avg: 0.53 [231/403/1] test_nis
+0:03:24 load avg: 0.53 [232/403/1] test_nntplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[233/401/1] test_normalization
-[234/401/1] test_ntpath
-[235/401/1] test_old_mailbox
-[236/401/1] test_openpty
-[237/401/1] test_operator
-[238/401/1] test_optparse
-[239/401/1] test_ordered_dict
-[240/401/1] test_os
-[241/401/1] test_ossaudiodev
+0:03:24 load avg: 0.53 [233/403/1] test_normalization
+0:03:24 load avg: 0.53 [234/403/1] test_ntpath
+0:03:24 load avg: 0.53 [235/403/1] test_old_mailbox
+0:03:24 load avg: 0.53 [236/403/1] test_openpty
+0:03:24 load avg: 0.53 [237/403/1] test_operator
+0:03:24 load avg: 0.53 [238/403/1] test_optparse
+0:03:25 load avg: 0.53 [239/403/1] test_ordered_dict
+0:03:25 load avg: 0.53 [240/403/1] test_os
+0:03:26 load avg: 0.54 [241/403/1] test_ossaudiodev
 test_ossaudiodev skipped -- Use of the `audio' resource not enabled
-[242/401/1] test_parser
-[243/401/1] test_pdb
-[244/401/1] test_peepholer
-[245/401/1] test_pep247
-[246/401/1] test_pep277
+0:03:26 load avg: 0.54 [242/403/1] test_parser -- test_ossaudiodev skipped (resource denied)
+0:03:26 load avg: 0.54 [243/403/1] test_pdb
+0:03:27 load avg: 0.54 [244/403/1] test_peepholer
+0:03:27 load avg: 0.54 [245/403/1] test_pep247
+0:03:27 load avg: 0.54 [246/403/1] test_pep277
 test_pep277 skipped -- only NT+ and systems with Unicode-friendly filesystem encoding
-[247/401/1] test_pep352
-[248/401/1] test_pickle
-[249/401/1] test_pickletools
-[250/401/1] test_pipes
-[251/401/1] test_pkg
-[252/401/1] test_pkgimport
-[253/401/1] test_pkgutil
-[254/401/1] test_platform
-[255/401/1] test_plistlib
-[256/401/1] test_poll
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:27 load avg: 0.54 [247/403/1] test_pep352 -- test_pep277 skipped
+0:03:27 load avg: 0.54 [248/403/1] test_pickle
+0:03:28 load avg: 0.54 [249/403/1] test_pickletools
+0:03:28 load avg: 0.54 [250/403/1] test_pipes
+0:03:29 load avg: 0.55 [251/403/1] test_pkg
+0:03:29 load avg: 0.55 [252/403/1] test_pkgimport
+0:03:29 load avg: 0.55 [253/403/1] test_pkgutil
+0:03:29 load avg: 0.55 [254/403/1] test_platform
+0:03:29 load avg: 0.55 [255/403/1] test_plistlib
+0:03:29 load avg: 0.55 [256/403/1] test_poll
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[257/401/1] test_popen
-[258/401/1] test_popen2
-[259/401/1] test_poplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:40 load avg: 0.53 [257/403/1] test_popen
+0:03:40 load avg: 0.53 [258/403/1] test_popen2
+0:03:41 load avg: 0.52 [259/403/1] test_poplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[260/401/1] test_posix
-[261/401/1] test_posixpath
-[262/401/1] test_pow
-[263/401/1] test_pprint
-[264/401/1] test_print
-[265/401/1] test_profile
-[266/401/1] test_property
-[267/401/1] test_pstats
-[268/401/1] test_pty
-[269/401/1] test_pwd
-[270/401/1] test_py3kwarn
-[271/401/1] test_py_compile
-[272/401/1] test_pyclbr
-[273/401/1] test_pydoc
-[274/401/1] test_pyexpat
-[275/401/1] test_queue
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:42 load avg: 0.52 [260/403/1] test_posix
+0:03:42 load avg: 0.52 [261/403/1] test_posixpath
+0:03:42 load avg: 0.52 [262/403/1] test_pow
+0:03:42 load avg: 0.52 [263/403/1] test_pprint
+0:03:42 load avg: 0.52 [264/403/1] test_print
+0:03:43 load avg: 0.51 [265/403/1] test_profile
+0:03:43 load avg: 0.51 [266/403/1] test_property
+0:03:43 load avg: 0.51 [267/403/1] test_pstats
+0:03:43 load avg: 0.51 [268/403/1] test_pty
+0:03:43 load avg: 0.51 [269/403/1] test_pwd
+0:03:43 load avg: 0.51 [270/403/1] test_py3kwarn
+0:03:43 load avg: 0.51 [271/403/1] test_py_compile
+0:03:43 load avg: 0.51 [272/403/1] test_pyclbr
+0:03:44 load avg: 0.50 [273/403/1] test_pydoc
+0:03:45 load avg: 0.50 [274/403/1] test_pyexpat
+0:03:45 load avg: 0.50 [275/403/1] test_queue
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[276/401/1] test_quopri
-[277/401/1] test_random
-[278/401/1] test_re
-[279/401/1] test_readline
-[280/401/1] test_repr
-[281/401/1] test_resource
-[282/401/1] test_rfc822
-[283/401/1] test_richcmp
-[284/401/1] test_rlcompleter
-[285/401/1] test_robotparser
-[286/401/1] test_runpy
-[287/401/1] test_sax
-[288/401/1] test_scope
-[289/401/1] test_scriptpackages
+0:03:49 load avg: 0.50 [276/403/1] test_quopri
+0:03:49 load avg: 0.50 [277/403/1] test_random
+0:03:50 load avg: 0.50 [278/403/1] test_re
+0:03:50 load avg: 0.50 [279/403/1] test_readline
+0:03:51 load avg: 0.50 [280/403/1] test_regrtest
+0:03:54 load avg: 0.50 [281/403/1] test_repr
+0:03:55 load avg: 0.50 [282/403/1] test_resource
+0:03:55 load avg: 0.50 [283/403/1] test_rfc822
+0:03:55 load avg: 0.50 [284/403/1] test_richcmp
+0:03:55 load avg: 0.50 [285/403/1] test_rlcompleter
+0:03:55 load avg: 0.50 [286/403/1] test_robotparser
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+  self.__exc_clear()
+0:03:55 load avg: 0.50 [287/403/1] test_runpy
+0:03:57 load avg: 0.51 [288/403/1] test_sax
+0:03:57 load avg: 0.51 [289/403/1] test_scope
+0:03:57 load avg: 0.51 [290/403/1] test_scriptpackages
 test_scriptpackages skipped -- No module named aetools
-[290/401/1] test_select
-[291/401/1] test_set
-[292/401/1] test_setcomps
-[293/401/1] test_sets
-[294/401/1] test_sgmllib
-[295/401/1] test_sha
-[296/401/1] test_shelve
-[297/401/1] test_shlex
-[298/401/1] test_shutil
-[299/401/1] test_signal
-[300/401/1] test_site
-Warning -- sys.path was modified by test_site
-[301/401/1] test_slice
-[302/401/1] test_smtplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:58 load avg: 0.52 [291/403/1] test_select -- test_scriptpackages skipped
+0:04:09 load avg: 0.50 [292/403/1] test_set
+0:04:09 load avg: 0.50 [293/403/1] test_setcomps
+0:04:09 load avg: 0.50 [294/403/1] test_sets
+0:04:10 load avg: 0.50 [295/403/1] test_sgmllib
+0:04:10 load avg: 0.50 [296/403/1] test_sha
+0:04:10 load avg: 0.50 [297/403/1] test_shelve
+0:04:10 load avg: 0.50 [298/403/1] test_shlex
+0:04:10 load avg: 0.50 [299/403/1] test_shutil
+0:04:10 load avg: 0.50 [300/403/1] test_signal
+0:04:18 load avg: 0.46 [301/403/1] test_site
+0:04:19 load avg: 0.46 [302/403/1] test_slice
+0:04:19 load avg: 0.46 [303/403/1] test_smtplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[303/401/1] test_smtpnet
+0:04:19 load avg: 0.46 [304/403/1] test_smtpnet
 test_smtpnet skipped -- Use of the `network' resource not enabled
-[304/401/1] test_socket
-[305/401/1] test_socketserver
+0:04:19 load avg: 0.46 [305/403/1] test_socket -- test_smtpnet skipped (resource denied)
+0:04:35 load avg: 0.39 [306/403/1] test_socketserver
 test_socketserver skipped -- Use of the `network' resource not enabled
-[306/401/1] test_softspace
-[307/401/1] test_sort
-[308/401/1] test_source_encoding
-[309/401/1] test_spwd
-[310/401/1] test_sqlite
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:35 load avg: 0.39 [307/403/1] test_softspace -- test_socketserver skipped (resource denied)
+0:04:36 load avg: 0.38 [308/403/1] test_sort
+0:04:36 load avg: 0.38 [309/403/1] test_source_encoding
+0:04:36 load avg: 0.38 [310/403/1] test_spwd
+0:04:36 load avg: 0.38 [311/403/1] test_sqlite
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[311/401/1] test_ssl
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:38 load avg: 0.37 [312/403/1] test_ssl
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[312/401/1] test_startfile
-test_startfile skipped -- module os has no attribute startfile
-[313/401/1] test_stat
-[314/401/1] test_str
-[315/401/1] test_strftime
-[316/401/1] test_string
-[317/401/1] test_stringprep
-[318/401/1] test_strop
-[319/401/1] test_strptime
-[320/401/1] test_strtod
-[321/401/1] test_struct
-[322/401/1] test_structmembers
-[323/401/1] test_structseq
-[324/401/1] test_subprocess
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:39 load avg: 0.37 [313/403/1] test_startfile
+test_startfile skipped -- module 'os' has no attribute 'startfile'
+0:04:39 load avg: 0.37 [314/403/1] test_stat -- test_startfile skipped
+0:04:39 load avg: 0.37 [315/403/1] test_str
+0:04:40 load avg: 0.37 [316/403/1] test_strftime
+0:04:41 load avg: 0.37 [317/403/1] test_string
+0:04:41 load avg: 0.37 [318/403/1] test_stringprep
+0:04:41 load avg: 0.37 [319/403/1] test_strop
+0:04:41 load avg: 0.37 [320/403/1] test_strptime
+0:04:41 load avg: 0.37 [321/403/1] test_strtod
+0:04:42 load avg: 0.37 [322/403/1] test_struct
+0:04:43 load avg: 0.38 [323/403/1] test_structmembers
+0:04:43 load avg: 0.38 [324/403/1] test_structseq
+0:04:43 load avg: 0.38 [325/403/1] test_subprocess
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[325/401/1] test_sunau
-[326/401/1] test_sunaudiodev
+0:06:38 load avg: 0.87 [326/403/1] test_sunau -- test_subprocess passed in 1 min 55 sec
+0:06:38 load avg: 0.87 [327/403/1] test_sunaudiodev
 test_sunaudiodev skipped -- no audio device found!
-[327/401/1] test_sundry
-[328/401/1] test_symtable
-[329/401/1] test_syntax
-[330/401/1] test_sys
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:38 load avg: 0.87 [328/403/1] test_sundry -- test_sunaudiodev skipped
+0:06:38 load avg: 0.87 [329/403/1] test_symtable
+0:06:38 load avg: 0.87 [330/403/1] test_syntax
+0:06:38 load avg: 0.87 [331/403/1] test_sys
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[331/401/1] test_sys_setprofile
-[332/401/1] test_sys_settrace
-[333/401/1] test_sysconfig
-[334/401/1] test_tarfile
-[335/401/1] test_tcl
+0:06:39 load avg: 0.87 [332/403/1] test_sys_setprofile
+0:06:39 load avg: 0.87 [333/403/1] test_sys_settrace
+0:06:39 load avg: 0.87 [334/403/1] test_sysconfig
+0:06:39 load avg: 0.87 [335/403/1] test_tarfile
+0:06:41 load avg: 0.86 [336/403/1] test_tcl
 test_tcl skipped -- No module named _tkinter
-[336/401/1] test_telnetlib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:41 load avg: 0.86 [337/403/1] test_telnetlib -- test_tcl skipped
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[337/401/1] test_tempfile
-[338/401/1] test_textwrap
-[339/401/1] test_thread
-[340/401/1] test_threaded_import
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:46 load avg: 0.84 [338/403/1] test_tempfile
+0:06:47 load avg: 0.84 [339/403/1] test_test_support
+0:06:47 load avg: 0.84 [340/403/1] test_textwrap
+0:06:47 load avg: 0.84 [341/403/1] test_thread
+0:06:47 load avg: 0.84 [342/403/1] test_threaded_import
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[341/401/1] test_threadedtempfile
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:48 load avg: 0.84 [343/403/1] test_threadedtempfile
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[342/401/1] test_threading
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:48 load avg: 0.84 [344/403/1] test_threading
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[343/401/1] test_threading_local
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:53 load avg: 0.81 [345/403/1] test_threading_local
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[344/401/1] test_threadsignals
-[345/401/1] test_time
-[346/401/1] test_timeit
-[347/401/1] test_timeout
+0:06:54 load avg: 0.80 [346/403/1] test_threadsignals
+0:06:54 load avg: 0.80 [347/403/1] test_time
+0:06:55 load avg: 0.80 [348/403/1] test_timeit
+0:06:55 load avg: 0.80 [349/403/1] test_timeout
 test_timeout skipped -- Use of the `network' resource not enabled
-[348/401/1] test_tk
+0:06:55 load avg: 0.80 [350/403/1] test_tk -- test_timeout skipped (resource denied)
 test_tk skipped -- No module named _tkinter
-[349/401/1] test_tokenize
-[350/401/1] test_tools
-recursedown('@test_19743_tmp')
-[351/401/1] test_trace
-[352/401/1] test_traceback
-[353/401/1] test_transformer
-[354/401/1] test_ttk_guionly
+0:06:56 load avg: 0.80 [351/403/1] test_tokenize -- test_tk skipped
+0:06:56 load avg: 0.80 [352/403/1] test_tools
+recursedown('@test_5316_tmp')
+0:06:58 load avg: 0.80 [353/403/1] test_trace
+0:07:00 load avg: 0.79 [354/403/1] test_traceback
+0:07:04 load avg: 0.79 [355/403/1] test_transformer
+0:07:04 load avg: 0.79 [356/403/1] test_ttk_guionly
 test_ttk_guionly skipped -- No module named _tkinter
-[355/401/1] test_ttk_textonly
+0:07:04 load avg: 0.79 [357/403/1] test_ttk_textonly -- test_ttk_guionly skipped
 test_ttk_textonly skipped -- No module named _tkinter
-[356/401/1] test_tuple
-[357/401/1] test_turtle
+0:07:04 load avg: 0.79 [358/403/1] test_tuple -- test_ttk_textonly skipped
+0:07:09 load avg: 0.77 [359/403/1] test_turtle
 test_turtle skipped -- No module named _tkinter
-[358/401/1] test_typechecks
-[359/401/1] test_ucn
-[360/401/1] test_unary
-[361/401/1] test_undocumented_details
-[362/401/1] test_unicode
-[363/401/1] test_unicode_file
+0:07:10 load avg: 0.77 [360/403/1] test_typechecks -- test_turtle skipped
+0:07:10 load avg: 0.77 [361/403/1] test_ucn
+0:07:10 load avg: 0.77 [362/403/1] test_unary
+0:07:10 load avg: 0.77 [363/403/1] test_undocumented_details
+0:07:10 load avg: 0.77 [364/403/1] test_unicode
+0:07:12 load avg: 0.77 [365/403/1] test_unicode_file
 test_unicode_file skipped -- No Unicode filesystem semantics on this platform.
-[364/401/1] test_unicodedata
-[365/401/1] test_univnewlines
-[366/401/1] test_univnewlines2k
-[367/401/1] test_unpack
-[368/401/1] test_urllib
-[369/401/1] test_urllib2
-[370/401/1] test_urllib2_localnet
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:07:12 load avg: 0.77 [366/403/1] test_unicodedata -- test_unicode_file skipped
+0:07:13 load avg: 0.77 [367/403/1] test_univnewlines
+0:07:13 load avg: 0.77 [368/403/1] test_univnewlines2k
+0:07:13 load avg: 0.77 [369/403/1] test_unpack
+0:07:13 load avg: 0.77 [370/403/1] test_urllib
+0:07:13 load avg: 0.77 [371/403/1] test_urllib2
+0:07:14 load avg: 0.77 [372/403/1] test_urllib2_localnet
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[371/401/1] test_urllib2net
+0:07:14 load avg: 0.77 [373/403/1] test_urllib2net
 test_urllib2net skipped -- Use of the `network' resource not enabled
-[372/401/1] test_urllibnet
+0:07:14 load avg: 0.77 [374/403/1] test_urllibnet -- test_urllib2net skipped (resource denied)
 test_urllibnet skipped -- Use of the `network' resource not enabled
-[373/401/1] test_urlparse
-[374/401/1] test_userdict
-[375/401/1] test_userlist
-[376/401/1] test_userstring
-[377/401/1] test_uu
-[378/401/1] test_uuid
-[379/401/1] test_wait3
-[380/401/1] test_wait4
-[381/401/1] test_warnings
-[382/401/1] test_wave
-[383/401/1] test_weakref
-[384/401/1] test_weakset
-[385/401/1] test_whichdb
-[386/401/1] test_winreg
-test_winreg skipped -- No module named _winreg
-[387/401/1] test_winsound
-test_winsound skipped -- Use of the `audio' resource not enabled
-[388/401/1] test_with
-[389/401/1] test_wsgiref
-[390/401/1] test_xdrlib
-[391/401/1] test_xml_etree
-[392/401/1] test_xml_etree_c
-[393/401/1] test_xmllib
-[394/401/1] test_xmlrpc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:07:15 load avg: 0.77 [375/403/1] test_urlparse -- test_urllibnet skipped (resource denied)
+0:07:15 load avg: 0.77 [376/403/1] test_userdict
+0:07:15 load avg: 0.77 [377/403/1] test_userlist
+0:07:15 load avg: 0.77 [378/403/1] test_userstring
+0:07:18 load avg: 0.78 [379/403/1] test_uu
+0:07:18 load avg: 0.78 [380/403/1] test_uuid
+0:07:19 load avg: 0.78 [381/403/1] test_wait3
+0:07:25 load avg: 0.76 [382/403/1] test_wait4
+0:07:31 load avg: 0.70 [383/403/1] test_warnings
+0:07:32 load avg: 0.69 [384/403/1] test_wave
+0:07:32 load avg: 0.69 [385/403/1] test_weakref
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[395/401/1] test_xpickle
-[396/401/1] test_xrange
-[397/401/1] test_zipfile
-[398/401/1] test_zipfile64
+0:07:39 load avg: 0.67 [386/403/1] test_weakset
+0:07:39 load avg: 0.67 [387/403/1] test_whichdb
+0:07:39 load avg: 0.67 [388/403/1] test_winreg
+test_winreg skipped -- No module named _winreg
+0:07:40 load avg: 0.67 [389/403/1] test_winsound -- test_winreg skipped
+test_winsound skipped -- Use of the `audio' resource not enabled
+0:07:40 load avg: 0.67 [390/403/1] test_with -- test_winsound skipped (resource denied)
+0:07:40 load avg: 0.67 [391/403/1] test_wsgiref
+0:07:40 load avg: 0.67 [392/403/1] test_xdrlib
+0:07:40 load avg: 0.67 [393/403/1] test_xml_etree
+0:07:40 load avg: 0.67 [394/403/1] test_xml_etree_c
+0:07:41 load avg: 0.68 [395/403/1] test_xmllib
+0:07:41 load avg: 0.68 [396/403/1] test_xmlrpc
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+  self.__exc_clear()
+0:07:44 load avg: 0.69 [397/403/1] test_xpickle
+0:07:45 load avg: 0.69 [398/403/1] test_xrange
+0:07:45 load avg: 0.69 [399/403/1] test_zipfile
+0:07:48 load avg: 0.69 [400/403/1] test_zipfile64
 test_zipfile64 skipped -- test requires loads of disk-space bytes and a long time to run
-[399/401/1] test_zipimport
-[400/401/1] test_zipimport_support
-[401/401/1] test_zlib
-353 tests OK.
+0:07:48 load avg: 0.69 [401/403/1] test_zipimport -- test_zipfile64 skipped (resource denied)
+0:07:48 load avg: 0.69 [402/403/1] test_zipimport_support
+0:07:49 load avg: 0.69 [403/403/1] test_zlib
+357 tests OK.
 1 test failed:
     test_distutils
-2 tests altered the execution environment:
-    test_import test_site
 45 tests skipped:
     test_aepack test_al test_applesingle test_bsddb test_bsddb185
     test_bsddb3 test_cd test_cl test_codecmaps_cn test_codecmaps_hk
@@ -651,266 +656,272 @@ test_zipfile64 skipped -- test requires loads of disk-space bytes and a long tim
 10 skips unexpected on sunos5:
     test_bsddb3 test_dl test_gdb test_idle test_sunaudiodev test_tcl
     test_tk test_ttk_guionly test_ttk_textonly test_turtle
-== CPython 2.7.13 (default, Sep 1 2017, 10:58:39) [GCC 5.4.0]
+
+Total duration: 7 min 52 sec
+Tests result: FAILURE
+== CPython 2.7.14 (default, Sep 23 2017, 16:34:57) [GCC 5.4.0]
 ==   Solaris-2.11-i86pc-i386-64bit-ELF little-endian
-==   /data/omnios-build/omniosorg/_build/Python-2.7.13/build/test_python_22745
-Testing with flags: sys.flags(debug=0, py3k_warning=1, division_warning=1, division_new=0, inspect=0, interactive=0, optimize=0, dont_write_bytecode=0, no_user_site=0, no_site=0, ignore_environment=1, tabcheck=2, verbose=0, unicode=0, bytes_warning=0, hash_randomization=0)
-[  1/401] test_grammar
-[  2/401] test_opcodes
-[  3/401] test_dict
-[  4/401] test_builtin
-[  5/401] test_exceptions
-[  6/401] test_types
-[  7/401] test_unittest
-[  8/401] test_doctest
-[  9/401] test_doctest2
-[ 10/401] test_MimeWriter
-[ 11/401] test_SimpleHTTPServer
-[ 12/401] test_StringIO
-[ 13/401] test___all__
-[ 14/401] test___future__
-[ 15/401] test__locale
-[ 16/401] test__osx_support
-[ 17/401] test_abc
-[ 18/401] test_abstract_numbers
-[ 19/401] test_aepack
+==   /data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/build/test_python_8241
+== CPU count: 8
+Run tests sequentially
+0:00:00 load avg: 0.69 [  1/403] test_grammar
+0:00:00 load avg: 0.69 [  2/403] test_opcodes
+0:00:00 load avg: 0.69 [  3/403] test_dict
+0:00:00 load avg: 0.69 [  4/403] test_builtin
+0:00:00 load avg: 0.69 [  5/403] test_exceptions
+0:00:00 load avg: 0.69 [  6/403] test_types
+0:00:00 load avg: 0.69 [  7/403] test_unittest
+0:00:00 load avg: 0.69 [  8/403] test_doctest
+0:00:00 load avg: 0.69 [  9/403] test_doctest2
+0:00:00 load avg: 0.69 [ 10/403] test_MimeWriter
+0:00:00 load avg: 0.69 [ 11/403] test_SimpleHTTPServer
+0:00:00 load avg: 0.69 [ 12/403] test_StringIO
+0:00:00 load avg: 0.69 [ 13/403] test___all__
+0:00:01 load avg: 0.70 [ 14/403] test___future__
+0:00:01 load avg: 0.70 [ 15/403] test__locale
+0:00:01 load avg: 0.70 [ 16/403] test__osx_support
+0:00:01 load avg: 0.70 [ 17/403] test_abc
+0:00:01 load avg: 0.70 [ 18/403] test_abstract_numbers
+0:00:01 load avg: 0.70 [ 19/403] test_aepack
 test_aepack skipped -- No module named aetypes
-[ 20/401] test_aifc
-[ 21/401] test_al
+0:00:01 load avg: 0.70 [ 20/403] test_aifc -- test_aepack skipped
+0:00:01 load avg: 0.70 [ 21/403] test_al
 test_al skipped -- No module named al
-[ 22/401] test_anydbm
-[ 23/401] test_applesingle
+0:00:01 load avg: 0.70 [ 22/403] test_anydbm -- test_al skipped
+0:00:01 load avg: 0.70 [ 23/403] test_applesingle
 test_applesingle skipped -- No module named MacOS
-[ 24/401] test_argparse
-[ 25/401] test_array
-[ 26/401] test_ascii_formatd
-[ 27/401] test_ast
-[ 28/401] test_asynchat
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:01 load avg: 0.70 [ 24/403] test_argparse -- test_applesingle skipped
+0:00:02 load avg: 0.70 [ 25/403] test_array
+0:00:03 load avg: 0.70 [ 26/403] test_ascii_formatd
+0:00:03 load avg: 0.70 [ 27/403] test_ast
+0:00:03 load avg: 0.70 [ 28/403] test_asynchat
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 29/401] test_asyncore
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:11 load avg: 0.69 [ 29/403] test_asyncore
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 30/401] test_atexit
-[ 31/401] test_audioop
-[ 32/401] test_augassign
-[ 33/401] test_base64
-[ 34/401] test_bastion
-[ 35/401] test_bigaddrspace
-[ 36/401] test_bigmem
-[ 37/401] test_binascii
-[ 38/401] test_binhex
-[ 39/401] test_binop
-[ 40/401] test_bisect
-[ 41/401] test_bool
-[ 42/401] test_bsddb
+0:00:12 load avg: 0.68 [ 30/403] test_atexit
+0:00:12 load avg: 0.68 [ 31/403] test_audioop
+0:00:12 load avg: 0.67 [ 32/403] test_augassign
+0:00:12 load avg: 0.67 [ 33/403] test_base64
+0:00:12 load avg: 0.67 [ 34/403] test_bastion
+0:00:13 load avg: 0.67 [ 35/403] test_bigaddrspace
+0:00:13 load avg: 0.67 [ 36/403] test_bigmem
+0:00:13 load avg: 0.67 [ 37/403] test_binascii
+0:00:13 load avg: 0.67 [ 38/403] test_binhex
+0:00:13 load avg: 0.67 [ 39/403] test_binop
+0:00:13 load avg: 0.67 [ 40/403] test_bisect
+0:00:13 load avg: 0.67 [ 41/403] test_bool
+0:00:13 load avg: 0.67 [ 42/403] test_bsddb
 test_bsddb skipped -- No module named _bsddb
-[ 43/401] test_bsddb185
+0:00:13 load avg: 0.67 [ 43/403] test_bsddb185 -- test_bsddb skipped
 test_bsddb185 skipped -- No module named bsddb185
-[ 44/401] test_bsddb3
+0:00:13 load avg: 0.67 [ 44/403] test_bsddb3 -- test_bsddb185 skipped
 test_bsddb3 skipped -- No module named _bsddb
-[ 45/401] test_buffer
-[ 46/401] test_bufio
-[ 47/401] test_bytes
-[ 48/401] test_bz2
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:13 load avg: 0.67 [ 45/403] test_buffer -- test_bsddb3 skipped
+0:00:13 load avg: 0.67 [ 46/403] test_bufio
+0:00:14 load avg: 0.66 [ 47/403] test_bytes
+0:00:14 load avg: 0.66 [ 48/403] test_bz2
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 49/401] test_calendar
-[ 50/401] test_call
-[ 51/401] test_capi
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:15 load avg: 0.66 [ 49/403] test_calendar
+0:00:18 load avg: 0.64 [ 50/403] test_call
+0:00:18 load avg: 0.64 [ 51/403] test_capi
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 52/401] test_cd
+0:00:21 load avg: 0.64 [ 52/403] test_cd
 test_cd skipped -- No module named cd
-[ 53/401] test_cfgparser
-[ 54/401] test_cgi
-[ 55/401] test_charmapcodec
-[ 56/401] test_cl
+0:00:21 load avg: 0.64 [ 53/403] test_cfgparser -- test_cd skipped
+0:00:22 load avg: 0.64 [ 54/403] test_cgi
+0:00:22 load avg: 0.64 [ 55/403] test_charmapcodec
+0:00:22 load avg: 0.64 [ 56/403] test_cl
 test_cl skipped -- No module named cl
-[ 57/401] test_class
-[ 58/401] test_cmath
-[ 59/401] test_cmd
-[ 60/401] test_cmd_line
-[ 61/401] test_cmd_line_script
-[ 62/401] test_code
-[ 63/401] test_codeccallbacks
-[ 64/401] test_codecencodings_cn
-[ 65/401] test_codecencodings_hk
-[ 66/401] test_codecencodings_iso2022
-[ 67/401] test_codecencodings_jp
-[ 68/401] test_codecencodings_kr
-[ 69/401] test_codecencodings_tw
-[ 70/401] test_codecmaps_cn
+0:00:22 load avg: 0.64 [ 57/403] test_class -- test_cl skipped
+0:00:22 load avg: 0.64 [ 58/403] test_cmath
+0:00:22 load avg: 0.64 [ 59/403] test_cmd
+0:00:22 load avg: 0.64 [ 60/403] test_cmd_line
+0:00:23 load avg: 0.64 [ 61/403] test_cmd_line_script
+0:00:24 load avg: 0.64 [ 62/403] test_code
+0:00:24 load avg: 0.64 [ 63/403] test_codeccallbacks
+0:00:24 load avg: 0.64 [ 64/403] test_codecencodings_cn
+0:00:24 load avg: 0.64 [ 65/403] test_codecencodings_hk
+0:00:24 load avg: 0.64 [ 66/403] test_codecencodings_iso2022
+0:00:24 load avg: 0.64 [ 67/403] test_codecencodings_jp
+0:00:25 load avg: 0.64 [ 68/403] test_codecencodings_kr
+0:00:25 load avg: 0.64 [ 69/403] test_codecencodings_tw
+0:00:25 load avg: 0.64 [ 70/403] test_codecmaps_cn
 test_codecmaps_cn skipped -- Use of the `urlfetch' resource not enabled
-[ 71/401] test_codecmaps_hk
+0:00:25 load avg: 0.64 [ 71/403] test_codecmaps_hk -- test_codecmaps_cn skipped (resource denied)
 test_codecmaps_hk skipped -- Use of the `urlfetch' resource not enabled
-[ 72/401] test_codecmaps_jp
+0:00:25 load avg: 0.64 [ 72/403] test_codecmaps_jp -- test_codecmaps_hk skipped (resource denied)
 test_codecmaps_jp skipped -- Use of the `urlfetch' resource not enabled
-[ 73/401] test_codecmaps_kr
+0:00:25 load avg: 0.64 [ 73/403] test_codecmaps_kr -- test_codecmaps_jp skipped (resource denied)
 test_codecmaps_kr skipped -- Use of the `urlfetch' resource not enabled
-[ 74/401] test_codecmaps_tw
+0:00:25 load avg: 0.64 [ 74/403] test_codecmaps_tw -- test_codecmaps_kr skipped (resource denied)
 test_codecmaps_tw skipped -- Use of the `urlfetch' resource not enabled
-[ 75/401] test_codecs
-[ 76/401] test_codeop
-[ 77/401] test_coercion
-[ 78/401] test_collections
-[ 79/401] test_colorsys
-[ 80/401] test_commands
-[ 81/401] test_compare
-[ 82/401] test_compile
-[ 83/401] test_compileall
-[ 84/401] test_compiler
-[ 85/401] test_complex
-[ 86/401] test_complex_args
-[ 87/401] test_contains
-[ 88/401] test_contextlib
-[ 89/401] test_cookie
-[ 90/401] test_cookielib
-[ 91/401] test_copy
-[ 92/401] test_copy_reg
-[ 93/401] test_cpickle
-[ 94/401] test_cprofile
-[ 95/401] test_crypt
-[ 96/401] test_csv
-[ 97/401] test_ctypes
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:25 load avg: 0.64 [ 75/403] test_codecs -- test_codecmaps_tw skipped (resource denied)
+0:00:26 load avg: 0.64 [ 76/403] test_codeop
+0:00:26 load avg: 0.64 [ 77/403] test_coercion
+0:00:26 load avg: 0.64 [ 78/403] test_collections
+0:00:27 load avg: 0.64 [ 79/403] test_colorsys
+0:00:27 load avg: 0.64 [ 80/403] test_commands
+0:00:27 load avg: 0.64 [ 81/403] test_compare
+0:00:27 load avg: 0.64 [ 82/403] test_compile
+0:00:27 load avg: 0.64 [ 83/403] test_compileall
+0:00:27 load avg: 0.64 [ 84/403] test_compiler
+0:00:27 load avg: 0.64 [ 85/403] test_complex
+0:00:27 load avg: 0.64 [ 86/403] test_complex_args
+0:00:27 load avg: 0.64 [ 87/403] test_contains
+0:00:27 load avg: 0.64 [ 88/403] test_contextlib
+0:00:28 load avg: 0.64 [ 89/403] test_cookie
+0:00:28 load avg: 0.64 [ 90/403] test_cookielib
+0:00:28 load avg: 0.64 [ 91/403] test_copy
+0:00:28 load avg: 0.64 [ 92/403] test_copy_reg
+0:00:28 load avg: 0.64 [ 93/403] test_cpickle
+0:00:29 load avg: 0.64 [ 94/403] test_cprofile
+0:00:29 load avg: 0.64 [ 95/403] test_crypt
+0:00:29 load avg: 0.64 [ 96/403] test_csv
+0:00:29 load avg: 0.64 [ 97/403] test_ctypes
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[ 98/401] test_curses
+0:00:31 load avg: 0.65 [ 98/403] test_curses
 test_curses skipped -- Use of the `curses' resource not enabled
-[ 99/401] test_datetime
-[100/401] test_dbm
-[101/401] test_decimal
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:31 load avg: 0.65 [ 99/403] test_datetime -- test_curses skipped (resource denied)
+0:00:31 load avg: 0.65 [100/403] test_dbm
+0:00:31 load avg: 0.65 [101/403] test_decimal
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[102/401] test_decorators
-[103/401] test_defaultdict
-[104/401] test_deque
-[105/401] test_descr
-[106/401] test_descrtut
-[107/401] test_dictcomps
-[108/401] test_dictviews
-[109/401] test_difflib
-[110/401] test_dircache
-[111/401] test_dis
-[112/401] test_distutils
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/distutils/command/build_ext.py:686: DeprecationWarning: apply() not supported in 3.x; use func(*args, **kwargs)
+0:00:33 load avg: 0.66 [102/403] test_decorators
+0:00:33 load avg: 0.66 [103/403] test_defaultdict
+0:00:33 load avg: 0.66 [104/403] test_deque
+0:00:34 load avg: 0.67 [105/403] test_descr
+0:00:35 load avg: 0.67 [106/403] test_descrtut
+0:00:35 load avg: 0.68 [107/403] test_dictcomps
+0:00:35 load avg: 0.68 [108/403] test_dictviews
+0:00:36 load avg: 0.68 [109/403] test_difflib
+0:00:36 load avg: 0.68 [110/403] test_dircache
+0:00:37 load avg: 0.68 [111/403] test_dis
+0:00:37 load avg: 0.68 [112/403] test_distutils
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/distutils/command/build_ext.py:686: DeprecationWarning: apply() not supported in 3.x; use func(*args, **kwargs)
   path = apply(os.path.join, ext_path)
 test test_distutils failed -- multiple errors occurred; run in verbose mode for details
-[113/401/1] test_dl
+0:00:38 load avg: 0.68 [113/403/1] test_dl -- test_distutils failed
 test_dl skipped -- No module named dl
-[114/401/1] test_docxmlrpc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:38 load avg: 0.68 [114/403/1] test_docxmlrpc -- test_dl skipped
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[115/401/1] test_dumbdbm
-[116/401/1] test_dummy_thread
-[117/401/1] test_dummy_threading
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:41 load avg: 0.68 [115/403/1] test_dumbdbm
+0:00:41 load avg: 0.68 [116/403/1] test_dummy_thread
+0:00:41 load avg: 0.68 [117/403/1] test_dummy_threading
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[118/401/1] test_email
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:42 load avg: 0.68 [118/403/1] test_email
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[119/401/1] test_email_codecs
-[120/401/1] test_email_renamed
-[121/401/1] test_ensurepip
-[122/401/1] test_enumerate
-[123/401/1] test_eof
-[124/401/1] test_epoll
-[125/401/1] test_errno
-[126/401/1] test_exception_variations
-[127/401/1] test_extcall
-[128/401/1] test_fcntl
-[129/401/1] test_file
-[130/401/1] test_file2k
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:45 load avg: 0.70 [119/403/1] test_email_codecs
+0:00:45 load avg: 0.70 [120/403/1] test_email_renamed
+0:00:45 load avg: 0.70 [121/403/1] test_ensurepip
+0:00:45 load avg: 0.70 [122/403/1] test_enumerate
+0:00:45 load avg: 0.71 [123/403/1] test_eof
+0:00:45 load avg: 0.71 [124/403/1] test_epoll
+0:00:48 load avg: 0.73 [125/403/1] test_errno
+0:00:48 load avg: 0.73 [126/403/1] test_exception_variations
+0:00:48 load avg: 0.73 [127/403/1] test_extcall
+0:00:48 load avg: 0.73 [128/403/1] test_fcntl
+0:00:48 load avg: 0.73 [129/403/1] test_file
+0:00:48 load avg: 0.73 [130/403/1] test_file2k
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[131/401/1] test_file_eintr
-[132/401/1] test_filecmp
-[133/401/1] test_fileinput
-[134/401/1] test_fileio
-[135/401/1] test_float
-[136/401/1] test_fnmatch
-[137/401/1] test_fork1
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:00:55 load avg: 0.87 [131/403/1] test_file_eintr
+0:00:57 load avg: 0.89 [132/403/1] test_filecmp
+0:00:57 load avg: 0.89 [133/403/1] test_fileinput
+0:00:57 load avg: 0.89 [134/403/1] test_fileio
+0:00:57 load avg: 0.89 [135/403/1] test_float
+0:00:57 load avg: 0.89 [136/403/1] test_fnmatch
+0:00:57 load avg: 0.89 [137/403/1] test_fork1
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[138/401/1] test_format
-[139/401/1] test_fpformat
-[140/401/1] test_fractions
-[141/401/1] test_frozen
-[142/401/1] test_ftplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:04 load avg: 0.89 [138/403/1] test_format
+0:01:04 load avg: 0.89 [139/403/1] test_fpformat
+0:01:04 load avg: 0.89 [140/403/1] test_fractions
+0:01:04 load avg: 0.89 [141/403/1] test_frozen
+0:01:04 load avg: 0.89 [142/403/1] test_ftplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[143/401/1] test_funcattrs
-[144/401/1] test_functools
-[145/401/1] test_future
-[146/401/1] test_future3
-[147/401/1] test_future4
-[148/401/1] test_future5
-[149/401/1] test_future_builtins
-[150/401/1] test_gc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:05 load avg: 0.88 [143/403/1] test_funcattrs
+0:01:05 load avg: 0.88 [144/403/1] test_functools
+0:01:05 load avg: 0.88 [145/403/1] test_future
+0:01:05 load avg: 0.88 [146/403/1] test_future3
+0:01:05 load avg: 0.88 [147/403/1] test_future4
+0:01:05 load avg: 0.88 [148/403/1] test_future5
+0:01:05 load avg: 0.88 [149/403/1] test_future_builtins
+0:01:05 load avg: 0.88 [150/403/1] test_gc
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[151/401/1] test_gdb
+0:01:08 load avg: 0.85 [151/403/1] test_gdb
 test_gdb skipped -- Couldn't find gdb on the path
-[152/401/1] test_gdbm
+0:01:08 load avg: 0.85 [152/403/1] test_gdbm -- test_gdb skipped
 test_gdbm skipped -- No module named gdbm
-[153/401/1] test_generators
-[154/401/1] test_genericpath
-[155/401/1] test_genexps
-[156/401/1] test_getargs
-[157/401/1] test_getargs2
-[158/401/1] test_getopt
-[159/401/1] test_gettext
-[160/401/1] test_gl
+0:01:08 load avg: 0.85 [153/403/1] test_generators -- test_gdbm skipped
+0:01:08 load avg: 0.85 [154/403/1] test_genericpath
+0:01:08 load avg: 0.85 [155/403/1] test_genexps
+0:01:08 load avg: 0.85 [156/403/1] test_getargs
+0:01:08 load avg: 0.85 [157/403/1] test_getargs2
+0:01:08 load avg: 0.85 [158/403/1] test_getopt
+0:01:08 load avg: 0.85 [159/403/1] test_gettext
+0:01:08 load avg: 0.85 [160/403/1] test_gl
 test_gl skipped -- No module named gl
-[161/401/1] test_glob
-[162/401/1] test_global
-[163/401/1] test_grp
-[164/401/1] test_gzip
-[165/401/1] test_hash
-[166/401/1] test_hashlib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:08 load avg: 0.84 [161/403/1] test_glob -- test_gl skipped
+0:01:09 load avg: 0.84 [162/403/1] test_global
+0:01:09 load avg: 0.84 [163/403/1] test_grp
+0:01:09 load avg: 0.84 [164/403/1] test_gzip
+0:01:09 load avg: 0.83 [165/403/1] test_hash
+0:01:11 load avg: 0.83 [166/403/1] test_hashlib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[167/401/1] test_heapq
-[168/401/1] test_hmac
-[169/401/1] test_hotshot
-[170/401/1] test_htmllib
-[171/401/1] test_htmlparser
-[172/401/1] test_httplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:11 load avg: 0.83 [167/403/1] test_heapq
+0:01:11 load avg: 0.83 [168/403/1] test_hmac
+0:01:11 load avg: 0.83 [169/403/1] test_hotshot
+0:01:11 load avg: 0.82 [170/403/1] test_htmllib
+0:01:12 load avg: 0.82 [171/403/1] test_htmlparser
+0:01:12 load avg: 0.82 [172/403/1] test_httplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[173/401/1] test_httpservers
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:12 load avg: 0.82 [173/403/1] test_httpservers
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[174/401/1] test_idle
+0:01:15 load avg: 0.81 [174/403/1] test_idle
 test_idle skipped -- No module named _tkinter
-[175/401/1] test_imageop
+0:01:15 load avg: 0.81 [175/403/1] test_imageop -- test_idle skipped
 test_imageop skipped -- No module named imageop
-[176/401/1] test_imaplib
-[177/401/1] test_imgfile
+0:01:15 load avg: 0.81 [176/403/1] test_imaplib -- test_imageop skipped
+0:01:15 load avg: 0.81 [177/403/1] test_imgfile
 test_imgfile skipped -- No module named imgfile
-[178/401/1] test_imghdr
-[179/401/1] test_imp
-[180/401/1] test_import
-Warning -- sys.path was modified by test_import
-[181/401/1] test_importhooks
-[182/401/1] test_importlib
-[183/401/1] test_index
-[184/401/1] test_inspect
-[185/401/1] test_int
-[186/401/1] test_int_literal
-[187/401/1] test_io
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:01:15 load avg: 0.81 [178/403/1] test_imghdr -- test_imgfile skipped
+0:01:15 load avg: 0.81 [179/403/1] test_imp
+0:01:15 load avg: 0.81 [180/403/1] test_import
+0:01:15 load avg: 0.81 [181/403/1] test_import_magic
+0:01:15 load avg: 0.81 [182/403/1] test_importhooks
+0:01:15 load avg: 0.81 [183/403/1] test_importlib
+0:01:15 load avg: 0.81 [184/403/1] test_index
+0:01:16 load avg: 0.81 [185/403/1] test_inspect
+0:01:16 load avg: 0.81 [186/403/1] test_int
+0:01:16 load avg: 0.81 [187/403/1] test_int_literal
+0:01:16 load avg: 0.81 [188/403/1] test_io
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[188/401/1] test_ioctl
-[189/401/1] test_isinstance
-[190/401/1] test_iter
-[191/401/1] test_iterlen
-[192/401/1] test_itertools
-[193/401/1] test_json
-[194/401/1] test_kqueue
+0:01:51 load avg: 0.61 [189/403/1] test_ioctl -- test_io passed in 34 sec
+0:01:51 load avg: 0.61 [190/403/1] test_isinstance
+0:01:51 load avg: 0.61 [191/403/1] test_iter
+0:01:51 load avg: 0.61 [192/403/1] test_iterlen
+0:01:51 load avg: 0.61 [193/403/1] test_itertools
+0:01:55 load avg: 0.59 [194/403/1] test_json
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/json/tests/test_speedups.py:6: DeprecationWarning: classic int division
+  1/0
+0:01:57 load avg: 0.58 [195/403/1] test_kqueue
 test_kqueue skipped -- test works only on BSD
-[195/401/1] test_largefile
-[196/401/1] test_lib2to3
+0:01:57 load avg: 0.58 [196/403/1] test_largefile -- test_kqueue skipped
+0:02:02 load avg: 0.59 [197/403/1] test_lib2to3
 No differences encountered
 No differences encountered
 No differences encountered
@@ -1009,278 +1020,281 @@ No differences encountered
 No differences encountered
 No differences encountered
 No differences encountered
-[197/401/1] test_linecache
-[198/401/1] test_linuxaudiodev
+0:02:19 load avg: 0.64 [198/403/1] test_linecache
+0:02:19 load avg: 0.64 [199/403/1] test_linuxaudiodev
 test_linuxaudiodev skipped -- Use of the `audio' resource not enabled
-[199/401/1] test_list
-[200/401/1] test_locale
-[201/401/1] test_logging
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:02:19 load avg: 0.65 [200/403/1] test_list -- test_linuxaudiodev skipped (resource denied)
+0:02:20 load avg: 0.65 [201/403/1] test_locale
+0:02:20 load avg: 0.65 [202/403/1] test_logging
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[202/401/1] test_long
-[203/401/1] test_long_future
-[204/401/1] test_longexp
-[205/401/1] test_macos
+0:02:32 load avg: 0.60 [203/403/1] test_long
+0:02:33 load avg: 0.59 [204/403/1] test_long_future
+0:02:35 load avg: 0.58 [205/403/1] test_longexp
+0:02:35 load avg: 0.58 [206/403/1] test_macos
 test_macos skipped -- No module named MacOS
-[206/401/1] test_macostools
+0:02:35 load avg: 0.58 [207/403/1] test_macostools -- test_macos skipped
 test_macostools skipped -- No module named MacOS
-[207/401/1] test_macpath
-[208/401/1] test_macurl2path
-[209/401/1] test_mailbox
-[210/401/1] test_marshal
-[211/401/1] test_math
-[212/401/1] test_md5
-[213/401/1] test_memoryio
-[214/401/1] test_memoryview
-[215/401/1] test_mhlib
-[216/401/1] test_mimetools
-[217/401/1] test_mimetypes
-[218/401/1] test_minidom
-[219/401/1] test_mmap
-[220/401/1] test_module
-[221/401/1] test_modulefinder
-[222/401/1] test_msilib
+0:02:35 load avg: 0.58 [208/403/1] test_macpath -- test_macostools skipped
+0:02:35 load avg: 0.58 [209/403/1] test_macurl2path
+0:02:35 load avg: 0.58 [210/403/1] test_mailbox
+0:02:44 load avg: 0.54 [211/403/1] test_marshal
+0:02:44 load avg: 0.54 [212/403/1] test_math
+0:02:45 load avg: 0.54 [213/403/1] test_md5
+0:02:45 load avg: 0.54 [214/403/1] test_memoryio
+0:02:45 load avg: 0.53 [215/403/1] test_memoryview
+0:02:46 load avg: 0.53 [216/403/1] test_mhlib
+0:02:46 load avg: 0.53 [217/403/1] test_mimetools
+0:02:46 load avg: 0.53 [218/403/1] test_mimetypes
+0:02:46 load avg: 0.53 [219/403/1] test_minidom
+0:02:46 load avg: 0.53 [220/403/1] test_mmap
+0:02:50 load avg: 0.52 [221/403/1] test_module
+0:02:50 load avg: 0.52 [222/403/1] test_modulefinder
+0:02:51 load avg: 0.51 [223/403/1] test_msilib
 test_msilib skipped -- No module named _msi
-[223/401/1] test_multibytecodec
-[224/401/1] test_multibytecodec_support
-[225/401/1] test_multifile
-[226/401/1] test_multiprocessing
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:02:51 load avg: 0.51 [224/403/1] test_multibytecodec -- test_msilib skipped
+0:02:52 load avg: 0.51 [225/403/1] test_multifile
+0:02:52 load avg: 0.51 [226/403/1] test_multiprocessing
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[227/401/1] test_mutants
-[228/401/1] test_mutex
-[229/401/1] test_netrc
-[230/401/1] test_new
-[231/401/1] test_nis
-[232/401/1] test_nntplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:20 load avg: 0.56 [227/403/1] test_mutants
+0:03:20 load avg: 0.56 [228/403/1] test_mutex
+0:03:20 load avg: 0.56 [229/403/1] test_netrc
+0:03:20 load avg: 0.56 [230/403/1] test_new
+0:03:20 load avg: 0.56 [231/403/1] test_nis
+0:03:20 load avg: 0.56 [232/403/1] test_nntplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[233/401/1] test_normalization
-[234/401/1] test_ntpath
-[235/401/1] test_old_mailbox
-[236/401/1] test_openpty
-[237/401/1] test_operator
-[238/401/1] test_optparse
-[239/401/1] test_ordered_dict
-[240/401/1] test_os
-[241/401/1] test_ossaudiodev
+0:03:20 load avg: 0.56 [233/403/1] test_normalization
+0:03:21 load avg: 0.56 [234/403/1] test_ntpath
+0:03:21 load avg: 0.56 [235/403/1] test_old_mailbox
+0:03:21 load avg: 0.56 [236/403/1] test_openpty
+0:03:21 load avg: 0.56 [237/403/1] test_operator
+0:03:21 load avg: 0.56 [238/403/1] test_optparse
+0:03:21 load avg: 0.56 [239/403/1] test_ordered_dict
+0:03:21 load avg: 0.56 [240/403/1] test_os
+0:03:22 load avg: 0.56 [241/403/1] test_ossaudiodev
 test_ossaudiodev skipped -- Use of the `audio' resource not enabled
-[242/401/1] test_parser
-[243/401/1] test_pdb
-[244/401/1] test_peepholer
-[245/401/1] test_pep247
-[246/401/1] test_pep277
+0:03:22 load avg: 0.56 [242/403/1] test_parser -- test_ossaudiodev skipped (resource denied)
+0:03:22 load avg: 0.56 [243/403/1] test_pdb
+0:03:23 load avg: 0.56 [244/403/1] test_peepholer
+0:03:23 load avg: 0.56 [245/403/1] test_pep247
+0:03:23 load avg: 0.56 [246/403/1] test_pep277
 test_pep277 skipped -- only NT+ and systems with Unicode-friendly filesystem encoding
-[247/401/1] test_pep352
-[248/401/1] test_pickle
-[249/401/1] test_pickletools
-[250/401/1] test_pipes
-[251/401/1] test_pkg
-[252/401/1] test_pkgimport
-[253/401/1] test_pkgutil
-[254/401/1] test_platform
-[255/401/1] test_plistlib
-[256/401/1] test_poll
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:23 load avg: 0.56 [247/403/1] test_pep352 -- test_pep277 skipped
+0:03:23 load avg: 0.56 [248/403/1] test_pickle
+0:03:24 load avg: 0.57 [249/403/1] test_pickletools
+0:03:25 load avg: 0.57 [250/403/1] test_pipes
+0:03:25 load avg: 0.57 [251/403/1] test_pkg
+0:03:25 load avg: 0.57 [252/403/1] test_pkgimport
+0:03:25 load avg: 0.57 [253/403/1] test_pkgutil
+0:03:25 load avg: 0.57 [254/403/1] test_platform
+0:03:25 load avg: 0.57 [255/403/1] test_plistlib
+0:03:25 load avg: 0.57 [256/403/1] test_poll
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[257/401/1] test_popen
-[258/401/1] test_popen2
-[259/401/1] test_poplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:36 load avg: 0.55 [257/403/1] test_popen
+0:03:36 load avg: 0.55 [258/403/1] test_popen2
+0:03:37 load avg: 0.54 [259/403/1] test_poplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[260/401/1] test_posix
-[261/401/1] test_posixpath
-[262/401/1] test_pow
-[263/401/1] test_pprint
-[264/401/1] test_print
-[265/401/1] test_profile
-[266/401/1] test_property
-[267/401/1] test_pstats
-[268/401/1] test_pty
-[269/401/1] test_pwd
-[270/401/1] test_py3kwarn
-[271/401/1] test_py_compile
-[272/401/1] test_pyclbr
-[273/401/1] test_pydoc
-[274/401/1] test_pyexpat
-[275/401/1] test_queue
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:38 load avg: 0.53 [260/403/1] test_posix
+0:03:38 load avg: 0.53 [261/403/1] test_posixpath
+0:03:38 load avg: 0.53 [262/403/1] test_pow
+0:03:38 load avg: 0.53 [263/403/1] test_pprint
+0:03:39 load avg: 0.53 [264/403/1] test_print
+0:03:39 load avg: 0.53 [265/403/1] test_profile
+0:03:39 load avg: 0.53 [266/403/1] test_property
+0:03:39 load avg: 0.53 [267/403/1] test_pstats
+0:03:39 load avg: 0.53 [268/403/1] test_pty
+0:03:39 load avg: 0.53 [269/403/1] test_pwd
+0:03:39 load avg: 0.53 [270/403/1] test_py3kwarn
+0:03:39 load avg: 0.53 [271/403/1] test_py_compile
+0:03:39 load avg: 0.53 [272/403/1] test_pyclbr
+0:03:40 load avg: 0.52 [273/403/1] test_pydoc
+0:03:41 load avg: 0.52 [274/403/1] test_pyexpat
+0:03:41 load avg: 0.52 [275/403/1] test_queue
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[276/401/1] test_quopri
-[277/401/1] test_random
-[278/401/1] test_re
-[279/401/1] test_readline
-[280/401/1] test_repr
-[281/401/1] test_resource
-[282/401/1] test_rfc822
-[283/401/1] test_richcmp
-[284/401/1] test_rlcompleter
-[285/401/1] test_robotparser
-[286/401/1] test_runpy
-[287/401/1] test_sax
-[288/401/1] test_scope
-[289/401/1] test_scriptpackages
+0:03:45 load avg: 0.51 [276/403/1] test_quopri
+0:03:45 load avg: 0.51 [277/403/1] test_random
+0:03:45 load avg: 0.51 [278/403/1] test_re
+0:03:46 load avg: 0.51 [279/403/1] test_readline
+0:03:46 load avg: 0.51 [280/403/1] test_regrtest
+0:03:50 load avg: 0.51 [281/403/1] test_repr
+0:03:50 load avg: 0.51 [282/403/1] test_resource
+0:03:50 load avg: 0.51 [283/403/1] test_rfc822
+0:03:50 load avg: 0.51 [284/403/1] test_richcmp
+0:03:51 load avg: 0.52 [285/403/1] test_rlcompleter
+0:03:51 load avg: 0.52 [286/403/1] test_robotparser
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+  self.__exc_clear()
+0:03:51 load avg: 0.52 [287/403/1] test_runpy
+0:03:53 load avg: 0.52 [288/403/1] test_sax
+0:03:53 load avg: 0.52 [289/403/1] test_scope
+0:03:53 load avg: 0.52 [290/403/1] test_scriptpackages
 test_scriptpackages skipped -- No module named aetools
-[290/401/1] test_select
-[291/401/1] test_set
-[292/401/1] test_setcomps
-[293/401/1] test_sets
-[294/401/1] test_sgmllib
-[295/401/1] test_sha
-[296/401/1] test_shelve
-[297/401/1] test_shlex
-[298/401/1] test_shutil
-[299/401/1] test_signal
-[300/401/1] test_site
-[301/401/1] test_slice
-[302/401/1] test_smtplib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:03:53 load avg: 0.52 [291/403/1] test_select -- test_scriptpackages skipped
+0:04:04 load avg: 0.51 [292/403/1] test_set
+0:04:05 load avg: 0.50 [293/403/1] test_setcomps
+0:04:05 load avg: 0.50 [294/403/1] test_sets
+0:04:05 load avg: 0.50 [295/403/1] test_sgmllib
+0:04:05 load avg: 0.50 [296/403/1] test_sha
+0:04:05 load avg: 0.50 [297/403/1] test_shelve
+0:04:05 load avg: 0.50 [298/403/1] test_shlex
+0:04:05 load avg: 0.50 [299/403/1] test_shutil
+0:04:06 load avg: 0.50 [300/403/1] test_signal
+0:04:14 load avg: 0.46 [301/403/1] test_site
+0:04:14 load avg: 0.46 [302/403/1] test_slice
+0:04:14 load avg: 0.46 [303/403/1] test_smtplib
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[303/401/1] test_smtpnet
+0:04:15 load avg: 0.46 [304/403/1] test_smtpnet
 test_smtpnet skipped -- Use of the `network' resource not enabled
-[304/401/1] test_socket
-[305/401/1] test_socketserver
+0:04:15 load avg: 0.46 [305/403/1] test_socket -- test_smtpnet skipped (resource denied)
+0:04:31 load avg: 0.39 [306/403/1] test_socketserver
 test_socketserver skipped -- Use of the `network' resource not enabled
-[306/401/1] test_softspace
-[307/401/1] test_sort
-[308/401/1] test_source_encoding
-[309/401/1] test_spwd
-[310/401/1] test_sqlite
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:31 load avg: 0.39 [307/403/1] test_softspace -- test_socketserver skipped (resource denied)
+0:04:31 load avg: 0.39 [308/403/1] test_sort
+0:04:31 load avg: 0.39 [309/403/1] test_source_encoding
+0:04:32 load avg: 0.38 [310/403/1] test_spwd
+0:04:32 load avg: 0.38 [311/403/1] test_sqlite
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[311/401/1] test_ssl
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:33 load avg: 0.38 [312/403/1] test_ssl
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[312/401/1] test_startfile
-test_startfile skipped -- module os has no attribute startfile
-[313/401/1] test_stat
-[314/401/1] test_str
-[315/401/1] test_strftime
-[316/401/1] test_string
-[317/401/1] test_stringprep
-[318/401/1] test_strop
-[319/401/1] test_strptime
-[320/401/1] test_strtod
-[321/401/1] test_struct
-[322/401/1] test_structmembers
-[323/401/1] test_structseq
-[324/401/1] test_subprocess
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:04:34 load avg: 0.38 [313/403/1] test_startfile
+test_startfile skipped -- module 'os' has no attribute 'startfile'
+0:04:34 load avg: 0.38 [314/403/1] test_stat -- test_startfile skipped
+0:04:35 load avg: 0.38 [315/403/1] test_str
+0:04:35 load avg: 0.38 [316/403/1] test_strftime
+0:04:36 load avg: 0.38 [317/403/1] test_string
+0:04:37 load avg: 0.38 [318/403/1] test_stringprep
+0:04:37 load avg: 0.38 [319/403/1] test_strop
+0:04:37 load avg: 0.38 [320/403/1] test_strptime
+0:04:37 load avg: 0.38 [321/403/1] test_strtod
+0:04:38 load avg: 0.38 [322/403/1] test_struct
+0:04:38 load avg: 0.38 [323/403/1] test_structmembers
+0:04:38 load avg: 0.38 [324/403/1] test_structseq
+0:04:38 load avg: 0.38 [325/403/1] test_subprocess
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[325/401/1] test_sunau
-[326/401/1] test_sunaudiodev
+0:06:34 load avg: 0.88 [326/403/1] test_sunau -- test_subprocess passed in 1 min 55 sec
+0:06:34 load avg: 0.88 [327/403/1] test_sunaudiodev
 test_sunaudiodev skipped -- no audio device found!
-[327/401/1] test_sundry
-[328/401/1] test_symtable
-[329/401/1] test_syntax
-[330/401/1] test_sys
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:34 load avg: 0.88 [328/403/1] test_sundry -- test_sunaudiodev skipped
+0:06:34 load avg: 0.88 [329/403/1] test_symtable
+0:06:34 load avg: 0.88 [330/403/1] test_syntax
+0:06:34 load avg: 0.88 [331/403/1] test_sys
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[331/401/1] test_sys_setprofile
-[332/401/1] test_sys_settrace
-[333/401/1] test_sysconfig
-[334/401/1] test_tarfile
-[335/401/1] test_tcl
+0:06:35 load avg: 0.87 [332/403/1] test_sys_setprofile
+0:06:35 load avg: 0.87 [333/403/1] test_sys_settrace
+0:06:35 load avg: 0.87 [334/403/1] test_sysconfig
+0:06:36 load avg: 0.87 [335/403/1] test_tarfile
+0:06:37 load avg: 0.87 [336/403/1] test_tcl
 test_tcl skipped -- No module named _tkinter
-[336/401/1] test_telnetlib
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:38 load avg: 0.87 [337/403/1] test_telnetlib -- test_tcl skipped
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[337/401/1] test_tempfile
-[338/401/1] test_textwrap
-[339/401/1] test_thread
-[340/401/1] test_threaded_import
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:43 load avg: 0.84 [338/403/1] test_tempfile
+0:06:43 load avg: 0.84 [339/403/1] test_test_support
+0:06:43 load avg: 0.84 [340/403/1] test_textwrap
+0:06:43 load avg: 0.84 [341/403/1] test_thread
+0:06:44 load avg: 0.84 [342/403/1] test_threaded_import
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[341/401/1] test_threadedtempfile
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:44 load avg: 0.84 [343/403/1] test_threadedtempfile
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[342/401/1] test_threading
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:44 load avg: 0.84 [344/403/1] test_threading
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[343/401/1] test_threading_local
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:06:49 load avg: 0.81 [345/403/1] test_threading_local
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[344/401/1] test_threadsignals
-[345/401/1] test_time
-[346/401/1] test_timeit
-[347/401/1] test_timeout
+0:06:50 load avg: 0.81 [346/403/1] test_threadsignals
+0:06:50 load avg: 0.81 [347/403/1] test_time
+0:06:51 load avg: 0.80 [348/403/1] test_timeit
+0:06:51 load avg: 0.80 [349/403/1] test_timeout
 test_timeout skipped -- Use of the `network' resource not enabled
-[348/401/1] test_tk
+0:06:51 load avg: 0.80 [350/403/1] test_tk -- test_timeout skipped (resource denied)
 test_tk skipped -- No module named _tkinter
-[349/401/1] test_tokenize
-[350/401/1] test_tools
-recursedown('@test_22745_tmp')
-[351/401/1] test_trace
-[352/401/1] test_traceback
-[353/401/1] test_transformer
-[354/401/1] test_ttk_guionly
+0:06:51 load avg: 0.80 [351/403/1] test_tokenize -- test_tk skipped
+0:06:52 load avg: 0.80 [352/403/1] test_tools
+recursedown('@test_8241_tmp')
+0:06:54 load avg: 0.80 [353/403/1] test_trace
+0:06:55 load avg: 0.80 [354/403/1] test_traceback
+0:06:59 load avg: 0.79 [355/403/1] test_transformer
+0:07:00 load avg: 0.79 [356/403/1] test_ttk_guionly
 test_ttk_guionly skipped -- No module named _tkinter
-[355/401/1] test_ttk_textonly
+0:07:00 load avg: 0.79 [357/403/1] test_ttk_textonly -- test_ttk_guionly skipped
 test_ttk_textonly skipped -- No module named _tkinter
-[356/401/1] test_tuple
-[357/401/1] test_turtle
+0:07:00 load avg: 0.79 [358/403/1] test_tuple -- test_ttk_textonly skipped
+0:07:05 load avg: 0.77 [359/403/1] test_turtle
 test_turtle skipped -- No module named _tkinter
-[358/401/1] test_typechecks
-[359/401/1] test_ucn
-[360/401/1] test_unary
-[361/401/1] test_undocumented_details
-[362/401/1] test_unicode
-[363/401/1] test_unicode_file
+0:07:05 load avg: 0.77 [360/403/1] test_typechecks -- test_turtle skipped
+0:07:05 load avg: 0.77 [361/403/1] test_ucn
+0:07:06 load avg: 0.77 [362/403/1] test_unary
+0:07:06 load avg: 0.77 [363/403/1] test_undocumented_details
+0:07:06 load avg: 0.77 [364/403/1] test_unicode
+0:07:07 load avg: 0.76 [365/403/1] test_unicode_file
 test_unicode_file skipped -- No Unicode filesystem semantics on this platform.
-[364/401/1] test_unicodedata
-[365/401/1] test_univnewlines
-[366/401/1] test_univnewlines2k
-[367/401/1] test_unpack
-[368/401/1] test_urllib
-[369/401/1] test_urllib2
-[370/401/1] test_urllib2_localnet
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:07:07 load avg: 0.76 [366/403/1] test_unicodedata -- test_unicode_file skipped
+0:07:09 load avg: 0.77 [367/403/1] test_univnewlines
+0:07:09 load avg: 0.77 [368/403/1] test_univnewlines2k
+0:07:09 load avg: 0.77 [369/403/1] test_unpack
+0:07:09 load avg: 0.77 [370/403/1] test_urllib
+0:07:09 load avg: 0.77 [371/403/1] test_urllib2
+0:07:09 load avg: 0.77 [372/403/1] test_urllib2_localnet
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[371/401/1] test_urllib2net
+0:07:10 load avg: 0.77 [373/403/1] test_urllib2net
 test_urllib2net skipped -- Use of the `network' resource not enabled
-[372/401/1] test_urllibnet
+0:07:11 load avg: 0.77 [374/403/1] test_urllibnet -- test_urllib2net skipped (resource denied)
 test_urllibnet skipped -- Use of the `network' resource not enabled
-[373/401/1] test_urlparse
-[374/401/1] test_userdict
-[375/401/1] test_userlist
-[376/401/1] test_userstring
-[377/401/1] test_uu
-[378/401/1] test_uuid
-[379/401/1] test_wait3
-[380/401/1] test_wait4
-[381/401/1] test_warnings
-[382/401/1] test_wave
-[383/401/1] test_weakref
-[384/401/1] test_weakset
-[385/401/1] test_whichdb
-[386/401/1] test_winreg
-test_winreg skipped -- No module named _winreg
-[387/401/1] test_winsound
-test_winsound skipped -- Use of the `audio' resource not enabled
-[388/401/1] test_with
-[389/401/1] test_wsgiref
-[390/401/1] test_xdrlib
-[391/401/1] test_xml_etree
-[392/401/1] test_xml_etree_c
-[393/401/1] test_xmllib
-[394/401/1] test_xmlrpc
-/data/omnios-build/omniosorg/_build/Python-2.7.13/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+0:07:11 load avg: 0.77 [375/403/1] test_urlparse -- test_urllibnet skipped (resource denied)
+0:07:11 load avg: 0.77 [376/403/1] test_userdict
+0:07:11 load avg: 0.77 [377/403/1] test_userlist
+0:07:11 load avg: 0.77 [378/403/1] test_userstring
+0:07:14 load avg: 0.78 [379/403/1] test_uu
+0:07:14 load avg: 0.78 [380/403/1] test_uuid
+0:07:14 load avg: 0.78 [381/403/1] test_wait3
+0:07:20 load avg: 0.77 [382/403/1] test_wait4
+0:07:26 load avg: 0.71 [383/403/1] test_warnings
+0:07:27 load avg: 0.70 [384/403/1] test_wave
+0:07:27 load avg: 0.70 [385/403/1] test_weakref
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
   self.__exc_clear()
-[395/401/1] test_xpickle
-[396/401/1] test_xrange
-[397/401/1] test_zipfile
-[398/401/1] test_zipfile64
+0:07:34 load avg: 0.67 [386/403/1] test_weakset
+0:07:34 load avg: 0.67 [387/403/1] test_whichdb
+0:07:35 load avg: 0.67 [388/403/1] test_winreg
+test_winreg skipped -- No module named _winreg
+0:07:35 load avg: 0.67 [389/403/1] test_winsound -- test_winreg skipped
+test_winsound skipped -- Use of the `audio' resource not enabled
+0:07:35 load avg: 0.67 [390/403/1] test_with -- test_winsound skipped (resource denied)
+0:07:35 load avg: 0.67 [391/403/1] test_wsgiref
+0:07:35 load avg: 0.67 [392/403/1] test_xdrlib
+0:07:35 load avg: 0.67 [393/403/1] test_xml_etree
+0:07:35 load avg: 0.67 [394/403/1] test_xml_etree_c
+0:07:35 load avg: 0.68 [395/403/1] test_xmllib
+0:07:36 load avg: 0.68 [396/403/1] test_xmlrpc
+/data/omnios-build/omniosorg/bloody/_build/Python-2.7.14/Lib/threading.py:846: DeprecationWarning: sys.exc_clear() not supported in 3.x; use except clauses
+  self.__exc_clear()
+0:07:39 load avg: 0.69 [397/403/1] test_xpickle
+0:07:40 load avg: 0.69 [398/403/1] test_xrange
+0:07:40 load avg: 0.69 [399/403/1] test_zipfile
+0:07:43 load avg: 0.69 [400/403/1] test_zipfile64
 test_zipfile64 skipped -- test requires loads of disk-space bytes and a long time to run
-[399/401/1] test_zipimport
-[400/401/1] test_zipimport_support
-[401/401/1] test_zlib
-354 tests OK.
+0:07:43 load avg: 0.69 [401/403/1] test_zipimport -- test_zipfile64 skipped (resource denied)
+0:07:43 load avg: 0.69 [402/403/1] test_zipimport_support
+0:07:44 load avg: 0.69 [403/403/1] test_zlib
+357 tests OK.
 1 test failed:
     test_distutils
-1 test altered the execution environment:
-    test_import
 45 tests skipped:
     test_aepack test_al test_applesingle test_bsddb test_bsddb185
     test_bsddb3 test_cd test_cl test_codecmaps_cn test_codecmaps_hk
@@ -1295,4 +1309,7 @@ test_zipfile64 skipped -- test requires loads of disk-space bytes and a long tim
 10 skips unexpected on sunos5:
     test_bsddb3 test_dl test_gdb test_idle test_sunaudiodev test_tcl
     test_tk test_ttk_guionly test_ttk_textonly test_turtle
-gmake: *** [Makefile:901: test] Error 1
+
+Total duration: 7 min 47 sec
+Tests result: FAILURE
+gmake: *** [Makefile:891: test] Error 2


### PR DESCRIPTION
Usually when a software package is upgraded, local patches against it tend to carry on working but apply with some level of fuzz, offset or whatever.
It's good to be able to re-base patches again so that they apply cleanly to the source, and this also means that they are more likely to apply to the next version too.

So, I've added a `-P` flag to buildctl/build.sh allowing patches to be rebased. It's possible to change to a package directory and run `./build.sh -P`, or to run a full build with the option if necessary/desired (`./buildctl -P build all`)

This PR also includes a rebase of all of the Python patches. I've built python from this, regression tested it and also successfully run the pkg test suite.

I haven't re-based other packages as each one should be tested as it's done, but we can start to do this routinely when applying upgrades.