### PR TITLE
dbus: update to 1.11.20

### DIFF
--- a/build/dbus/build.sh
+++ b/build/dbus/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=dbus
-VER=1.11.18
+VER=1.11.20
 PKG=dbus ##IGNORE##
 SUMMARY="$PROG - IPC-based message notifications"
 DESC="$SUMMARY"

--- a/build/dbus/dbus.mog
+++ b/build/dbus/dbus.mog
@@ -21,14 +21,12 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-<transform dir path=usr/lib$ -> drop>
-<transform dir path=usr/lib/.* -> drop>
-<transform file path=usr/lib/.*dbus-1.* -> drop>
-<transform link path=usr/lib/.*dbus-1.* -> drop>
+<transform dir path=usr/lib -> drop>
+<transform file link path=usr/lib/.*dbus-1 -> drop>
 
-<transform dir path=usr/include.* -> drop>
-<transform file path=usr/include.* -> drop>
-<transform link path=usr/include.* -> drop>
+<transform file dir link path=usr/include -> drop>
+<transform file dir link path=usr/share/doc -> drop>
 

--- a/build/dbus/libdbus.mog
+++ b/build/dbus/libdbus.mog
@@ -21,27 +21,16 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-<transform dir path=etc.* -> drop>
-<transform file path=etc.* -> drop>
-<transform link path=etc.* -> drop>
-<transform dir path=var.* -> drop>
-<transform file path=var.* -> drop>
-<transform link path=var.* -> drop>
-<transform dir path=lib.* -> drop>
-<transform file path=lib.* -> drop>
-<transform link path=lib.* -> drop>
+<transform file dir link path=etc -> drop>
+<transform file dir link path=var -> drop>
+<transform file dir link path=lib -> drop>
 
-<transform dir path=usr/bin.* -> drop>
-<transform file path=usr/bin.* -> drop>
-<transform link path=usr/bin.* -> drop>
-<transform dir path=usr/libexec.* -> drop>
-<transform file path=usr/libexec.* -> drop>
-<transform link path=usr/libexec.* -> drop>
-<transform dir path=usr/share.* -> drop>
-<transform file path=usr/share.* -> drop>
-<transform link path=usr/share.* -> drop>
+<transform file dir link path=usr/bin -> drop>
+<transform file dir link path=usr/libexec -> drop>
+<transform file dir link path=usr/share -> drop>
 
 <transform file path=usr/lib/dbus-daemon$ -> drop>
 <transform file path=usr/lib/cmake/DBus1/DBus1Config.cmake$ -> drop>

--- a/build/dbus/testsuite.log
+++ b/build/dbus/testsuite.log
@@ -143,7 +143,7 @@ PASS: test-sd-activation 4 /sd-activation/deny-receive/com.example.ReceiveDenied
 PASS: test-sd-activation 5 /sd-activation/transient-services/later
 PASS: test-sd-activation 6 /sd-activation/transient-services/in-advance
 ============================================================================
-Testsuite summary for dbus 1.11.18
+Testsuite summary for dbus 1.11.20
 ============================================================================
 # TOTAL: 136
 # PASS:  132
@@ -155,7 +155,7 @@ Testsuite summary for dbus 1.11.18
 ============================================================================
 Making check in name-test
 ============================================================================
-Testsuite summary for dbus 1.11.18
+Testsuite summary for dbus 1.11.20
 ============================================================================
 # TOTAL: 0
 # PASS:  0

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -62,7 +62,7 @@
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.00		| https://github.com/tcsh-org/tcsh/releases
 | shell/zsh				| 5.4.2			| https://sourceforge.net/projects/zsh/files/zsh
-| system/library/dbus			| 1.11.18		| https://dbus.freedesktop.org/releases/dbus
+| system/library/dbus			| 1.11.20		| https://dbus.freedesktop.org/releases/dbus
 | system/library/libdbus-glib		| 0.108			| https://dbus.freedesktop.org/releases/dbus-glib/
 | system/library/pcap			| 1.8.1			| http://www.tcpdump.org/#latest-releases
 | system/management/ipmitool		| 1.8.18		| https://sourceforge.net/projects/ipmitool/files/ipmitool


### PR DESCRIPTION
Also took the opportunity to tidy up the .mog files and drop the following documentation from the library/dbus package:

```
# pkg contents library/dbus | grep /doc/
usr/share/doc/dbus
usr/share/doc/dbus/diagram.png
usr/share/doc/dbus/diagram.svg
usr/share/doc/dbus/examples
usr/share/doc/dbus/examples/GetAllMatchRules.py
usr/share/doc/dbus/examples/example-session-disable-stats.conf
usr/share/doc/dbus/examples/example-system-enable-stats.conf
usr/share/doc/dbus/system-activation.txt
```