### PR TITLE
cffi: update to 1.11.1

### DIFF
--- a/build/python27/cffi/build.sh
+++ b/build/python27/cffi/build.sh
@@ -30,7 +30,7 @@
 
 PKG=library/python-2/cffi-27
 PROG=cffi
-VER=1.11.0
+VER=1.11.1
 SUMMARY="cffi - Foreign Function Interface for Python calling C code"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -88,7 +88,7 @@
 | developer/swig			| 3.0.12		| http://www.swig.org/download.html
 | library/security/trousers		| 0.3.14		| https://sourceforge.net/projects/trousers/files/trousers
 | library/python-2/asn1crypto-27	| 0.23.0		| https://pypi.python.org/pypi/asn1crypto
-| library/python-2/cffi-27		| 1.11.0		| https://pypi.python.org/pypi/cffi
+| library/python-2/cffi-27		| 1.11.1		| https://pypi.python.org/pypi/cffi
 | library/python-2/cheroot-27		| 5.8.3			| https://pypi.python.org/pypi/cheroot
 | library/python-2/cherrypy-27		| 11.0.0		| https://pypi.python.org/pypi/cherrypy
 | library/python-2/coverage-27		| 4.4.1			| https://pypi.python.org/pypi/coverage


### PR DESCRIPTION
`pkg(5)` test suite results according to baseline.