### PR TITLE
dbus: update to 1.11.18

### DIFF
--- a/build/dbus/build.sh
+++ b/build/dbus/build.sh
@@ -28,46 +28,40 @@
 . ../../lib/functions.sh
 
 PROG=dbus
-VER=1.11.16
+VER=1.11.18
 PKG=dbus ##IGNORE##
 SUMMARY="$PROG - IPC-based message notifications"
 DESC="$SUMMARY"
 
-DEPENDS_IPS="SUNWcs"
-
 # Use old gcc4 standards level for this.
-CFLAGS="$CFLAGS -std=gnu89"
-CPPFLAGS="$CPPFLAGS -D__EXTENSIONS__ -D_REENTRANT"
-CONFIGURE_OPTS="--with-x=no --with-dbus-user=root --disable-static --with-dbus-daemondir=/usr/lib
-	--bindir=/usr/bin --localstatedir=/var --libexecdir=/usr/libexec"
+CFLAGS+="-std=gnu89"
+CPPFLAGS+="-D__EXTENSIONS__ -D_REENTRANT"
+CONFIGURE_OPTS="
+	--with-dbus-daemondir=/usr/lib
+	--bindir=/usr/bin
+	--localstatedir=/var
+	--libexecdir=/usr/libexec
+	--with-x=no
+	--with-dbus-user=root
+	--disable-static
+"
 
-# We build backwards here on purpose so that 32bit binaries win (for install collisions).
+LIBTOOL_NOSTDLIB=libtool
+
+# We build backwards here on purpose so that 32bit binaries win
+# (for install collisions).
 build() {
-    if [[ $BUILDARCH == "64" || $BUILDARCH == "both" ]]; then
-        build64
-    fi
-    if [[ $BUILDARCH == "32" || $BUILDARCH == "both" ]]; then
-        build32
-    fi
-}
-
-make_prog64() {
-    logcmd perl -pi -e 's#(\$CC.*\$compiler_flags)#$1 -nostdlib#g;' libtool ||
-        logerr "libtool patch failed"
-    logcmd gmake || logerr "Make failed"
-}
-
-make_prog32() {
-    logcmd perl -pi -e 's#(\$CC.*\$compiler_flags)#$1 -nostdlib#g;' libtool ||
-        logerr "libtool patch failed"
-    logcmd gmake || logerr "Make failed"
+    [[ $BUILDARCH =~ ^(64|both)$ ]] && build64
+    [[ $BUILDARCH =~ ^(32|both)$ ]] && build32
 }
 
 post_install() {
     mkdir -p $DESTDIR/etc/security/auth_attr.d
     mkdir -p $DESTDIR/etc/security/prof_attr.d
-    cp files/auth-system%2Flibrary%2Fdbus $DESTDIR/etc/security/auth_attr.d/system%2Flibrary%2Fdbus
-    cp files/prof-system%2Flibrary%2Fdbus $DESTDIR/etc/security/prof_attr.d/system%2Flibrary%2Fdbus
+    cp files/auth-system%2Flibrary%2Fdbus \
+        $DESTDIR/etc/security/auth_attr.d/system%2Flibrary%2Fdbus
+    cp files/prof-system%2Flibrary%2Fdbus \
+        $DESTDIR/etc/security/prof_attr.d/system%2Flibrary%2Fdbus
 }
 
 init
@@ -90,4 +84,4 @@ SUMMARY="Simple IPC library based on messages - client libraries"
 DESC="Simple IPC library based on messages - client libraries"
 make_package libdbus.mog
 
-#clean_up
+clean_up

--- a/build/dbus/testsuite.log
+++ b/build/dbus/testsuite.log
@@ -6,6 +6,9 @@ Making check in .
   GEN      copy-config-local
 -- No need to copy test data as srcdir = builddir
   GEN      uninstalled-config-local
+PASS: test-dbus-daemon-fork.sh 1 - normal dbus-daemon
+PASS: test-dbus-daemon-fork.sh 2 - dbus-daemon with stdin closed
+PASS: test-dbus-daemon-fork.sh 3 - dbus-daemon with stdin, stdout, stderr closed
 PASS: test-shell 1
 PASS: test-shell 2
 PASS: test-shell 3
@@ -24,12 +27,127 @@ PASS: test-printf 4
 PASS: test-printf 5
 PASS: test-printf 6
 PASS: test-printf 7
+PASS: test-corrupt 1 /corrupt/tcp
+PASS: test-corrupt 2 /corrupt/unix
+PASS: test-corrupt 3 /corrupt/byte-order/tcp
+PASS: test-dbus-daemon 1 /creds
+PASS: test-dbus-daemon 2 /processid
+PASS: test-dbus-daemon 3 /unix-runtime-is-default
+PASS: test-dbus-daemon 4 /echo/session
+PASS: test-dbus-daemon 5 /echo/limited
+PASS: test-dbus-daemon 6 /no-reply/disconnect
+PASS: test-dbus-daemon 7 /no-reply/timeout
+PASS: test-dbus-daemon 8 /canonical-path/uae
+PASS: test-dbus-daemon 9 /limits/max-completed-connections
+PASS: test-dbus-daemon 10 /limits/max-connections-per-user
+PASS: test-dbus-daemon 11 /limits/max-replies-per-connection
+PASS: test-dbus-daemon 12 /limits/max-match-rules-per-connection
+PASS: test-dbus-daemon 13 /limits/max-names-per-connection
+PASS: test-dbus-daemon 14 /limits/pending-fd-timeout
+PASS: test-dbus-daemon 15 /peer/ping
+PASS: test-dbus-daemon 16 /peer/get-machine-id
+PASS: test-dbus-daemon 17 /properties/get-invalid-iface
+PASS: test-dbus-daemon 18 /properties/get-invalid-path
+PASS: test-dbus-daemon 19 /properties/get-invalid
+PASS: test-dbus-daemon 20 /properties/get-all-invalid-iface
+PASS: test-dbus-daemon 21 /properties/get-all-invalid-path
+PASS: test-dbus-daemon 22 /properties/set-invalid-iface
+PASS: test-dbus-daemon 23 /properties/set-invalid-path
+PASS: test-dbus-daemon 24 /properties/set-invalid
+PASS: test-dbus-daemon 25 /properties/set
+PASS: test-dbus-daemon 26 /properties/features
+PASS: test-dbus-daemon 27 /properties/interfaces
+PASS: test-dbus-daemon 28 /properties/get-all
+PASS: test-dbus-daemon 29 /policy/count-fds
+PASS: test-dbus-daemon-eavesdrop 1 /eavedrop/match_keyword/broadcast
+PASS: test-dbus-daemon-eavesdrop 2 /eavedrop/match_keyword/unicast_to_receiver
+PASS: test-dbus-daemon-eavesdrop 3 /eavedrop/match_keyword/unicast_to_sender
+PASS: test-fdpass 1 /unsupported
+PASS: test-fdpass 2 /relay
+PASS: test-fdpass 3 /limit
+PASS: test-fdpass 4 /too-many/plus1
+PASS: test-fdpass 5 /too-many/plus2
+PASS: test-fdpass 6 /too-many/plus17
+PASS: test-fdpass 7 /too-many/split
+PASS: test-fdpass 8 /flood/1
+PASS: test-fdpass 9 /flood/half-limit
+PASS: test-fdpass 10 /flood/over-half-limit
+PASS: test-fdpass 11 /flood/limit
+PASS: test-fdpass 12 /odd-limit/minus1
+PASS: test-fdpass 13 /odd-limit/at
+PASS: test-fdpass 14 /odd-limit/plus1
+PASS: test-fdpass 15 /odd-limit/plus2
+PASS: test-message 1 /message/fd
+PASS: test-message 2 /message/zero-iter
+PASS: test-message 3 /message/array/array
+PASS: test-message 4 /message/array/dict
+PASS: test-message 5 /message/array/variant
+PASS: test-monitor 1 /monitor/invalid
+PASS: test-monitor 2 /monitor/become
+PASS: test-monitor 3 /monitor/broadcast
+PASS: test-monitor 4 /monitor/forbidden-broadcast
+PASS: test-monitor 5 /monitor/unicast-signal
+PASS: test-monitor 6 /monitor/forbidden
+PASS: test-monitor 7 /monitor/method-call
+PASS: test-monitor 8 /monitor/forbidden-method
+PASS: test-monitor 9 /monitor/dbus-daemon
+PASS: test-monitor 10 /monitor/selective
+PASS: test-monitor 11 /monitor/well-known-destination
+PASS: test-monitor 12 /monitor/unique-destination
+PASS: test-monitor 13 /monitor/wildcard
+PASS: test-monitor 14 /monitor/no-rule
+PASS: test-monitor 15 /monitor/eavesdrop
+PASS: test-monitor 16 /monitor/no-eavesdrop
+PASS: test-monitor 17 /monitor/activation
+PASS: test-loopback 1 /connect/tcp
+PASS: test-loopback 2 /connect/nonce-tcp
+PASS: test-loopback 3 /connect/unix/tmpdir
+PASS: test-loopback 4 /connect/unix/dir
+PASS: test-loopback 5 /connect/unix/runtime
+PASS: test-loopback 6 /connect/unix/no-runtime
+PASS: test-loopback 7 /message/tcp
+PASS: test-loopback 8 /message/nonce-tcp
+PASS: test-loopback 9 /message/bad-guid
+PASS: test-loopback 10 /message/unix/tmpdir
+PASS: test-loopback 11 /message/unix/dir
+PASS: test-marshal 1 /demarshal/le
+PASS: test-marshal 2 /demarshal/be
+PASS: test-marshal 3 /demarshal/needed/le
+PASS: test-marshal 4 /demarshal/needed/be
+PASS: test-refs 1 /refs/connection
+PASS: test-refs 2 /refs/message
+PASS: test-refs 3 /refs/pending-call
+PASS: test-refs 4 /refs/server
+PASS: test-relay 1 /connect
+PASS: test-relay 2 /relay
+PASS: test-relay 3 /limit
+PASS: test-syntax 1 /syntax/path
+PASS: test-syntax 2 /syntax/interface
+PASS: test-syntax 3 /syntax/error
+PASS: test-syntax 4 /syntax/member
+PASS: test-syntax 5 /syntax/bus-name
+PASS: test-syntax 6 /syntax/signature
+PASS: test-syntax 7 /syntax/single-signature
+PASS: test-syntax 8 /syntax/utf8
+PASS: test-syslog 1 /syslog/normal
+SKIP: test-uid-permissions 1 /uid-permissions/uae/other # SKIP cannot use alternative uid when not uid 0
+SKIP: test-uid-permissions 2 /uid-permissions/monitor/root # SKIP cannot use alternative uid when not uid 0
+SKIP: test-uid-permissions 3 /uid-permissions/monitor/messagebus # SKIP cannot use alternative uid when not uid 0
+SKIP: test-uid-permissions 4 /uid-permissions/monitor/other # SKIP cannot use alternative uid when not uid 0
+PASS: test-variant 1 /variant/simple
+PASS: test-variant 2 /variant/oom
+PASS: test-sd-activation 1 /sd-activation/activation
+PASS: test-sd-activation 2 /sd-activation/uae
+PASS: test-sd-activation 3 /sd-activation/deny-send/com.example.SendDenied
+PASS: test-sd-activation 4 /sd-activation/deny-receive/com.example.ReceiveDenied
+PASS: test-sd-activation 5 /sd-activation/transient-services/later
+PASS: test-sd-activation 6 /sd-activation/transient-services/in-advance
 ============================================================================
-Testsuite summary for dbus 1.11.16
+Testsuite summary for dbus 1.11.18
 ============================================================================
-# TOTAL: 18
-# PASS:  18
-# SKIP:  0
+# TOTAL: 136
+# PASS:  132
+# SKIP:  4
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
@@ -37,7 +155,7 @@ Testsuite summary for dbus 1.11.16
 ============================================================================
 Making check in name-test
 ============================================================================
-Testsuite summary for dbus 1.11.16
+Testsuite summary for dbus 1.11.18
 ============================================================================
 # TOTAL: 0
 # PASS:  0

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -62,7 +62,7 @@
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.00		| https://github.com/tcsh-org/tcsh/releases
 | shell/zsh				| 5.4.2			| https://sourceforge.net/projects/zsh/files/zsh
-| system/library/dbus			| 1.11.16		| https://dbus.freedesktop.org/releases/dbus
+| system/library/dbus			| 1.11.18		| https://dbus.freedesktop.org/releases/dbus
 | system/library/libdbus-glib		| 0.108			| https://dbus.freedesktop.org/releases/dbus-glib/
 | system/library/pcap			| 1.8.1			| http://www.tcpdump.org/#latest-releases
 | system/management/ipmitool		| 1.8.18		| https://sourceforge.net/projects/ipmitool/files/ipmitool


### PR DESCRIPTION
There are a couple of other cleanups to the build script here too.

* Use `LIBTOOL_NOSTDLIB` feature instead of overriding `make_progxx`;
* Let automatic dependency discovery find SUNWcs.