### PR TITLE
open-vm-tools: update to 10.1.15

### DIFF
--- a/build/open-vm-tools/build.sh
+++ b/build/open-vm-tools/build.sh
@@ -30,9 +30,7 @@
 . ../../lib/functions.sh
 
 PROG=open-vm-tools
-VER=10.1.10
-BUILD=6082533
-BUILDDIR=$PROG-$VER-$BUILD
+VER=10.1.15
 PKG=system/virtualization/open-vm-tools
 SUMMARY="Open Virtual Machine Tools"
 DESC="The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under the VMware hypervisor."
@@ -40,7 +38,7 @@ DESC="The Open Virtual Machine Tools project aims to provide a suite of open sou
 PATH=/usr/gnu/bin:$PATH export PATH
 
 BUILD_DEPENDS_IPS='developer/pkg-config'
-RUN_DEPENDS_IPS='library/glib2 system/library/gcc-5-runtime'
+RUN_DEPENDS_IPS='system/library/gcc-5-runtime'
 
 # _FILE_OFFSET_BITS=64 - Large file interface is required
 # _XPG4_2 - Need cmsg from UNIX95
@@ -89,7 +87,7 @@ install_conf() {
 }
 
 init
-download_source $PROG $PROG $VER-$BUILD
+download_source $PROG $PROG $VER
 patch_source
 prep_build
 export LIBS="-lnsl"

--- a/build/open-vm-tools/patches/lock.patch
+++ b/build/open-vm-tools/patches/lock.patch
@@ -1,5 +1,6 @@
---- open-vm-tools-10.1.10-6082533~/lib/file/fileLockPrimitive.c	2017-07-28 22:19:20.000000000 +0000
-+++ open-vm-tools-10.1.10-6082533/lib/file/fileLockPrimitive.c	2017-09-18 16:58:04.385144884 +0000
+diff -pruN '--exclude=*.orig' open-vm-tools-10.1.15~/lib/file/fileLockPrimitive.c open-vm-tools-10.1.15/lib/file/fileLockPrimitive.c
+--- open-vm-tools-10.1.15~/lib/file/fileLockPrimitive.c	2017-09-29 21:15:57.000000000 +0000
++++ open-vm-tools-10.1.15/lib/file/fileLockPrimitive.c	2017-10-03 09:31:21.681628379 +0000
 @@ -60,8 +60,8 @@
  #define LOGLEVEL_MODULE main
  #include "loglevel_user.h"
@@ -11,7 +12,7 @@
  #define FILELOCK_PROGRESS_DEARTH 8000 // Dearth of progress time in msec
  #define FILELOCK_PROGRESS_SAMPLE 200  // Progress sampling time in msec
  
-@@ -472,8 +472,8 @@
+@@ -472,8 +472,8 @@ fixedUp:
        goto corrupt;
     }
  
@@ -22,7 +23,7 @@
        goto corrupt;
     }
  
-@@ -1096,8 +1096,8 @@
+@@ -1096,8 +1096,8 @@ FileLockWaitForPossession(const char *lo
         ((memberValues->lamportNumber == myValues->lamportNumber) &&
            (Unicode_Compare(memberValues->memberName,
                             myValues->memberName) < 0))) &&
@@ -33,7 +34,7 @@
        char *path;
        uint32 loopCount;
        Bool   thisMachine;
-@@ -1675,7 +1675,7 @@
+@@ -1675,7 +1675,7 @@ FileLockIntrinsicPortable(const char *pa
            */
  
           Warning(LGPFX" %s implicit %s lock succeeded on '%s'.\n",
@@ -42,7 +43,7 @@
  
           *err = 0;
           memberFilePath = &implicitReadToken;
-@@ -1838,7 +1838,7 @@
+@@ -1838,7 +1838,7 @@ FileLockIntrinsic(const char *pathName,
     /* Construct the locking directory path */
     lockBase = Unicode_Append(pathName, FILELOCK_SUFFIX);
  

--- a/build/open-vm-tools/patches/nicInfo.patch
+++ b/build/open-vm-tools/patches/nicInfo.patch
@@ -1,5 +1,6 @@
---- open-vm-tools-10.1.10-6082533/lib/nicInfo/nicInfoPosix.c	2017-07-28 22:19:20.000000000 +0000
-+++ l/lib/nicInfo/nicInfoPosix.c	2017-09-18 19:31:27.588587527 +0000
+diff -pruN '--exclude=*.orig' open-vm-tools-10.1.15~/lib/nicInfo/nicInfoPosix.c open-vm-tools-10.1.15/lib/nicInfo/nicInfoPosix.c
+--- open-vm-tools-10.1.15~/lib/nicInfo/nicInfoPosix.c	2017-09-29 21:15:57.000000000 +0000
++++ open-vm-tools-10.1.15/lib/nicInfo/nicInfoPosix.c	2017-10-03 09:31:21.952732216 +0000
 @@ -34,11 +34,8 @@
  #include <sys/socket.h>
  #include <sys/stat.h>
@@ -12,7 +13,7 @@
  #ifndef NO_DNET
  # ifdef DNET_IS_DUMBNET
  #  include <dumbnet.h>
-@@ -168,7 +168,7 @@
+@@ -171,7 +168,7 @@ GuestInfoGetFqdn(int outBufLen,    // IN
  }
  
  
@@ -21,7 +22,7 @@
  /*
   ******************************************************************************
   * CountNetmaskBits --                                                   */ /**
-@@ -256,7 +256,7 @@
+@@ -259,7 +256,7 @@ GuestInfoGetNicInfo(NicInfoV3 *nicInfo)
     }
  
     return TRUE;
@@ -30,7 +31,7 @@
     struct ifaddrs *ifaddrs = NULL;
  
     if (getifaddrs(&ifaddrs) == 0 && ifaddrs != NULL) {
-@@ -348,7 +345,7 @@
+@@ -348,7 +345,7 @@ GuestInfoGetNicInfo(NicInfoV3 *nicInfo)
   *
   ******************************************************************************
   */

--- a/build/open-vm-tools/patches/no-glib-main-loop-unref.patch
+++ b/build/open-vm-tools/patches/no-glib-main-loop-unref.patch
@@ -1,6 +1,7 @@
---- services/vmtoolsd/mainLoop.c.orig	Tue Oct  7 15:00:06 2014
-+++ services/vmtoolsd/mainLoop.c	Tue Oct  7 15:00:27 2014
-@@ -64,7 +64,15 @@
+diff -pruN '--exclude=*.orig' open-vm-tools-10.1.15~/services/vmtoolsd/mainLoop.c open-vm-tools-10.1.15/services/vmtoolsd/mainLoop.c
+--- open-vm-tools-10.1.15~/services/vmtoolsd/mainLoop.c	2017-09-29 21:15:57.000000000 +0000
++++ open-vm-tools-10.1.15/services/vmtoolsd/mainLoop.c	2017-10-03 09:31:21.147907737 +0000
+@@ -71,7 +71,15 @@ ToolsCoreCleanup(ToolsServiceState *stat
        state->ctx.rpc = NULL;
     }
     g_key_file_free(state->ctx.config);

--- a/build/open-vm-tools/patches/ucontext.patch
+++ b/build/open-vm-tools/patches/ucontext.patch
@@ -1,5 +1,6 @@
---- lib/include/sigPosixRegs.h.orig	Tue Dec  8 07:30:06 2015
-+++ lib/include/sigPosixRegs.h	Tue Dec  8 07:30:15 2015
+diff -pruN '--exclude=*.orig' open-vm-tools-10.1.15~/lib/include/sigPosixRegs.h open-vm-tools-10.1.15/lib/include/sigPosixRegs.h
+--- open-vm-tools-10.1.15~/lib/include/sigPosixRegs.h	2017-09-29 21:15:57.000000000 +0000
++++ open-vm-tools-10.1.15/lib/include/sigPosixRegs.h	2017-10-03 09:31:21.409516608 +0000
 @@ -70,7 +70,7 @@
  
  #include <signal.h>

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -84,7 +84,7 @@
 | library/glib2				| 2.54.0		| https://download.gnome.org/sources/glib/cache.json
 | developer/gnu-binutils		| 2.25			| https://ftp.gnu.org/gnu/binutils | On hold pending illumos fix https://www.illumos.org/issues/6653
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
-| system/virtualization/open-vm-tools	| 10.1.10		| https://github.com/vmware/open-vm-tools/releases
+| system/virtualization/open-vm-tools	| 10.1.15		| https://github.com/vmware/open-vm-tools/releases
 | developer/swig			| 3.0.12		| http://www.swig.org/download.html
 | library/security/trousers		| 0.3.14		| https://sourceforge.net/projects/trousers/files/trousers
 | library/python-2/asn1crypto-27	| 0.23.0		| https://pypi.python.org/pypi/asn1crypto


### PR DESCRIPTION
This release does not use the build number as part of the archive and directory name which simplifies build.sh slightly.
Also, the glib dependency is automatically detected so I've removed the manual entry from build.sh.
Finally, patches have been re-based.

Tested on bloody with VMware 5.5:
* time sync;
* shutdown / restart;
* snapshot with filesystem quiesce;
* service logs showing communication with ESX.
