### PR TITLE
ncurses: update to 20170930

### DIFF
--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=ncurses
-VER=6.0-20170916
+VER=6.0-20170930
 VERHUMAN=$VER
 BUILDDIR=$PROG-$VER
 VER=${VER/-/.}

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -37,7 +37,7 @@
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
 | library/libxml2			| 2.9.5			| http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
-| library/ncurses			| 6.0.20170916		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/
+| library/ncurses			| 6.0.20170930		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.26.0		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.33			| https://ftp.mozilla.org/pub/security/nss/releases/
 | library/nspr				| 4.17			| http://archive.mozilla.org/pub/nspr/releases/


### PR DESCRIPTION
Ncurses update to latest release in preparation for r151024 freeze.
Tested curses applications such as vim and also run the demo applications from the source.