### PR TITLE
m2crypto: update to 0.27.0

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -144,7 +144,7 @@ depend fmri=library/nghttp2@1.26,5.11-@PVER@ type=require
 depend fmri=library/nspr@4.17,5.11-@PVER@ type=require
 depend fmri=library/pcre@8.41,5.11-@PVER@ type=require
 depend fmri=library/python-2/cherrypy-27@11,5.11-@PVER@ type=require
-depend fmri=library/python-2/m2crypto-27@0.26,5.11-@PVER@ type=require
+depend fmri=library/python-2/m2crypto-27@0.27,5.11-@PVER@ type=require
 depend fmri=library/python-2/mako-27@1.0,5.11-@PVER@ type=require
 depend fmri=library/python-2/numpy-27@1.13,5.11-@PVER@ type=require
 depend fmri=library/python-2/ply-27@3.10,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -68,7 +68,7 @@ library/python-2/idna-27		2.6
 library/python-2/ipaddress-27		1.0
 library/python-2/jsonschema-27		2.6
 library/python-2/lxml-27		4.0
-library/python-2/m2crypto-27		0.26
+library/python-2/m2crypto-27		0.27
 library/python-2/mako-27		1.0
 library/python-2/numpy-27		1.13
 library/python-2/ply-27			3.10

--- a/build/python27/m2crypto/build.sh
+++ b/build/python27/m2crypto/build.sh
@@ -30,7 +30,7 @@
 
 PKG=library/python-2/m2crypto-27
 PROG=M2Crypto
-VER=0.26.4
+VER=0.27.0
 SUMMARY="Python interface for openssl"
 DESC="M2Crypto provides a python interface to the openssl library."
 

--- a/build/python27/m2crypto/patches/include.patch
+++ b/build/python27/m2crypto/patches/include.patch
@@ -1,0 +1,10 @@
+--- M2Crypto-0.27.0~/setup.py	Thu Oct  5 20:55:05 2017
++++ M2Crypto-0.27.0/setup.py	Fri Oct  6 09:25:11 2017
+@@ -153,6 +153,7 @@
+         if _openssl and os.path.isdir(_openssl):
+             self.openssl = _openssl
+ 
++	self.include_dirs.append('/usr/include')
+         log.debug('self.include_dirs = %s', self.include_dirs)
+         log.debug('self.openssl = %s', self.openssl)
+         openssl_library_dir = os.path.join(self.openssl, 'lib')

--- a/build/python27/m2crypto/patches/series
+++ b/build/python27/m2crypto/patches/series
@@ -1,1 +1,2 @@
 M2Crypto-crl.patch
+include.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -100,7 +100,7 @@
 | library/python-2/jsonrpclib-27	| 0.1.7			| https://pypi.python.org/pypi/jsonrpclib
 | library/python-2/jsonschema-27	| 2.6.0			| https://pypi.python.org/pypi/jsonschema
 | library/python-2/lxml-27		| 4.0.0			| https://pypi.python.org/pypi/lxml/
-| library/python-2/m2crypto-27		| 0.26.4		| https://pypi.python.org/pypi/M2Crypto
+| library/python-2/m2crypto-27		| 0.27.0		| https://pypi.python.org/pypi/M2Crypto
 | library/python-2/mako-27		| 1.0.7			| https://pypi.python.org/pypi/Mako
 | library/python-2/numpy-27		| 1.13.3		| https://pypi.python.org/pypi/numpy
 | library/python-2/ply-27		| 3.10			| https://pypi.python.org/pypi/ply


### PR DESCRIPTION
`pkg(5)` test suite ran with no differences to baseline for components that are used in OmniOS.