### PR TITLE
openssh: sftp-readonly patch

### DIFF
--- a/build/openssh/patches/0001-Skip-config-check.patch
+++ b/build/openssh/patches/0001-Skip-config-check.patch
@@ -10,15 +10,10 @@ Subject: [PATCH 01/34] Skip config check
 # they are not suitable in a build system.  This is for Solaris only, so we
 # will not contribute back this change to the upstream community.
 #
----
- Makefile.in | 11 ++++++++++-
- 1 file changed, 10 insertions(+), 1 deletion(-)
-
-diff --git a/Makefile.in b/Makefile.in
-index e10f3742..4bbfb736 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -302,7 +302,16 @@ install-nokeys: $(CONFIGFILES) $(MANPAGES) $(TARGETS) install-files install-sysc
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:44.264425265 +0000
+@@ -306,7 +306,16 @@ install-nokeys: $(CONFIGFILES) $(MANPAGE
  install-nosysconf: $(CONFIGFILES) $(MANPAGES) $(TARGETS) install-files
  
  check-config:
@@ -36,6 +31,3 @@ index e10f3742..4bbfb736 100644
  
  install-files:
  	$(srcdir)/mkinstalldirs $(DESTDIR)$(bindir)
--- 
-2.11.0
-

--- a/build/openssh/patches/0002-PAM-Support.patch
+++ b/build/openssh/patches/0002-PAM-Support.patch
@@ -10,15 +10,10 @@ Subject: [PATCH 02/34] PAM Support
 #
 
 *** orig/servconf.c	Mon Dec  5 17:23:03 2011
----
- servconf.c | 14 ++++++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/servconf.c b/servconf.c
-index 795ddbab..409d4800 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -194,7 +194,12 @@ fill_default_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.317091811 +0000
+@@ -194,7 +194,12 @@ fill_default_server_options(ServerOption
  
  	/* Portable-specific options */
  	if (options->use_pam == -1)
@@ -31,7 +26,7 @@ index 795ddbab..409d4800 100644
  
  	/* Standard Options */
  	if (options->num_host_key_files == 0) {
-@@ -998,8 +1003,17 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1007,8 +1012,17 @@ process_server_config_line(ServerOptions
  	switch (opcode) {
  	/* Portable-specific options */
  	case sUsePAM:
@@ -49,6 +44,3 @@ index 795ddbab..409d4800 100644
  
  	/* Standard Options */
  	case sBadOption:
--- 
-2.11.0
-

--- a/build/openssh/patches/0003-lastlogin.patch
+++ b/build/openssh/patches/0003-lastlogin.patch
@@ -4,15 +4,10 @@ Date: Mon, 3 Aug 2015 14:34:41 -0700
 Subject: [PATCH 03/34] lastlogin
 
 *** old/servconf.c Wed Sep 17 02:54:26 2014
----
- sshd_config.4 | 7 ++++---
- 1 file changed, 4 insertions(+), 3 deletions(-)
-
-diff --git a/sshd_config.4 b/sshd_config.4
-index 32b29d24..9eea74bd 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
-@@ -1260,8 +1260,8 @@ Specifies whether
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:44.364608462 +0000
+@@ -1276,8 +1276,8 @@ Specifies whether
  .Xr sshd 8
  should print the date and time of the last user login when a user logs
  in interactively.
@@ -23,7 +18,7 @@ index 32b29d24..9eea74bd 100644
  .It Cm PrintMotd
  Specifies whether
  .Xr sshd 8
-@@ -1667,7 +1667,8 @@ This file should be writable by root only, but it is recommended
+@@ -1665,7 +1665,8 @@ This file should be writable by root onl
  .El
  .Sh SEE ALSO
  .Xr sftp-server 8 ,
@@ -33,6 +28,3 @@ index 32b29d24..9eea74bd 100644
  .Sh AUTHORS
  .An -nosplit
  OpenSSH is a derivative of the original and free
--- 
-2.11.0
-

--- a/build/openssh/patches/0004-Reorganise-man-pages-into-Illumos-numbering-adjust-t.patch
+++ b/build/openssh/patches/0004-Reorganise-man-pages-into-Illumos-numbering-adjust-t.patch
@@ -4,23 +4,10 @@ Date: Mon, 3 Aug 2015 14:34:55 -0700
 Subject: [PATCH 04/34] Reorganise man pages into Illumos numbering, adjust
  text
 
----
- Makefile.in           |   22 +-
- contrib/ssh-copy-id.1 |    4 +-
- scp.1                 |    8 +-
- sftp.1                |   14 +-
- ssh-add.1             |    4 +-
- ssh-agent.1           |    8 +-
- ssh-keygen.1          |   20 +-
- ssh-keyscan.1         |    2 +-
- ssh.1                 |   50 +-
- 23 files changed, 4911 insertions(+), 4913 deletions(-)
-
-diff --git a/Makefile.in b/Makefile.in
-index 4bbfb736..6541b3bb 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -112,8 +112,8 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:44.264425265 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:44.412028093 +0000
+@@ -112,8 +112,8 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passw
  	sandbox-seccomp-filter.o sandbox-capsicum.o sandbox-pledge.o \
  	sandbox-solaris.o
  
@@ -31,7 +18,7 @@ index 4bbfb736..6541b3bb 100644
  MANTYPE		= @MANTYPE@
  
  CONFIGFILES=sshd_config.out ssh_config.out moduli.out
-@@ -318,8 +318,8 @@ install-files:
+@@ -322,8 +322,8 @@ install-files:
  	$(srcdir)/mkinstalldirs $(DESTDIR)$(sbindir)
  	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)
  	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)/$(mansubdir)1
@@ -42,7 +29,7 @@ index 4bbfb736..6541b3bb 100644
  	$(srcdir)/mkinstalldirs $(DESTDIR)$(libexecdir)
  	(umask 022 ; $(srcdir)/mkinstalldirs $(DESTDIR)$(PRIVSEP_PATH))
  	$(INSTALL) -m 0755 $(STRIP_OPT) ssh$(EXEEXT) $(DESTDIR)$(bindir)/ssh$(EXEEXT)
-@@ -339,14 +339,14 @@ install-files:
+@@ -343,14 +343,14 @@ install-files:
  	$(INSTALL) -m 644 ssh-agent.1.out $(DESTDIR)$(mandir)/$(mansubdir)1/ssh-agent.1
  	$(INSTALL) -m 644 ssh-keygen.1.out $(DESTDIR)$(mandir)/$(mansubdir)1/ssh-keygen.1
  	$(INSTALL) -m 644 ssh-keyscan.1.out $(DESTDIR)$(mandir)/$(mansubdir)1/ssh-keyscan.1
@@ -64,10 +51,9 @@ index 4bbfb736..6541b3bb 100644
  
  install-sysconf:
  	if [ ! -d $(DESTDIR)$(sysconfdir) ]; then \
-diff --git a/contrib/ssh-copy-id.1 b/contrib/ssh-copy-id.1
-index 8850cced..270e13ef 100644
---- a/contrib/ssh-copy-id.1
-+++ b/contrib/ssh-copy-id.1
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/contrib/ssh-copy-id.1 openssh-7.5p1/contrib/ssh-copy-id.1
+--- openssh-7.5p1~/contrib/ssh-copy-id.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/contrib/ssh-copy-id.1	2017-10-06 12:34:44.412230917 +0000
 @@ -95,7 +95,7 @@ options, respectively.
  Rather than specifying these as command line options, it is often better to use (per-host) settings in
  .Xr ssh 1 Ns 's
@@ -83,11 +69,10 @@ index 8850cced..270e13ef 100644
  .Xr ssh-agent 1 ,
 -.Xr sshd 8
 +.Xr sshd 1M
-diff --git a/scp.1 b/scp.1
-index 4ae87775..515fa400 100644
---- a/scp.1
-+++ b/scp.1
-@@ -116,13 +116,13 @@ Limits the used bandwidth, specified in Kbit/s.
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/scp.1 openssh-7.5p1/scp.1
+--- openssh-7.5p1~/scp.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/scp.1	2017-10-06 12:34:44.412338458 +0000
+@@ -116,13 +116,13 @@ Limits the used bandwidth, specified in
  Can be used to pass options to
  .Nm ssh
  in the format used in
@@ -103,7 +88,7 @@ index 4ae87775..515fa400 100644
  .Pp
  .Bl -tag -width Ds -offset indent -compact
  .It AddressFamily
-@@ -233,8 +233,8 @@ debugging connection, authentication, and configuration problems.
+@@ -233,8 +233,8 @@ debugging connection, authentication, an
  .Xr ssh-add 1 ,
  .Xr ssh-agent 1 ,
  .Xr ssh-keygen 1 ,
@@ -114,11 +99,10 @@ index 4ae87775..515fa400 100644
  .Sh HISTORY
  .Nm
  is based on the rcp program in
-diff --git a/sftp.1 b/sftp.1
-index fbdd00a1..a281ebcd 100644
---- a/sftp.1
-+++ b/sftp.1
-@@ -85,7 +85,7 @@ The final usage format allows for automated sessions using the
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp.1 openssh-7.5p1/sftp.1
+--- openssh-7.5p1~/sftp.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sftp.1	2017-10-06 12:34:44.412497731 +0000
+@@ -85,7 +85,7 @@ The final usage format allows for automa
  option.
  In such cases, it is necessary to configure non-interactive authentication
  to obviate the need to enter a password at connection time (see
@@ -127,7 +111,7 @@ index fbdd00a1..a281ebcd 100644
  and
  .Xr ssh-keygen 1
  for details).
-@@ -179,7 +179,7 @@ Limits the used bandwidth, specified in Kbit/s.
+@@ -179,7 +179,7 @@ Limits the used bandwidth, specified in
  Can be used to pass options to
  .Nm ssh
  in the format used in
@@ -167,11 +151,10 @@ index fbdd00a1..a281ebcd 100644
  .Rs
  .%A T. Ylonen
  .%A S. Lehtinen
-diff --git a/ssh-add.1 b/ssh-add.1
-index f02b595d..b4d7c8f8 100644
---- a/ssh-add.1
-+++ b/ssh-add.1
-@@ -134,7 +134,7 @@ Add keys provided by the PKCS#11 shared library
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-add.1 openssh-7.5p1/ssh-add.1
+--- openssh-7.5p1~/ssh-add.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-add.1	2017-10-06 12:34:44.412593181 +0000
+@@ -134,7 +134,7 @@ Add keys provided by the PKCS#11 shared
  Set a maximum lifetime when adding identities to an agent.
  The lifetime may be specified in seconds or in a time format
  specified in
@@ -180,7 +163,7 @@ index f02b595d..b4d7c8f8 100644
  .It Fl X
  Unlock the agent.
  .It Fl x
-@@ -200,7 +200,7 @@ is unable to contact the authentication agent.
+@@ -200,7 +200,7 @@ is unable to contact the authentication
  .Xr ssh-agent 1 ,
  .Xr ssh-askpass 1 ,
  .Xr ssh-keygen 1 ,
@@ -189,10 +172,9 @@ index f02b595d..b4d7c8f8 100644
  .Sh AUTHORS
  OpenSSH is a derivative of the original and free
  ssh 1.2.12 release by Tatu Ylonen.
-diff --git a/ssh-agent.1 b/ssh-agent.1
-index 83b2b41c..d2cad7e8 100644
---- a/ssh-agent.1
-+++ b/ssh-agent.1
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-agent.1 openssh-7.5p1/ssh-agent.1
+--- openssh-7.5p1~/ssh-agent.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-agent.1	2017-10-06 12:34:44.412707116 +0000
 @@ -71,7 +71,7 @@ Keys are added using
  (see
  .Cm AddKeysToAgent
@@ -202,7 +184,7 @@ index 83b2b41c..d2cad7e8 100644
  for details)
  or
  .Xr ssh-add 1 .
-@@ -132,7 +132,7 @@ The default is to allow loading PKCS#11 libraries from
+@@ -132,7 +132,7 @@ The default is to allow loading PKCS#11
  .Dq /usr/lib/*,/usr/local/lib/* .
  PKCS#11 libraries that do not match the whitelist will be refused.
  See PATTERNS in
@@ -211,7 +193,7 @@ index 83b2b41c..d2cad7e8 100644
  for a description of pattern-list syntax.
  .It Fl s
  Generate Bourne shell commands on
-@@ -143,7 +143,7 @@ does not look like it's a csh style of shell.
+@@ -143,7 +143,7 @@ does not look like it's a csh style of s
  .It Fl t Ar life
  Set a default value for the maximum lifetime of identities added to the agent.
  The lifetime may be specified in seconds or in a time format specified in
@@ -220,7 +202,7 @@ index 83b2b41c..d2cad7e8 100644
  A lifetime specified for an identity with
  .Xr ssh-add 1
  overrides this value.
-@@ -218,7 +218,7 @@ The sockets should get automatically removed when the agent exits.
+@@ -218,7 +218,7 @@ The sockets should get automatically rem
  .Xr ssh 1 ,
  .Xr ssh-add 1 ,
  .Xr ssh-keygen 1 ,
@@ -229,10 +211,9 @@ index 83b2b41c..d2cad7e8 100644
  .Sh AUTHORS
  .An -nosplit
  OpenSSH is a derivative of the original and free ssh 1.2.12 release by
-diff --git a/ssh-keygen.1 b/ssh-keygen.1
-index ce2213c7..f0824509 100644
---- a/ssh-keygen.1
-+++ b/ssh-keygen.1
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-keygen.1 openssh-7.5p1/ssh-keygen.1
+--- openssh-7.5p1~/ssh-keygen.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-keygen.1	2017-10-06 12:34:44.412933265 +0000
 @@ -178,9 +178,7 @@ key in
  .Pa ~/.ssh/id_ed25519
  or
@@ -253,7 +234,7 @@ index ce2213c7..f0824509 100644
  to generate new host keys.
  .It Fl a Ar rounds
  When saving a new-format private key (i.e. an ed25519 key or any SSH protocol
-@@ -449,7 +447,7 @@ Disable PTY allocation (permitted by default).
+@@ -449,7 +447,7 @@ Disable PTY allocation (permitted by def
  Disable execution of
  .Pa ~/.ssh/rc
  by
@@ -271,7 +252,7 @@ index ce2213c7..f0824509 100644
  .It Ic permit-x11-forwarding
  Allows X11 forwarding.
  .It Ic source-address Ns = Ns Ar address_list
-@@ -556,7 +554,7 @@ The start time may be specified as a date in YYYYMMDD format, a time
+@@ -556,7 +554,7 @@ The start time may be specified as a dat
  in YYYYMMDDHHMMSS format or a relative time (to the current time) consisting
  of a minus sign followed by a relative time in the format described in the
  TIME FORMATS section of
@@ -289,7 +270,7 @@ index ce2213c7..f0824509 100644
  or
  .Xr ssh 1 .
  Please refer to those manual pages for details.
-@@ -846,14 +844,14 @@ There is no need to keep the contents of this file secret.
+@@ -846,14 +844,14 @@ There is no need to keep the contents of
  .It Pa /etc/moduli
  Contains Diffie-Hellman groups used for DH-GEX.
  The file format is described in
@@ -307,11 +288,10 @@ index ce2213c7..f0824509 100644
  .Rs
  .%R RFC 4716
  .%T "The Secure Shell (SSH) Public Key File Format"
-diff --git a/ssh-keyscan.1 b/ssh-keyscan.1
-index d29d9d90..17a69770 100644
---- a/ssh-keyscan.1
-+++ b/ssh-keyscan.1
-@@ -166,7 +166,7 @@ $ ssh-keyscan -t rsa,dsa,ecdsa,ed25519 -f ssh_hosts | \e
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-keyscan.1 openssh-7.5p1/ssh-keyscan.1
+--- openssh-7.5p1~/ssh-keyscan.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-keyscan.1	2017-10-06 12:34:44.413038258 +0000
+@@ -166,7 +166,7 @@ $ ssh-keyscan -t rsa,dsa,ecdsa,ed25519 -
  .Ed
  .Sh SEE ALSO
  .Xr ssh 1 ,
@@ -320,10 +300,9 @@ index d29d9d90..17a69770 100644
  .Sh AUTHORS
  .An -nosplit
  .An David Mazieres Aq Mt dm@lcs.mit.edu
-diff --git a/ssh.1 b/ssh.1
-index 4011c65a..df81563e 100644
---- a/ssh.1
-+++ b/ssh.1
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh.1 openssh-7.5p1/ssh.1
+--- openssh-7.5p1~/ssh.1	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh.1	2017-10-06 12:34:44.415186344 +0000
 @@ -173,7 +173,7 @@ listed in order of preference.
  See the
  .Cm Ciphers
@@ -333,7 +312,7 @@ index 4011c65a..df81563e 100644
  for more information.
  .Pp
  .It Fl D Xo
-@@ -417,7 +417,7 @@ mode with confirmation required before slave connections are accepted.
+@@ -417,7 +417,7 @@ mode with confirmation required before s
  Refer to the description of
  .Cm ControlMaster
  in
@@ -342,7 +321,7 @@ index 4011c65a..df81563e 100644
  for details.
  .Pp
  .It Fl m Ar mac_spec
-@@ -476,7 +476,7 @@ Can be used to give options in the format used in the configuration file.
+@@ -476,7 +476,7 @@ Can be used to give options in the forma
  This is useful for specifying options for which there is no separate
  command-line flag.
  For full details of the options listed below, and their possible values, see
@@ -387,7 +366,7 @@ index 4011c65a..df81563e 100644
  for more information.
  .Pp
  .It Fl x
-@@ -804,14 +804,14 @@ By default this information is sent to stderr.
+@@ -804,14 +804,14 @@ By default this information is sent to s
  may additionally obtain configuration data from
  a per-user configuration file and a system-wide configuration file.
  The file format and configuration options are described in
@@ -422,7 +401,7 @@ index 4011c65a..df81563e 100644
  Basic help is available, using the
  .Fl h
  option.
-@@ -1280,7 +1280,7 @@ Are you sure you want to continue connecting (yes/no)?
+@@ -1280,7 +1280,7 @@ Are you sure you want to continue connec
  See the
  .Cm VerifyHostKeyDNS
  option in
@@ -449,7 +428,7 @@ index 4011c65a..df81563e 100644
  .Sh FILES
  .Bl -tag -width Ds -compact
  .It Pa ~/.rhosts
-@@ -1448,7 +1448,7 @@ This file is used for host-based authentication (see above).
+@@ -1448,7 +1448,7 @@ This file is used for host-based authent
  On some machines this file may need to be
  world-readable if the user's home directory is on an NFS partition,
  because
@@ -467,7 +446,7 @@ index 4011c65a..df81563e 100644
  manual page.
  This file is not highly sensitive, but the recommended
  permissions are read/write for the user, and not accessible by others.
-@@ -1481,7 +1481,7 @@ permissions are read/write for the user, and not accessible by others.
+@@ -1481,7 +1481,7 @@ permissions are read/write for the user,
  .It Pa ~/.ssh/config
  This is the per-user configuration file.
  The file format and configuration options are described in
@@ -476,7 +455,7 @@ index 4011c65a..df81563e 100644
  Because of the potential for abuse, this file must have strict permissions:
  read/write for the user, and not writable by others.
  .Pp
-@@ -1518,7 +1518,7 @@ sensitive and can (but need not) be readable by anyone.
+@@ -1518,7 +1518,7 @@ sensitive and can (but need not) be read
  Contains a list of host keys for all hosts the user has logged into
  that are not already in the systemwide list of known host keys.
  See
@@ -503,7 +482,7 @@ index 4011c65a..df81563e 100644
  .Pp
  .It Pa /etc/ssh/ssh_host_key
  .It Pa /etc/ssh/ssh_host_dsa_key
-@@ -1560,7 +1560,7 @@ system administrator to contain the public host keys of all machines in the
+@@ -1560,7 +1560,7 @@ system administrator to contain the publ
  organization.
  It should be world-readable.
  See

--- a/build/openssh/patches/0005-Deprecated-SunSSH-options.patch
+++ b/build/openssh/patches/0005-Deprecated-SunSSH-options.patch
@@ -11,15 +11,10 @@ Subject: [PATCH 05/34] Deprecated SunSSH options
 # changed from deprecated to supported. Since this is for Solaris only, we will
 # not contribute back this change to the upstream community.
 #
----
- readconf.c | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
-
-diff --git a/readconf.c b/readconf.c
-index fa3fab8f..e11a928d 100644
---- a/readconf.c
-+++ b/readconf.c
-@@ -297,6 +297,24 @@ static struct {
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.c openssh-7.5p1/readconf.c
+--- openssh-7.5p1~/readconf.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/readconf.c	2017-10-06 12:34:44.463408803 +0000
+@@ -309,6 +309,24 @@ static struct {
  	{ "ignoreunknown", oIgnoreUnknown },
  	{ "proxyjump", oProxyJump },
  
@@ -44,6 +39,3 @@ index fa3fab8f..e11a928d 100644
  	{ NULL, oBadOption }
  };
  
--- 
-2.11.0
-

--- a/build/openssh/patches/0006-GSS-store-creds-for-Solaris.patch
+++ b/build/openssh/patches/0006-GSS-store-creds-for-Solaris.patch
@@ -3,19 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:34 -0700
 Subject: [PATCH 06/34] GSS store creds for Solaris
 
----
- configure.ac    |  3 +++
- gss-serv-krb5.c |  7 ++++++-
- gss-serv.c      | 44 ++++++++++++++++++++++++++++++++++++++++++++
- servconf.c      |  4 ++++
- sshd.c          | 14 ++++++++++++++
- 5 files changed, 71 insertions(+), 1 deletion(-)
-
-diff --git a/configure.ac b/configure.ac
-index eb9f45dc..f5deed69 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -949,6 +949,9 @@ mips-sony-bsd|mips-sony-newsos4)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:44.509877706 +0000
+@@ -952,6 +952,9 @@ mips-sony-bsd|mips-sony-newsos4)
  		],
  	)
  	TEST_SHELL=$SHELL	# let configure find us a capable shell
@@ -25,11 +16,10 @@ index eb9f45dc..f5deed69 100644
  	;;
  *-*-sunos4*)
  	CPPFLAGS="$CPPFLAGS -DSUNOS4"
-diff --git a/gss-serv-krb5.c b/gss-serv-krb5.c
-index 795992d9..6e6cff7b 100644
---- a/gss-serv-krb5.c
-+++ b/gss-serv-krb5.c
-@@ -110,7 +110,7 @@ ssh_gssapi_krb5_userok(ssh_gssapi_client *client, char *name)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/gss-serv-krb5.c openssh-7.5p1/gss-serv-krb5.c
+--- openssh-7.5p1~/gss-serv-krb5.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/gss-serv-krb5.c	2017-10-06 12:34:44.509992163 +0000
+@@ -110,7 +110,7 @@ ssh_gssapi_krb5_userok(ssh_gssapi_client
  	return retval;
  }
  
@@ -38,7 +28,7 @@ index 795992d9..6e6cff7b 100644
  /* This writes out any forwarded credentials from the structure populated
   * during userauth. Called after we have setuid to the user */
  
-@@ -196,6 +196,7 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_client *client)
+@@ -196,6 +196,7 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_cl
  
  	return;
  }
@@ -58,11 +48,10 @@ index 795992d9..6e6cff7b 100644
  };
  
  #endif /* KRB5 */
-diff --git a/gss-serv.c b/gss-serv.c
-index 53993d67..209ffe82 100644
---- a/gss-serv.c
-+++ b/gss-serv.c
-@@ -320,22 +320,66 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_gssapi_client *client)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/gss-serv.c openssh-7.5p1/gss-serv.c
+--- openssh-7.5p1~/gss-serv.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/gss-serv.c	2017-10-06 12:34:44.510106068 +0000
+@@ -320,22 +320,66 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_g
  void
  ssh_gssapi_cleanup_creds(void)
  {
@@ -129,10 +118,9 @@ index 53993d67..209ffe82 100644
  }
  
  /* This allows GSSAPI methods to do things to the childs environment based
-diff --git a/servconf.c b/servconf.c
-index 409d4800..e98c6500 100644
---- a/servconf.c
-+++ b/servconf.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.317091811 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.510387478 +0000
 @@ -484,7 +484,11 @@ static struct {
  	{ "afstokenpassing", sUnsupported, SSHCFG_GLOBAL },
  #ifdef GSSAPI
@@ -145,11 +133,10 @@ index 409d4800..e98c6500 100644
  	{ "gssapistrictacceptorcheck", sGssStrictAcceptor, SSHCFG_GLOBAL },
  #else
  	{ "gssapiauthentication", sUnsupported, SSHCFG_ALL },
-diff --git a/sshd.c b/sshd.c
-index 1dc4d182..e39b3024 100644
---- a/sshd.c
-+++ b/sshd.c
-@@ -2048,9 +2048,23 @@ main(int ac, char **av)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.c openssh-7.5p1/sshd.c
+--- openssh-7.5p1~/sshd.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshd.c	2017-10-06 12:34:44.510656257 +0000
+@@ -2062,9 +2062,23 @@ main(int ac, char **av)
  
  #ifdef GSSAPI
  	if (options.gss_authentication) {
@@ -173,6 +160,3 @@ index 1dc4d182..e39b3024 100644
  	}
  #endif
  #ifdef USE_PAM
--- 
-2.11.0
-

--- a/build/openssh/patches/0007-DTrace-support-for-SFTP.patch
+++ b/build/openssh/patches/0007-DTrace-support-for-SFTP.patch
@@ -3,22 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:43 -0700
 Subject: [PATCH 07/34] DTrace support for SFTP
 
----
- Makefile.in          | 24 ++++++++++++++---
- sftp-server.c        | 25 ++++++++++++++++--
- sftp64.d             | 56 ++++++++++++++++++++++++++++++++++++++++
- sftp_provider.d      | 61 +++++++++++++++++++++++++++++++++++++++++++
- sftp_provider_impl.h | 73 ++++++++++++++++++++++++++++++++++++++++++++++++++++
- 5 files changed, 233 insertions(+), 6 deletions(-)
- create mode 100644 sftp64.d
- create mode 100644 sftp_provider.d
- create mode 100644 sftp_provider_impl.h
-
-diff --git a/Makefile.in b/Makefile.in
-index 6541b3bb..82065077 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -26,6 +26,7 @@ ASKPASS_PROGRAM=$(libexecdir)/ssh-askpass
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:44.412028093 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:44.562196133 +0000
+@@ -26,6 +26,7 @@ ASKPASS_PROGRAM=$(libexecdir)/ssh-askpas
  SFTP_SERVER=$(libexecdir)/sftp-server
  SSH_KEYSIGN=$(libexecdir)/ssh-keysign
  SSH_PKCS11_HELPER=$(libexecdir)/ssh-pkcs11-helper
@@ -34,7 +22,7 @@ index 6541b3bb..82065077 100644
  	ssh-pkcs11.o smult_curve25519_ref.o \
  	poly1305.o chacha.o cipher-chachapoly.o \
  	ssh-ed25519.o digest-openssl.o digest-libc.o hmac.o \
-@@ -110,7 +112,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
+@@ -110,7 +112,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passw
  	sftp-server.o sftp-common.o \
  	sandbox-null.o sandbox-rlimit.o sandbox-systrace.o sandbox-darwin.o \
  	sandbox-seccomp-filter.o sandbox-capsicum.o sandbox-pledge.o \
@@ -43,7 +31,7 @@ index 6541b3bb..82065077 100644
  
  MANPAGES	= moduli.4.out scp.1.out ssh-add.1.out ssh-agent.1.out ssh-keygen.1.out ssh-keyscan.1.out ssh.1.out sshd.1m.out sftp-server.1m.out sftp.1.out ssh-keysign.1m.out ssh-pkcs11-helper.1m.out sshd_config.4.out ssh_config.4.out
  MANPAGES_IN	= moduli.4 scp.1 ssh-add.1 ssh-agent.1 ssh-keygen.1 ssh-keyscan.1 ssh.1 sshd.1m sftp-server.1m sftp.1 ssh-keysign.1m ssh-pkcs11-helper.1m sshd_config.4 ssh_config.4
-@@ -187,8 +189,8 @@ ssh-pkcs11-helper$(EXEEXT): $(LIBCOMPAT) libssh.a ssh-pkcs11-helper.o ssh-pkcs11
+@@ -187,8 +189,8 @@ ssh-pkcs11-helper$(EXEEXT): $(LIBCOMPAT)
  ssh-keyscan$(EXEEXT): $(LIBCOMPAT) libssh.a ssh-keyscan.o
  	$(LD) -o $@ ssh-keyscan.o $(LDFLAGS) -lssh -lopenbsd-compat -lssh $(LIBS)
  
@@ -78,7 +66,7 @@ index 6541b3bb..82065077 100644
  	rm -f regress/unittests/test_helper/*.a
  	rm -f regress/unittests/test_helper/*.o
  	rm -f regress/unittests/sshbuf/*.o
-@@ -347,6 +362,7 @@ install-files:
+@@ -351,6 +366,7 @@ install-files:
  	$(INSTALL) -m 644 sftp-server.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/sftp-server.1m
  	$(INSTALL) -m 644 ssh-keysign.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-keysign.1m
  	$(INSTALL) -m 644 ssh-pkcs11-helper.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-pkcs11-helper.1m
@@ -86,10 +74,9 @@ index 6541b3bb..82065077 100644
  
  install-sysconf:
  	if [ ! -d $(DESTDIR)$(sysconfdir) ]; then \
-diff --git a/sftp-server.c b/sftp-server.c
-index 3619cdfc..78167f9d 100644
---- a/sftp-server.c
-+++ b/sftp-server.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp-server.c openssh-7.5p1/sftp-server.c
+--- openssh-7.5p1~/sftp-server.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sftp-server.c	2017-10-06 12:34:44.562482749 +0000
 @@ -50,6 +50,9 @@
  
  #include "sftp.h"
@@ -166,11 +153,9 @@ index 3619cdfc..78167f9d 100644
  			if (ret < 0) {
  				error("process_write: write failed");
  				status = errno_to_portable(errno);
-diff --git a/sftp64.d b/sftp64.d
-new file mode 100644
-index 00000000..8305d0af
---- /dev/null
-+++ b/sftp64.d
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp64.d openssh-7.5p1/sftp64.d
+--- openssh-7.5p1~/sftp64.d	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/sftp64.d	2017-10-06 12:34:44.562594719 +0000
 @@ -0,0 +1,56 @@
 +/*
 + * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
@@ -228,11 +213,9 @@ index 00000000..8305d0af
 +	sfi_pathname = copyinstr((uintptr_t)*(uint64_t *)copyin(
 +	    (uintptr_t)&s->sftp_pathname, sizeof (uint64_t)));
 +};
-diff --git a/sftp_provider.d b/sftp_provider.d
-new file mode 100644
-index 00000000..99e99202
---- /dev/null
-+++ b/sftp_provider.d
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp_provider.d openssh-7.5p1/sftp_provider.d
+--- openssh-7.5p1~/sftp_provider.d	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/sftp_provider.d	2017-10-06 12:34:44.562678800 +0000
 @@ -0,0 +1,61 @@
 +/*
 + * CDDL HEADER START
@@ -295,11 +278,9 @@ index 00000000..99e99202
 +#pragma D attributes Private/Private/Unknown provider sftp function
 +#pragma D attributes Private/Private/ISA provider sftp name
 +#pragma D attributes Evolving/Evolving/ISA provider sftp args
-diff --git a/sftp_provider_impl.h b/sftp_provider_impl.h
-new file mode 100644
-index 00000000..4b18e6ec
---- /dev/null
-+++ b/sftp_provider_impl.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp_provider_impl.h openssh-7.5p1/sftp_provider_impl.h
+--- openssh-7.5p1~/sftp_provider_impl.h	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/sftp_provider_impl.h	2017-10-06 12:34:44.562761122 +0000
 @@ -0,0 +1,73 @@
 +/*
 + * CDDL HEADER START
@@ -374,6 +355,3 @@ index 00000000..4b18e6ec
 +#endif
 +
 +#endif /* _SFTP_PROVIDER_IMPL_H */
--- 
-2.11.0
-

--- a/build/openssh/patches/0008-Add-DisableBanner-option.patch
+++ b/build/openssh/patches/0008-Add-DisableBanner-option.patch
@@ -3,17 +3,9 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:00 -0700
 Subject: [PATCH 08/34] Add DisableBanner option
 
----
- readconf.c    | 31 +++++++++++++++++++++++++++++++
- readconf.h    |  9 +++++++++
- ssh_config.4  |  8 ++++++++
- sshconnect2.c | 31 +++++++++++++++++++++++++++----
- 4 files changed, 75 insertions(+), 4 deletions(-)
-
-diff --git a/readconf.c b/readconf.c
-index e11a928d..b8c40291 100644
---- a/readconf.c
-+++ b/readconf.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.c openssh-7.5p1/readconf.c
+--- openssh-7.5p1~/readconf.c	2017-10-06 12:34:44.463408803 +0000
++++ openssh-7.5p1/readconf.c	2017-10-06 12:34:44.609720429 +0000
 @@ -163,6 +163,9 @@ typedef enum {
  	oServerAliveInterval, oServerAliveCountMax, oIdentitiesOnly,
  	oSendEnv, oControlPath, oControlMaster, oControlPersist,
@@ -24,7 +16,7 @@ index e11a928d..b8c40291 100644
  	oTunnel, oTunnelDevice, oLocalCommand, oPermitLocalCommand,
  	oVisualHostKey,
  	oKexAlgorithms, oIPQoS, oRequestTTY, oIgnoreUnknown, oProxyUseFdpass,
-@@ -272,6 +275,9 @@ static struct {
+@@ -285,6 +288,9 @@ static struct {
  	{ "controlpersist", oControlPersist },
  	{ "hashknownhosts", oHashKnownHosts },
  	{ "include", oInclude },
@@ -34,7 +26,7 @@ index e11a928d..b8c40291 100644
  	{ "tunnel", oTunnel },
  	{ "tunneldevice", oTunnelDevice },
  	{ "localcommand", oLocalCommand },
-@@ -812,6 +818,17 @@ static const struct multistate multistate_canonicalizehostname[] = {
+@@ -824,6 +830,17 @@ static const struct multistate multistat
  	{ NULL, -1 }
  };
  
@@ -52,7 +44,7 @@ index e11a928d..b8c40291 100644
  /*
   * Processes a single option line as used in the configuration files. This
   * only sets those values that have not already been set.
-@@ -1674,6 +1691,13 @@ parse_keytypes:
+@@ -1694,6 +1711,13 @@ parse_keytypes:
  		charptr = &options->identity_agent;
  		goto parse_string;
  
@@ -66,7 +58,7 @@ index e11a928d..b8c40291 100644
  	case oDeprecated:
  		debug("%s line %d: Deprecated option \"%s\"",
  		    filename, linenum, keyword);
-@@ -1864,6 +1888,9 @@ initialize_options(Options * options)
+@@ -1886,6 +1910,9 @@ initialize_options(Options * options)
  	options->ip_qos_bulk = -1;
  	options->request_tty = -1;
  	options->proxy_use_fdpass = -1;
@@ -76,7 +68,7 @@ index e11a928d..b8c40291 100644
  	options->ignored_unknown = NULL;
  	options->num_canonical_domains = 0;
  	options->num_permitted_cnames = 0;
-@@ -2058,6 +2085,10 @@ fill_default_options(Options * options)
+@@ -2080,6 +2107,10 @@ fill_default_options(Options * options)
  		options->canonicalize_fallback_local = 1;
  	if (options->canonicalize_hostname == -1)
  		options->canonicalize_hostname = SSH_CANONICALISE_NO;
@@ -87,10 +79,9 @@ index e11a928d..b8c40291 100644
  	if (options->fingerprint_hash == -1)
  		options->fingerprint_hash = SSH_FP_HASH_DEFAULT;
  	if (options->update_hostkeys == -1)
-diff --git a/readconf.h b/readconf.h
-index cef55f71..8005ebdd 100644
---- a/readconf.h
-+++ b/readconf.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.h openssh-7.5p1/readconf.h
+--- openssh-7.5p1~/readconf.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/readconf.h	2017-10-06 12:34:44.609835612 +0000
 @@ -169,6 +169,9 @@ typedef struct {
  	char   *jump_extra;
  
@@ -114,11 +105,10 @@ index cef55f71..8005ebdd 100644
  void     initialize_options(Options *);
  void     fill_default_options(Options *);
  void	 fill_default_options_for_canonicalization(Options *);
-diff --git a/ssh_config.4 b/ssh_config.4
-index ff5dc74b..6b790fb7 100644
---- a/ssh_config.4
-+++ b/ssh_config.4
-@@ -572,6 +572,14 @@ If set to a time in seconds, or a time in any of the formats documented in
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh_config.4 openssh-7.5p1/ssh_config.4
+--- openssh-7.5p1~/ssh_config.4	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh_config.4	2017-10-06 12:34:44.610652786 +0000
+@@ -576,6 +576,14 @@ If set to a time in seconds, or a time i
  then the backgrounded master connection will automatically terminate
  after it has remained idle (with no client connections) for the
  specified time.
@@ -133,10 +123,9 @@ index ff5dc74b..6b790fb7 100644
  .It Cm DynamicForward
  Specifies that a TCP port on the local machine be forwarded
  over the secure channel, and the application
-diff --git a/sshconnect2.c b/sshconnect2.c
-index 103a2b36..56942ca7 100644
---- a/sshconnect2.c
-+++ b/sshconnect2.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshconnect2.c openssh-7.5p1/sshconnect2.c
+--- openssh-7.5p1~/sshconnect2.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshconnect2.c	2017-10-06 12:34:44.610914892 +0000
 @@ -82,6 +82,10 @@ extern char *client_version_string;
  extern char *server_version_string;
  extern Options options;
@@ -148,7 +137,7 @@ index 103a2b36..56942ca7 100644
  /*
   * SSH2 key exchange
   */
-@@ -499,15 +503,34 @@ input_userauth_error(int type, u_int32_t seq, void *ctxt)
+@@ -499,15 +503,34 @@ input_userauth_error(int type, u_int32_t
  int
  input_userauth_banner(int type, u_int32_t seq, void *ctxt)
  {
@@ -187,6 +176,3 @@ index 103a2b36..56942ca7 100644
  	free(lang);
  	return 0;
  }
--- 
-2.11.0
-

--- a/build/openssh/patches/0009-PAM-conversation-fix.patch
+++ b/build/openssh/patches/0009-PAM-conversation-fix.patch
@@ -3,15 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:13 -0700
 Subject: [PATCH 09/34] PAM conversation fix
 
----
- auth-pam.c | 36 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 36 insertions(+)
-
-diff --git a/auth-pam.c b/auth-pam.c
-index 7d8b2926..ee09b804 100644
---- a/auth-pam.c
-+++ b/auth-pam.c
-@@ -1130,11 +1130,13 @@ free_pam_environment(char **env)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-pam.c openssh-7.5p1/auth-pam.c
+--- openssh-7.5p1~/auth-pam.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth-pam.c	2017-10-06 12:34:44.659092555 +0000
+@@ -1132,11 +1132,13 @@ free_pam_environment(char **env)
  	free(env);
  }
  
@@ -25,7 +20,7 @@ index 7d8b2926..ee09b804 100644
  static int
  sshpam_passwd_conv(int n, sshpam_const struct pam_message **msg,
      struct pam_response **resp, void *data)
-@@ -1156,12 +1158,24 @@ sshpam_passwd_conv(int n, sshpam_const struct pam_message **msg,
+@@ -1158,12 +1160,24 @@ sshpam_passwd_conv(int n, sshpam_const s
  	for (i = 0; i < n; ++i) {
  		switch (PAM_MSG_MEMBER(msg, i, msg_style)) {
  		case PAM_PROMPT_ECHO_OFF:
@@ -50,7 +45,7 @@ index 7d8b2926..ee09b804 100644
  		case PAM_ERROR_MSG:
  		case PAM_TEXT_INFO:
  			len = strlen(PAM_MSG_MEMBER(msg, i, msg));
-@@ -1197,6 +1211,9 @@ static struct pam_conv passwd_conv = { sshpam_passwd_conv, NULL };
+@@ -1199,6 +1213,9 @@ static struct pam_conv passwd_conv = { s
  int
  sshpam_auth_passwd(Authctxt *authctxt, const char *password)
  {
@@ -60,7 +55,7 @@ index 7d8b2926..ee09b804 100644
  	int flags = (options.permit_empty_passwd == 0 ?
  	    PAM_DISALLOW_NULL_AUTHTOK : 0);
  	char *fake = NULL;
-@@ -1217,6 +1234,15 @@ sshpam_auth_passwd(Authctxt *authctxt, const char *password)
+@@ -1219,6 +1236,15 @@ sshpam_auth_passwd(Authctxt *authctxt, c
  	    options.permit_root_login != PERMIT_YES))
  		sshpam_password = fake = fake_password(password);
  
@@ -76,7 +71,7 @@ index 7d8b2926..ee09b804 100644
  	sshpam_err = pam_set_item(sshpam_handle, PAM_CONV,
  	    (const void *)&passwd_conv);
  	if (sshpam_err != PAM_SUCCESS)
-@@ -1228,6 +1254,16 @@ sshpam_auth_passwd(Authctxt *authctxt, const char *password)
+@@ -1230,6 +1256,16 @@ sshpam_auth_passwd(Authctxt *authctxt, c
  	free(fake);
  	if (sshpam_err == PAM_MAXTRIES)
  		sshpam_set_maxtries_reached(1);
@@ -93,6 +88,3 @@ index 7d8b2926..ee09b804 100644
  	if (sshpam_err == PAM_SUCCESS && authctxt->valid) {
  		debug("PAM: password authentication accepted for %.100s",
  		    authctxt->user);
--- 
-2.11.0
-

--- a/build/openssh/patches/0010-PAM-enhancements-for-Solaris.patch
+++ b/build/openssh/patches/0010-PAM-enhancements-for-Solaris.patch
@@ -3,23 +3,9 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:36:19 -0700
 Subject: [PATCH 10/34] PAM enhancements for Solaris
 
----
- auth-pam.c     | 119 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- auth.h         |   3 ++
- auth2.c        |  61 ++++++++++++++++++++++++++++-
- monitor.c      |  65 +++++++++++++++++++++++++++++++
- monitor.h      |   3 ++
- monitor_wrap.c |  18 +++++++++
- servconf.c     |  56 +++++++++++++++++++++++++++
- servconf.h     |  10 +++++
- sshd.1m        |  27 +++++++++++++
- sshd_config.4  |  18 ++++++++-
- 10 files changed, 376 insertions(+), 4 deletions(-)
-
-diff --git a/auth-pam.c b/auth-pam.c
-index ee09b804..70a25c19 100644
---- a/auth-pam.c
-+++ b/auth-pam.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-pam.c openssh-7.5p1/auth-pam.c
+--- openssh-7.5p1~/auth-pam.c	2017-10-06 12:34:44.659092555 +0000
++++ openssh-7.5p1/auth-pam.c	2017-10-06 12:34:44.705025561 +0000
 @@ -617,6 +617,72 @@ sshpam_cleanup(void)
  	sshpam_handle = NULL;
  }
@@ -165,10 +151,9 @@ index ee09b804..70a25c19 100644
  	sshpam_authctxt = authctxt;
  
  	if (sshpam_err != PAM_SUCCESS) {
-diff --git a/auth.h b/auth.h
-index 338a62da..4a7f2c1f 100644
---- a/auth.h
-+++ b/auth.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth.h openssh-7.5p1/auth.h
+--- openssh-7.5p1~/auth.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth.h	2017-10-06 12:34:44.705125374 +0000
 @@ -81,6 +81,9 @@ struct Authctxt {
  
  	struct sshkey	**prev_userkeys;
@@ -179,11 +164,10 @@ index 338a62da..4a7f2c1f 100644
  };
  /*
   * Every authentication method has to handle authentication requests for
-diff --git a/auth2.c b/auth2.c
-index 9108b861..4623ae02 100644
---- a/auth2.c
-+++ b/auth2.c
-@@ -243,10 +243,21 @@ input_userauth_request(int type, u_int32_t seq, void *ctxt)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2.c openssh-7.5p1/auth2.c
+--- openssh-7.5p1~/auth2.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth2.c	2017-10-06 12:34:44.705371598 +0000
+@@ -245,10 +245,21 @@ input_userauth_request(int type, u_int32
  			PRIVSEP(audit_event(SSH_INVALID_USER));
  #endif
  		}
@@ -202,10 +186,10 @@ index 9108b861..4623ae02 100644
  			PRIVSEP(start_pam(authctxt));
  #endif
 +#endif
-		ssh_packet_set_log_preamble(ssh, "%suser %s",
-		    authctxt->valid ? "authenticating " : "invalid ", user);
-		setproctitle("%s%s", authctxt->valid ? user : "unknown",
-@@ -277,6 +288,18 @@ input_userauth_request(int type, u_int32_t seq, void *ctxt)
+ 		ssh_packet_set_log_preamble(ssh, "%suser %s",
+ 		    authctxt->valid ? "authenticating " : "invalid ", user);
+ 		setproctitle("%s%s", authctxt->valid ? user : "unknown",
+@@ -281,6 +292,18 @@ input_userauth_request(int type, u_int32
  	/* try to authenticate user */
  	m = authmethod_lookup(authctxt, method);
  	if (m != NULL && authctxt->failures < options.max_authtries) {
@@ -224,7 +208,7 @@ index 9108b861..4623ae02 100644
  		debug2("input_userauth_request: try method %s", method);
  		authenticated =	m->userauth(authctxt);
  	}
-@@ -295,6 +318,10 @@ userauth_finish(Authctxt *authctxt, int authenticated, const char *method,
+@@ -300,6 +323,10 @@ userauth_finish(Authctxt *authctxt, int
  	char *methods;
  	int partial = 0;
  
@@ -235,7 +219,7 @@ index 9108b861..4623ae02 100644
  	if (!authctxt->valid && authenticated)
  		fatal("INTERNAL ERROR: authenticated invalid user %s",
  		    authctxt->user);
-@@ -311,6 +338,25 @@ userauth_finish(Authctxt *authctxt, int authenticated, const char *method,
+@@ -316,6 +343,25 @@ userauth_finish(Authctxt *authctxt, int
  	}
  
  	if (authenticated && options.num_auth_methods != 0) {
@@ -261,7 +245,7 @@ index 9108b861..4623ae02 100644
  		if (!auth2_update_methods_lists(authctxt, method, submethod)) {
  			authenticated = 0;
  			partial = 1;
-@@ -324,7 +370,20 @@ userauth_finish(Authctxt *authctxt, int authenticated, const char *method,
+@@ -329,7 +375,20 @@ userauth_finish(Authctxt *authctxt, int
  		return;
  
  #ifdef USE_PAM
@@ -282,16 +266,15 @@ index 9108b861..4623ae02 100644
  		if (!PRIVSEP(do_pam_account())) {
  			/* if PAM returned a message, send it to the user */
  			if (buffer_len(&loginmsg) > 0) {
-@@ -615,5 +674,3 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
+@@ -621,5 +680,3 @@ auth2_update_methods_lists(Authctxt *aut
  		fatal("%s: method not in AuthenticationMethods", __func__);
  	return 0;
  }
 -
 -
-diff --git a/monitor.c b/monitor.c
-index 43f48470..8f044f4e 100644
---- a/monitor.c
-+++ b/monitor.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor.c openssh-7.5p1/monitor.c
+--- openssh-7.5p1~/monitor.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/monitor.c	2017-10-06 12:34:44.705762546 +0000
 @@ -127,6 +127,9 @@ int mm_answer_sign(int, Buffer *);
  int mm_answer_pwnamallow(int, Buffer *);
  int mm_answer_auth2_read_banner(int, Buffer *);
@@ -302,7 +285,7 @@ index 43f48470..8f044f4e 100644
  int mm_answer_authpassword(int, Buffer *);
  int mm_answer_bsdauthquery(int, Buffer *);
  int mm_answer_bsdauthrespond(int, Buffer *);
-@@ -202,10 +205,17 @@ struct mon_table mon_dispatch_proto20[] = {
+@@ -202,10 +205,17 @@ struct mon_table mon_dispatch_proto20[]
      {MONITOR_REQ_SIGN, MON_ONCE, mm_answer_sign},
      {MONITOR_REQ_PWNAM, MON_ONCE, mm_answer_pwnamallow},
      {MONITOR_REQ_AUTHSERV, MON_ONCE, mm_answer_authserv},
@@ -320,7 +303,7 @@ index 43f48470..8f044f4e 100644
      {MONITOR_REQ_PAM_ACCOUNT, 0, mm_answer_pam_account},
      {MONITOR_REQ_PAM_INIT_CTX, MON_ONCE, mm_answer_pam_init_ctx},
      {MONITOR_REQ_PAM_QUERY, 0, mm_answer_pam_query},
-@@ -311,6 +321,25 @@ monitor_child_preauth(Authctxt *_authctxt, struct monitor *pmonitor)
+@@ -312,6 +322,25 @@ monitor_child_preauth(Authctxt *_authctx
  
  		/* Special handling for multiple required authentications */
  		if (options.num_auth_methods != 0) {
@@ -346,7 +329,7 @@ index 43f48470..8f044f4e 100644
  			if (authenticated &&
  			    !auth2_update_methods_lists(authctxt,
  			    auth_method, auth_submethod)) {
-@@ -329,8 +358,21 @@ monitor_child_preauth(Authctxt *_authctxt, struct monitor *pmonitor)
+@@ -330,8 +359,21 @@ monitor_child_preauth(Authctxt *_authctx
  			    !auth_root_allowed(auth_method))
  				authenticated = 0;
  #ifdef USE_PAM
@@ -368,7 +351,7 @@ index 43f48470..8f044f4e 100644
  				Buffer m;
  
  				buffer_init(&m);
-@@ -771,6 +813,11 @@ mm_answer_pwnamallow(int sock, Buffer *m)
+@@ -776,6 +818,11 @@ mm_answer_pwnamallow(int sock, Buffer *m
  	monitor_permit(mon_dispatch, MONITOR_REQ_AUTHSERV, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_AUTH2_READ_BANNER, 1);
  
@@ -380,7 +363,7 @@ index 43f48470..8f044f4e 100644
  #ifdef USE_PAM
  	if (options.use_pam)
  		monitor_permit(mon_dispatch, MONITOR_REQ_PAM_START, 1);
-@@ -810,6 +857,24 @@ mm_answer_authserv(int sock, Buffer *m)
+@@ -815,6 +862,24 @@ mm_answer_authserv(int sock, Buffer *m)
  	return (0);
  }
  
@@ -405,10 +388,9 @@ index 43f48470..8f044f4e 100644
  int
  mm_answer_authpassword(int sock, Buffer *m)
  {
-diff --git a/monitor.h b/monitor.h
-index d68f6745..36e73f79 100644
---- a/monitor.h
-+++ b/monitor.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor.h openssh-7.5p1/monitor.h
+--- openssh-7.5p1~/monitor.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/monitor.h	2017-10-06 12:34:44.705846682 +0000
 @@ -65,6 +65,9 @@ enum monitor_reqtype {
  	MONITOR_REQ_PAM_FREE_CTX = 110, MONITOR_ANS_PAM_FREE_CTX = 111,
  	MONITOR_REQ_AUDIT_EVENT = 112, MONITOR_REQ_AUDIT_COMMAND = 113,
@@ -419,11 +401,10 @@ index d68f6745..36e73f79 100644
  };
  
  struct monitor {
-diff --git a/monitor_wrap.c b/monitor_wrap.c
-index 64ff9288..bc6382f3 100644
---- a/monitor_wrap.c
-+++ b/monitor_wrap.c
-@@ -345,6 +345,24 @@ mm_inform_authserv(char *service, char *style)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor_wrap.c openssh-7.5p1/monitor_wrap.c
+--- openssh-7.5p1~/monitor_wrap.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/monitor_wrap.c	2017-10-06 12:34:44.705989906 +0000
+@@ -345,6 +345,24 @@ mm_inform_authserv(char *service, char *
  	buffer_free(&m);
  }
  
@@ -448,11 +429,10 @@ index 64ff9288..bc6382f3 100644
  /* Do the password authentication */
  int
  mm_auth_password(Authctxt *authctxt, char *password)
-diff --git a/servconf.c b/servconf.c
-index e98c6500..36eb9057 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -164,6 +164,18 @@ initialize_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.510387478 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.706373579 +0000
+@@ -164,6 +164,18 @@ initialize_server_options(ServerOptions
  	options->version_addendum = NULL;
  	options->fingerprint_hash = -1;
  	options->disable_forwarding = -1;
@@ -471,7 +451,7 @@ index e98c6500..36eb9057 100644
  }
  
  /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
-@@ -330,6 +342,12 @@ fill_default_server_options(ServerOptions *options)
+@@ -330,6 +342,12 @@ fill_default_server_options(ServerOption
  		options->ip_qos_bulk = IPTOS_THROUGHPUT;
  	if (options->version_addendum == NULL)
  		options->version_addendum = xstrdup("");
@@ -505,7 +485,7 @@ index e98c6500..36eb9057 100644
  	{ "revokedkeys", sRevokedKeys, SSHCFG_ALL },
  	{ "trustedusercakeys", sTrustedUserCAKeys, SSHCFG_ALL },
  	{ "authorizedprincipalsfile", sAuthorizedPrincipalsFile, SSHCFG_ALL },
-@@ -1854,6 +1879,37 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1860,6 +1885,37 @@ process_server_config_line(ServerOptions
  			options->fingerprint_hash = value;
  		break;
  
@@ -543,10 +523,9 @@ index e98c6500..36eb9057 100644
  	case sDeprecated:
  	case sIgnore:
  	case sUnsupported:
-diff --git a/servconf.h b/servconf.h
-index 5853a974..104852f7 100644
---- a/servconf.h
-+++ b/servconf.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.h openssh-7.5p1/servconf.h
+--- openssh-7.5p1~/servconf.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/servconf.h	2017-10-06 12:34:44.706473218 +0000
 @@ -54,6 +54,10 @@
  /* Magic name for internal sftp-server */
  #define INTERNAL_SFTP_NAME	"internal-sftp"
@@ -571,11 +550,10 @@ index 5853a974..104852f7 100644
  	int	fingerprint_hash;
  }       ServerOptions;
  
-diff --git a/sshd.1m b/sshd.1m
-index b767cc7a..387ea69e 100644
---- a/sshd.1m
-+++ b/sshd.1m
-@@ -920,6 +920,33 @@ concurrently for different ports, this contains the process ID of the one
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.1m openssh-7.5p1/sshd.1m
+--- openssh-7.5p1~/sshd.1m	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshd.1m	2017-10-06 12:34:44.706646264 +0000
+@@ -920,6 +920,33 @@ concurrently for different ports, this c
  started last).
  The content of this file is not sensitive; it can be world-readable.
  .El
@@ -609,11 +587,10 @@ index b767cc7a..387ea69e 100644
  .Sh SEE ALSO
  .Xr scp 1 ,
  .Xr sftp 1 ,
-diff --git a/sshd_config.4 b/sshd_config.4
-index efb10c97..7e4a376b 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
-@@ -1117,6 +1117,21 @@ will refuse connection attempts with a probability of rate/100 (30%)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-10-06 12:34:44.364608462 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:44.706917129 +0000
+@@ -1133,6 +1133,21 @@ will refuse connection attempts with a p
  if there are currently start (10) unauthenticated connections.
  The probability increases linearly and all connection attempts
  are refused if the number of unauthenticated connections reaches full (60).
@@ -635,9 +612,9 @@ index efb10c97..7e4a376b 100644
  .It Cm PasswordAuthentication
  Specifies whether password authentication is allowed.
  The default is
-@@ -1472,8 +1487,7 @@ If
+@@ -1492,8 +1507,7 @@ If
  is enabled, you will not be able to run
- .Xr sshd 1M
+ .Xr sshd 8
  as a non-root user.
 -The default is
 -.Cm no .
@@ -645,6 +622,3 @@ index efb10c97..7e4a376b 100644
  .It Cm VersionAddendum
  Optionally specifies additional text to append to the SSH protocol banner
  sent by the server upon connection.
--- 
-2.11.0
-

--- a/build/openssh/patches/0011-SunSSH-compat-default-config-values.patch
+++ b/build/openssh/patches/0011-SunSSH-compat-default-config-values.patch
@@ -13,18 +13,10 @@ values for the following options to be as same as those in SunSSH.
 
 This is for Solaris only, we will not contribute back these changes to the
 upstream.
----
- readconf.c    | 8 ++++++++
- servconf.c    | 8 ++++++++
- ssh_config.4  | 7 +++++--
- sshd_config.4 | 8 ++++----
- 4 files changed, 25 insertions(+), 6 deletions(-)
-
-diff --git a/readconf.c b/readconf.c
-index b8c40291..e6fd1420 100644
---- a/readconf.c
-+++ b/readconf.c
-@@ -1931,7 +1931,11 @@ fill_default_options(Options * options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.c openssh-7.5p1/readconf.c
+--- openssh-7.5p1~/readconf.c	2017-10-06 12:34:44.609720429 +0000
++++ openssh-7.5p1/readconf.c	2017-10-06 12:34:44.763714825 +0000
+@@ -1953,7 +1953,11 @@ fill_default_options(Options * options)
  	if (options->forward_x11 == -1)
  		options->forward_x11 = 0;
  	if (options->forward_x11_trusted == -1)
@@ -36,7 +28,7 @@ index b8c40291..e6fd1420 100644
  	if (options->forward_x11_timeout == -1)
  		options->forward_x11_timeout = 1200;
  	/*
-@@ -1964,7 +1968,11 @@ fill_default_options(Options * options)
+@@ -1986,7 +1990,11 @@ fill_default_options(Options * options)
  	if (options->challenge_response_authentication == -1)
  		options->challenge_response_authentication = 1;
  	if (options->gss_authentication == -1)
@@ -48,11 +40,10 @@ index b8c40291..e6fd1420 100644
  	if (options->gss_deleg_creds == -1)
  		options->gss_deleg_creds = 0;
  	if (options->password_authentication == -1)
-diff --git a/servconf.c b/servconf.c
-index 36eb9057..6f11010a 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -249,7 +249,11 @@ fill_default_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.706373579 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.764037862 +0000
+@@ -249,7 +249,11 @@ fill_default_server_options(ServerOption
  	if (options->print_lastlog == -1)
  		options->print_lastlog = 1;
  	if (options->x11_forwarding == -1)
@@ -64,7 +55,7 @@ index 36eb9057..6f11010a 100644
  	if (options->x11_display_offset == -1)
  		options->x11_display_offset = 10;
  	if (options->x11_use_localhost == -1)
-@@ -283,7 +287,11 @@ fill_default_server_options(ServerOptions *options)
+@@ -283,7 +287,11 @@ fill_default_server_options(ServerOption
  	if (options->kerberos_get_afs_token == -1)
  		options->kerberos_get_afs_token = 0;
  	if (options->gss_authentication == -1)
@@ -76,11 +67,10 @@ index 36eb9057..6f11010a 100644
  	if (options->gss_cleanup_creds == -1)
  		options->gss_cleanup_creds = 1;
  	if (options->gss_strict_acceptor == -1)
-diff --git a/ssh_config.4 b/ssh_config.4
-index 6b790fb7..0953f11c 100644
---- a/ssh_config.4
-+++ b/ssh_config.4
-@@ -728,6 +728,9 @@ Furthermore, the
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh_config.4 openssh-7.5p1/ssh_config.4
+--- openssh-7.5p1~/ssh_config.4	2017-10-06 12:34:44.610652786 +0000
++++ openssh-7.5p1/ssh_config.4	2017-10-06 12:34:44.764299993 +0000
+@@ -732,6 +732,9 @@ Furthermore, the
  token used for the session will be set to expire after 20 minutes.
  Remote clients will be refused access after this time.
  .Pp
@@ -90,7 +80,7 @@ index 6b790fb7..0953f11c 100644
  See the X11 SECURITY extension specification for full details on
  the restrictions imposed on untrusted clients.
  .It Cm GatewayPorts
-@@ -754,8 +757,8 @@ The default is
+@@ -758,8 +761,8 @@ The default is
  .Pa /etc/ssh/ssh_known_hosts2 .
  .It Cm GSSAPIAuthentication
  Specifies whether user authentication based on GSSAPI is allowed.
@@ -101,11 +91,10 @@ index 6b790fb7..0953f11c 100644
  .It Cm GSSAPIDelegateCredentials
  Forward (delegate) credentials to the server.
  The default is
-diff --git a/sshd_config.4 b/sshd_config.4
-index 7e4a376b..45c54629 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
-@@ -621,8 +621,8 @@ The default is
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-10-06 12:34:44.706917129 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:44.764541314 +0000
+@@ -625,8 +625,8 @@ The default is
  .Cm no .
  .It Cm GSSAPIAuthentication
  Specifies whether user authentication based on GSSAPI is allowed.
@@ -116,7 +105,7 @@ index 7e4a376b..45c54629 100644
  .It Cm GSSAPICleanupCredentials
  Specifies whether to automatically destroy the user's credentials cache
  on logout.
-@@ -1527,8 +1527,8 @@ The argument must be
+@@ -1525,8 +1525,8 @@ The argument must be
  .Cm yes
  or
  .Cm no .
@@ -127,6 +116,3 @@ index 7e4a376b..45c54629 100644
  .Pp
  When X11 forwarding is enabled, there may be additional exposure to
  the server and to client displays if the
--- 
-2.11.0
-

--- a/build/openssh/patches/0012-Deprecate-SunSSH-compatible-server-options.patch
+++ b/build/openssh/patches/0012-Deprecate-SunSSH-compatible-server-options.patch
@@ -18,14 +18,9 @@ Subject: [PATCH 12/34] Deprecate SunSSH compatible server options
 # This is a Solaris specific change to ease the transition and will not be
 # offered upstream.
 #
----
- servconf.c | 23 +++++++++++++++++++++++
- 1 file changed, 23 insertions(+)
-
-diff --git a/servconf.c b/servconf.c
-index 6f11010a..c0aba508 100644
---- a/servconf.c
-+++ b/servconf.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.764037862 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.812538966 +0000
 @@ -587,6 +587,29 @@ static struct {
  	{ "pamserviceprefix", sPAMServicePrefix, SSHCFG_GLOBAL },
  	{ "pamservicename", sPAMServiceName, SSHCFG_GLOBAL },
@@ -56,6 +51,3 @@ index 6f11010a..c0aba508 100644
  	{ "revokedkeys", sRevokedKeys, SSHCFG_ALL },
  	{ "trustedusercakeys", sTrustedUserCAKeys, SSHCFG_ALL },
  	{ "authorizedprincipalsfile", sAuthorizedPrincipalsFile, SSHCFG_ALL },
--- 
-2.11.0
-

--- a/build/openssh/patches/0013-Solaris-Auditing-support.patch
+++ b/build/openssh/patches/0013-Solaris-Auditing-support.patch
@@ -3,22 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:37:01 -0700
 Subject: [PATCH 13/34] Solaris Auditing support
 
----
- INSTALL         |  15 +-
- Makefile.in     |   2 +-
- README.platform |   7 +-
- audit-solaris.c | 574 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- configure.ac    |   9 +-
- defines.h       |   5 +
- sshd.c          |   6 +
- 7 files changed, 609 insertions(+), 9 deletions(-)
- create mode 100644 audit-solaris.c
-
-diff --git a/INSTALL b/INSTALL
-index 6bc80b68..03417493 100644
---- a/INSTALL
-+++ b/INSTALL
-@@ -98,9 +98,13 @@ http://www.gnu.org/software/autoconf/
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/INSTALL openssh-7.5p1/INSTALL
+--- openssh-7.5p1~/INSTALL	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/INSTALL	2017-10-06 12:34:44.859386383 +0000
+@@ -99,9 +99,13 @@ http://www.gnu.org/software/autoconf/
  
  Basic Security Module (BSM):
  
@@ -35,7 +23,7 @@ index 6bc80b68..03417493 100644
  
  
  2. Building / Installation
-@@ -153,8 +157,9 @@ name).
+@@ -154,8 +158,9 @@ name).
  There are a few other options to the configure script:
  
  --with-audit=[module] enable additional auditing via the specified module.
@@ -47,11 +35,10 @@ index 6bc80b68..03417493 100644
  
  --with-pam enables PAM support. If PAM support is compiled in, it must
  also be enabled in sshd_config (refer to the UsePAM directive).
-diff --git a/Makefile.in b/Makefile.in
-index 82065077..48d773de 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -100,7 +100,7 @@ SSHOBJS= ssh.o readconf.o clientloop.o sshtty.o \
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:44.562196133 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:44.859552781 +0000
+@@ -100,7 +100,7 @@ SSHOBJS= ssh.o readconf.o clientloop.o s
  	sshconnect.o sshconnect1.o sshconnect2.o mux.o
  
  SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
@@ -60,11 +47,10 @@ index 82065077..48d773de 100644
  	sshpty.o sshlogin.o servconf.o serverloop.o \
  	auth.o auth2.o auth-options.o session.o \
  	auth2-chall.o groupaccess.o \
-diff --git a/README.platform b/README.platform
-index c7be95fb..ae461550 100644
---- a/README.platform
-+++ b/README.platform
-@@ -71,8 +71,8 @@ zlib-devel and pam-devel, on Debian based distros these may be
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/README.platform openssh-7.5p1/README.platform
+--- openssh-7.5p1~/README.platform	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/README.platform	2017-10-06 12:34:44.859653439 +0000
+@@ -71,8 +71,8 @@ zlib-devel and pam-devel, on Debian base
  libssl-dev, libz-dev and libpam-dev.
  
  
@@ -75,7 +61,7 @@ index c7be95fb..ae461550 100644
  If you enable BSM auditing on Solaris, you need to update audit_event(4)
  for praudit(1m) to give sensible output.  The following line needs to be
  added to /etc/security/audit_event:
-@@ -85,6 +85,9 @@ There is no official registry of 3rd party event numbers, so if this
+@@ -85,6 +85,9 @@ There is no official registry of 3rd par
  number is already in use on your system, you may change it at build time
  by configure'ing --with-cflags=-DAUE_openssh=32801 then rebuilding.
  
@@ -85,11 +71,9 @@ index c7be95fb..ae461550 100644
  
  Platforms using PAM
  -------------------
-diff --git a/audit-solaris.c b/audit-solaris.c
-new file mode 100644
-index 00000000..fc0839f5
---- /dev/null
-+++ b/audit-solaris.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/audit-solaris.c openssh-7.5p1/audit-solaris.c
+--- openssh-7.5p1~/audit-solaris.c	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/audit-solaris.c	2017-10-06 12:34:44.859848968 +0000
 @@ -0,0 +1,574 @@
 +/*
 + * CDDL HEADER START
@@ -665,11 +649,10 @@ index 00000000..fc0839f5
 +	(void) adt_end_session(ah);
 +}
 +#endif	/* USE_SOLARIS_AUDIT */
-diff --git a/configure.ac b/configure.ac
-index f5deed69..7a36eee9 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1561,7 +1561,7 @@ AC_ARG_WITH([libedit],
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:44.509877706 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:44.860506010 +0000
+@@ -1575,7 +1575,7 @@ AC_ARG_WITH([libedit],
  
  AUDIT_MODULE=none
  AC_ARG_WITH([audit],
@@ -678,7 +661,7 @@ index f5deed69..7a36eee9 100644
  	[
  	  AC_MSG_CHECKING([for supported audit module])
  	  case "$withval" in
-@@ -1598,6 +1598,13 @@ AC_ARG_WITH([audit],
+@@ -1612,6 +1612,13 @@ AC_ARG_WITH([audit],
  		SSHDLIBS="$SSHDLIBS -laudit"
  		AC_DEFINE([USE_LINUX_AUDIT], [1], [Use Linux audit module])
  		;;
@@ -692,10 +675,9 @@ index f5deed69..7a36eee9 100644
  	  debug)
  		AUDIT_MODULE=debug
  		AC_MSG_RESULT([debug])
-diff --git a/defines.h b/defines.h
-index c89f85a8..a2ec7361 100644
---- a/defines.h
-+++ b/defines.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/defines.h openssh-7.5p1/defines.h
+--- openssh-7.5p1~/defines.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/defines.h	2017-10-06 12:34:44.860655565 +0000
 @@ -645,6 +645,11 @@ struct winsize {
  # define CUSTOM_SSH_AUDIT_EVENTS
  #endif
@@ -708,11 +690,10 @@ index c89f85a8..a2ec7361 100644
  #if !defined(HAVE___func__) && defined(HAVE___FUNCTION__)
  #  define __func__ __FUNCTION__
  #elif !defined(HAVE___func__)
-diff --git a/sshd.c b/sshd.c
-index e39b3024..eee363ab 100644
---- a/sshd.c
-+++ b/sshd.c
-@@ -2043,7 +2043,9 @@ main(int ac, char **av)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.c openssh-7.5p1/sshd.c
+--- openssh-7.5p1~/sshd.c	2017-10-06 12:34:44.510656257 +0000
++++ openssh-7.5p1/sshd.c	2017-10-06 12:34:44.860941468 +0000
+@@ -2057,7 +2057,9 @@ main(int ac, char **av)
  	}
  
  #ifdef SSH_AUDIT_EVENTS
@@ -722,7 +703,7 @@ index e39b3024..eee363ab 100644
  #endif
  
  #ifdef GSSAPI
-@@ -2073,6 +2075,10 @@ main(int ac, char **av)
+@@ -2087,6 +2089,10 @@ main(int ac, char **av)
  		do_pam_session();
  	}
  #endif
@@ -733,6 +714,3 @@ index e39b3024..eee363ab 100644
  
  	/*
  	 * In privilege separation, we fork another child and prepare
--- 
-2.11.0
-

--- a/build/openssh/patches/0014-GSS-API-key-exchange-support.patch
+++ b/build/openssh/patches/0014-GSS-API-key-exchange-support.patch
@@ -3,51 +3,9 @@ From: Simon Wilkinson <simon@sxw.org.uk>
 Date: Fri, 27 Jan 2017 16:46:31 -0800
 Subject: [PATCH 14/34] GSS-API key exchange support
 
----
- ChangeLog.gssapi | 113 +++++++++++++++++++
- Makefile.in      |   3 +-
- auth-krb5.c      |  17 ++-
- auth.c           |  96 +---------------
- auth2-gss.c      |  48 +++++++-
- auth2.c          |   2 +
- canohost.c       |  93 +++++++++++++++
- canohost.h       |   3 +
- clientloop.c     |  15 ++-
- configure.ac     |  24 ++++
- gss-genr.c       | 275 +++++++++++++++++++++++++++++++++++++++++++-
- gss-serv-krb5.c  |  87 ++++++++++++--
- gss-serv.c       | 224 +++++++++++++++++++++++++++++++++---
- kex.c            |  19 ++++
- kex.h            |  14 +++
- kexgssc.c        | 339 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
- kexgsss.c        | 296 ++++++++++++++++++++++++++++++++++++++++++++++++
- monitor.c        | 115 +++++++++++++++++--
- monitor.h        |   2 +
- monitor_wrap.c   |  47 +++++++-
- monitor_wrap.h   |   4 +-
- readconf.c       |  42 +++++++
- readconf.h       |   5 +
- servconf.c       |  28 ++++-
- servconf.h       |   2 +
- ssh-gss.h        |  41 ++++++-
- ssh_config       |   2 +
- ssh_config.4     |  32 ++++++
- sshconnect2.c    | 131 ++++++++++++++++++++-
- sshd.c           | 112 +++++++++++++++++-
- sshd_config      |   2 +
- sshd_config.4    |  10 ++
- sshkey.c         |   3 +-
- sshkey.h         |   1 +
- 34 files changed, 2099 insertions(+), 148 deletions(-)
- create mode 100644 ChangeLog.gssapi
- create mode 100644 kexgssc.c
- create mode 100644 kexgsss.c
-
-diff --git a/ChangeLog.gssapi b/ChangeLog.gssapi
-new file mode 100644
-index 00000000..f117a336
---- /dev/null
-+++ b/ChangeLog.gssapi
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ChangeLog.gssapi openssh-7.5p1/ChangeLog.gssapi
+--- openssh-7.5p1~/ChangeLog.gssapi	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/ChangeLog.gssapi	2017-10-06 12:34:44.912910386 +0000
 @@ -0,0 +1,113 @@
 +20110101
 +  - Finally update for OpenSSH 5.6p1
@@ -162,10 +120,9 @@ index 00000000..f117a336
 +    add support for GssapiTrustDns option for gssapi-with-mic
 +    (from jbasney AT ncsa.uiuc.edu)
 +    <gssapi-with-mic support is Bugzilla #1008>
-diff --git a/Makefile.in b/Makefile.in
-index 48d773de..47dbceff 100644
---- a/Makefile.in
-+++ b/Makefile.in
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:44.859552781 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:44.914159718 +0000
 @@ -94,6 +94,7 @@ LIBSSH_OBJS=${LIBOPENSSH_OBJS} \
  	kex.o kexdh.o kexgex.o kexecdh.o kexc25519.o \
  	kexdhc.o kexgexc.o kexecdhc.o kexc25519c.o \
@@ -174,7 +131,7 @@ index 48d773de..47dbceff 100644
  	platform-pledge.o platform-tracing.o
  
  SSHOBJS= ssh.o readconf.o clientloop.o sshtty.o \
-@@ -107,7 +108,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passwd.o \
+@@ -107,7 +108,7 @@ SSHDOBJS=sshd.o auth-rhosts.o auth-passw
  	auth-skey.o auth-bsdauth.o auth2-hostbased.o auth2-kbdint.o \
  	auth2-none.o auth2-passwd.o auth2-pubkey.o \
  	monitor.o monitor_wrap.o auth-krb5.o \
@@ -183,11 +140,10 @@ index 48d773de..47dbceff 100644
  	loginrec.o auth-pam.o auth-shadow.o auth-sia.o md5crypt.o \
  	sftp-server.o sftp-common.o \
  	sandbox-null.o sandbox-rlimit.o sandbox-systrace.o sandbox-darwin.o \
-diff --git a/auth-krb5.c b/auth-krb5.c
-index a5a81ed2..38e7fee2 100644
---- a/auth-krb5.c
-+++ b/auth-krb5.c
-@@ -182,8 +182,13 @@ auth_krb5_password(Authctxt *authctxt, const char *password)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-krb5.c openssh-7.5p1/auth-krb5.c
+--- openssh-7.5p1~/auth-krb5.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth-krb5.c	2017-10-06 12:34:44.914308066 +0000
+@@ -182,8 +182,13 @@ auth_krb5_password(Authctxt *authctxt, c
  
  	len = strlen(authctxt->krb5_ticket_file) + 6;
  	authctxt->krb5_ccname = xmalloc(len);
@@ -226,7 +182,7 @@ index a5a81ed2..38e7fee2 100644
  	old_umask = umask(0177);
  	tmpfd = mkstemp(ccname + strlen("FILE:"));
  	oerrno = errno;
-@@ -265,6 +277,7 @@ ssh_krb5_cc_gen(krb5_context ctx, krb5_ccache *ccache) {
+@@ -265,6 +277,7 @@ ssh_krb5_cc_gen(krb5_context ctx, krb5_c
  		return oerrno;
  	}
  	close(tmpfd);
@@ -234,10 +190,9 @@ index a5a81ed2..38e7fee2 100644
  
  	return (krb5_cc_resolve(ctx, ccname, ccache));
  }
-diff --git a/auth.c b/auth.c
-index 6ee6116d..c6390687 100644
---- a/auth.c
-+++ b/auth.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth.c openssh-7.5p1/auth.c
+--- openssh-7.5p1~/auth.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth.c	2017-10-06 12:34:44.914493393 +0000
 @@ -372,7 +372,8 @@ auth_root_allowed(const char *method)
  	case PERMIT_NO_PASSWD:
  		if (strcmp(method, "publickey") == 0 ||
@@ -348,10 +303,9 @@ index 6ee6116d..c6390687 100644
   * Return the canonical name of the host in the other side of the current
   * connection.  The host name is cached, so it is efficient to call this
   * several times.
-diff --git a/auth2-gss.c b/auth2-gss.c
-index 1ca83577..3b5036df 100644
---- a/auth2-gss.c
-+++ b/auth2-gss.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2-gss.c openssh-7.5p1/auth2-gss.c
+--- openssh-7.5p1~/auth2-gss.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth2-gss.c	2017-10-06 12:34:44.914662894 +0000
 @@ -1,7 +1,7 @@
  /* $OpenBSD: auth2-gss.c,v 1.22 2015/01/19 20:07:45 markus Exp $ */
  
@@ -361,7 +315,7 @@ index 1ca83577..3b5036df 100644
   *
   * Redistribution and use in source and binary forms, with or without
   * modification, are permitted provided that the following conditions
-@@ -53,6 +53,40 @@ static int input_gssapi_mic(int type, u_int32_t plen, void *ctxt);
+@@ -53,6 +53,40 @@ static int input_gssapi_mic(int type, u_
  static int input_gssapi_exchange_complete(int type, u_int32_t plen, void *ctxt);
  static int input_gssapi_errtok(int, u_int32_t, void *);
  
@@ -402,7 +356,7 @@ index 1ca83577..3b5036df 100644
  /*
   * We only support those mechanisms that we know about (ie ones that we know
   * how to check local user kuserok and the like)
-@@ -238,7 +272,8 @@ input_gssapi_exchange_complete(int type, u_int32_t plen, void *ctxt)
+@@ -238,7 +272,8 @@ input_gssapi_exchange_complete(int type,
  
  	packet_check_eom();
  
@@ -412,7 +366,7 @@ index 1ca83577..3b5036df 100644
  
  	authctxt->postponed = 0;
  	dispatch_set(SSH2_MSG_USERAUTH_GSSAPI_TOKEN, NULL);
-@@ -274,7 +309,8 @@ input_gssapi_mic(int type, u_int32_t plen, void *ctxt)
+@@ -274,7 +309,8 @@ input_gssapi_mic(int type, u_int32_t ple
  	gssbuf.length = buffer_len(&b);
  
  	if (!GSS_ERROR(PRIVSEP(ssh_gssapi_checkmic(gssctxt, &gssbuf, &mic))))
@@ -422,7 +376,7 @@ index 1ca83577..3b5036df 100644
  	else
  		logit("GSSAPI MIC check failed");
  
-@@ -290,6 +326,12 @@ input_gssapi_mic(int type, u_int32_t plen, void *ctxt)
+@@ -290,6 +326,12 @@ input_gssapi_mic(int type, u_int32_t ple
  	return 0;
  }
  
@@ -435,10 +389,9 @@ index 1ca83577..3b5036df 100644
  Authmethod method_gssapi = {
  	"gssapi-with-mic",
  	userauth_gssapi,
-diff --git a/auth2.c b/auth2.c
-index 4623ae02..6a9f936b 100644
---- a/auth2.c
-+++ b/auth2.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2.c openssh-7.5p1/auth2.c
+--- openssh-7.5p1~/auth2.c	2017-10-06 12:34:44.705371598 +0000
++++ openssh-7.5p1/auth2.c	2017-10-06 12:34:44.914808161 +0000
 @@ -70,6 +70,7 @@ extern Authmethod method_passwd;
  extern Authmethod method_kbdint;
  extern Authmethod method_hostbased;
@@ -455,10 +408,9 @@ index 4623ae02..6a9f936b 100644
  	&method_gssapi,
  #endif
  	&method_passwd,
-diff --git a/canohost.c b/canohost.c
-index f71a0856..404731d2 100644
---- a/canohost.c
-+++ b/canohost.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/canohost.c openssh-7.5p1/canohost.c
+--- openssh-7.5p1~/canohost.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/canohost.c	2017-10-06 12:34:44.914926018 +0000
 @@ -35,6 +35,99 @@
  #include "canohost.h"
  #include "misc.h"
@@ -559,10 +511,9 @@ index f71a0856..404731d2 100644
  void
  ipv64_normalise_mapped(struct sockaddr_storage *addr, socklen_t *len)
  {
-diff --git a/canohost.h b/canohost.h
-index 26d62855..0cadc9f1 100644
---- a/canohost.h
-+++ b/canohost.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/canohost.h openssh-7.5p1/canohost.h
+--- openssh-7.5p1~/canohost.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/canohost.h	2017-10-06 12:34:44.915003253 +0000
 @@ -15,6 +15,9 @@
  #ifndef _CANOHOST_H
  #define _CANOHOST_H
@@ -573,10 +524,9 @@ index 26d62855..0cadc9f1 100644
  char		*get_peer_ipaddr(int);
  int		 get_peer_port(int);
  char		*get_local_ipaddr(int);
-diff --git a/clientloop.c b/clientloop.c
-index 4289a408..99c68b69 100644
---- a/clientloop.c
-+++ b/clientloop.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/clientloop.c openssh-7.5p1/clientloop.c
+--- openssh-7.5p1~/clientloop.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/clientloop.c	2017-10-06 12:34:44.915378005 +0000
 @@ -113,6 +113,10 @@
  #include "ssherr.h"
  #include "hostfile.h"
@@ -588,7 +538,7 @@ index 4289a408..99c68b69 100644
  /* import options */
  extern Options options;
  
-@@ -1664,9 +1668,18 @@ client_loop(int have_pty, int escape_char_arg, int ssh2_chan_id)
+@@ -1664,9 +1668,18 @@ client_loop(int have_pty, int escape_cha
  			break;
  
  		/* Do channel operations unless rekeying in progress. */
@@ -608,11 +558,10 @@ index 4289a408..99c68b69 100644
  		/* Buffer input from the connection.  */
  		client_process_net_input(readset);
  
-diff --git a/configure.ac b/configure.ac
-index 7a36eee9..1635897c 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -623,6 +623,30 @@ main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:44.860506010 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:44.916058487 +0000
+@@ -623,6 +623,30 @@ main() { if (NSVersionOfRunTimeLibrary("
  	    [Use tunnel device compatibility to OpenBSD])
  	AC_DEFINE([SSH_TUN_PREPEND_AF], [1],
  	    [Prepend the address family to IP tunnel traffic])
@@ -643,10 +592,9 @@ index 7a36eee9..1635897c 100644
  	m4_pattern_allow([AU_IPv])
  	AC_CHECK_DECL([AU_IPv4], [],
  	    AC_DEFINE([AU_IPv4], [0], [System only supports IPv4 audit records])
-diff --git a/gss-genr.c b/gss-genr.c
-index 62559ed9..0b3ae073 100644
---- a/gss-genr.c
-+++ b/gss-genr.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/gss-genr.c openssh-7.5p1/gss-genr.c
+--- openssh-7.5p1~/gss-genr.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/gss-genr.c	2017-10-06 12:34:44.916319312 +0000
 @@ -1,7 +1,7 @@
  /* $OpenBSD: gss-genr.c,v 1.24 2016/09/12 01:22:38 deraadt Exp $ */
  
@@ -824,7 +772,7 @@ index 62559ed9..0b3ae073 100644
  /* Check that the OID in a data stream matches that in the context */
  int
  ssh_gssapi_check_oid(Gssctxt *ctx, void *data, size_t len)
-@@ -198,7 +353,7 @@ ssh_gssapi_init_ctx(Gssctxt *ctx, int deleg_creds, gss_buffer_desc *recv_tok,
+@@ -198,7 +353,7 @@ ssh_gssapi_init_ctx(Gssctxt *ctx, int de
  	}
  
  	ctx->major = gss_init_sec_context(&ctx->minor,
@@ -833,7 +781,7 @@ index 62559ed9..0b3ae073 100644
  	    GSS_C_MUTUAL_FLAG | GSS_C_INTEG_FLAG | deleg_flag,
  	    0, NULL, recv_tok, NULL, send_tok, flags, NULL);
  
-@@ -228,8 +383,42 @@ ssh_gssapi_import_name(Gssctxt *ctx, const char *host)
+@@ -228,8 +383,42 @@ ssh_gssapi_import_name(Gssctxt *ctx, con
  }
  
  OM_uint32
@@ -876,7 +824,7 @@ index 62559ed9..0b3ae073 100644
  	if ((ctx->major = gss_get_mic(&ctx->minor, ctx->context,
  	    GSS_C_QOP_DEFAULT, buffer, hash)))
  		ssh_gssapi_error(ctx);
-@@ -237,6 +426,19 @@ ssh_gssapi_sign(Gssctxt *ctx, gss_buffer_t buffer, gss_buffer_t hash)
+@@ -237,6 +426,19 @@ ssh_gssapi_sign(Gssctxt *ctx, gss_buffer
  	return (ctx->major);
  }
  
@@ -896,7 +844,7 @@ index 62559ed9..0b3ae073 100644
  void
  ssh_gssapi_buildmic(Buffer *b, const char *user, const char *service,
      const char *context)
-@@ -250,11 +452,16 @@ ssh_gssapi_buildmic(Buffer *b, const char *user, const char *service,
+@@ -250,11 +452,16 @@ ssh_gssapi_buildmic(Buffer *b, const cha
  }
  
  int
@@ -914,7 +862,7 @@ index 62559ed9..0b3ae073 100644
  
  	/* RFC 4462 says we MUST NOT do SPNEGO */
  	if (oid->length == spnego_oid.length && 
-@@ -264,6 +471,10 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx, gss_OID oid, const char *host)
+@@ -264,6 +471,10 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx
  	ssh_gssapi_build_ctx(ctx);
  	ssh_gssapi_set_oid(*ctx, oid);
  	major = ssh_gssapi_import_name(*ctx, host);
@@ -925,7 +873,7 @@ index 62559ed9..0b3ae073 100644
  	if (!GSS_ERROR(major)) {
  		major = ssh_gssapi_init_ctx(*ctx, 0, GSS_C_NO_BUFFER, &token, 
  		    NULL);
-@@ -273,10 +484,66 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx, gss_OID oid, const char *host)
+@@ -273,10 +484,66 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx
  			    GSS_C_NO_BUFFER);
  	}
  
@@ -993,10 +941,9 @@ index 62559ed9..0b3ae073 100644
 +}
 +
  #endif /* GSSAPI */
-diff --git a/gss-serv-krb5.c b/gss-serv-krb5.c
-index 6e6cff7b..fcfb86a8 100644
---- a/gss-serv-krb5.c
-+++ b/gss-serv-krb5.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/gss-serv-krb5.c openssh-7.5p1/gss-serv-krb5.c
+--- openssh-7.5p1~/gss-serv-krb5.c	2017-10-06 12:34:44.509992163 +0000
++++ openssh-7.5p1/gss-serv-krb5.c	2017-10-06 12:34:44.916484549 +0000
 @@ -1,7 +1,7 @@
  /* $OpenBSD: gss-serv-krb5.c,v 1.8 2013/07/20 01:55:13 djm Exp $ */
  
@@ -1006,7 +953,7 @@ index 6e6cff7b..fcfb86a8 100644
   *
   * Redistribution and use in source and binary forms, with or without
   * modification, are permitted provided that the following conditions
-@@ -121,8 +121,8 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_client *client)
+@@ -121,8 +121,8 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_cl
  	krb5_error_code problem;
  	krb5_principal princ;
  	OM_uint32 maj_status, min_status;
@@ -1016,7 +963,7 @@ index 6e6cff7b..fcfb86a8 100644
  
  	if (client->creds == NULL) {
  		debug("No credentials stored");
-@@ -181,11 +181,16 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_client *client)
+@@ -181,11 +181,16 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_cl
  		return;
  	}
  
@@ -1037,7 +984,7 @@ index 6e6cff7b..fcfb86a8 100644
  
  #ifdef USE_PAM
  	if (options.use_pam)
-@@ -196,6 +201,72 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_client *client)
+@@ -196,6 +201,72 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_cl
  
  	return;
  }
@@ -1123,10 +1070,9 @@ index 6e6cff7b..fcfb86a8 100644
  #endif
  };
  
-diff --git a/gss-serv.c b/gss-serv.c
-index 209ffe82..3f9dfe5c 100644
---- a/gss-serv.c
-+++ b/gss-serv.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/gss-serv.c openssh-7.5p1/gss-serv.c
+--- openssh-7.5p1~/gss-serv.c	2017-10-06 12:34:44.510106068 +0000
++++ openssh-7.5p1/gss-serv.c	2017-10-06 12:34:44.916771004 +0000
 @@ -1,7 +1,7 @@
  /* $OpenBSD: gss-serv.c,v 1.29 2015/05/22 03:50:02 djm Exp $ */
  
@@ -1161,7 +1107,7 @@ index 209ffe82..3f9dfe5c 100644
  
  #ifdef KRB5
  extern ssh_gssapi_mech gssapi_kerberos_mech;
-@@ -142,6 +147,28 @@ ssh_gssapi_server_ctx(Gssctxt **ctx, gss_OID oid)
+@@ -142,6 +147,28 @@ ssh_gssapi_server_ctx(Gssctxt **ctx, gss
  }
  
  /* Unprivileged */
@@ -1190,7 +1136,7 @@ index 209ffe82..3f9dfe5c 100644
  void
  ssh_gssapi_supported_oids(gss_OID_set *oidset)
  {
-@@ -151,7 +178,9 @@ ssh_gssapi_supported_oids(gss_OID_set *oidset)
+@@ -151,7 +178,9 @@ ssh_gssapi_supported_oids(gss_OID_set *o
  	gss_OID_set supported;
  
  	gss_create_empty_oid_set(&min_status, oidset);
@@ -1251,7 +1197,7 @@ index 209ffe82..3f9dfe5c 100644
  
  	client->mech = NULL;
  
-@@ -293,6 +362,13 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_gssapi_client *client)
+@@ -293,6 +362,13 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_g
  	if (client->mech == NULL)
  		return GSS_S_FAILURE;
  
@@ -1265,7 +1211,7 @@ index 209ffe82..3f9dfe5c 100644
  	if ((ctx->major = gss_display_name(&ctx->minor, ctx->client,
  	    &client->displayname, NULL))) {
  		ssh_gssapi_error(ctx);
-@@ -310,6 +386,8 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_gssapi_client *client)
+@@ -310,6 +386,8 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_g
  		return (ctx->major);
  	}
  
@@ -1274,7 +1220,7 @@ index 209ffe82..3f9dfe5c 100644
  	/* We can't copy this structure, so we just move the pointer to it */
  	client->creds = ctx->client_creds;
  	ctx->client_creds = GSS_C_NO_CREDENTIAL;
-@@ -401,7 +479,7 @@ ssh_gssapi_do_child(char ***envp, u_int *envsizep)
+@@ -401,7 +479,7 @@ ssh_gssapi_do_child(char ***envp, u_int
  
  /* Privileged */
  int
@@ -1434,10 +1380,9 @@ index 209ffe82..3f9dfe5c 100644
  }
  
  #endif
-diff --git a/kex.c b/kex.c
-index 6a94bc53..d8708684 100644
---- a/kex.c
-+++ b/kex.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/kex.c openssh-7.5p1/kex.c
+--- openssh-7.5p1~/kex.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/kex.c	2017-10-06 12:34:44.916975994 +0000
 @@ -54,6 +54,10 @@
  #include "sshbuf.h"
  #include "digest.h"
@@ -1475,7 +1420,7 @@ index 6a94bc53..d8708684 100644
  	return NULL;
  }
  
-@@ -597,6 +613,9 @@ kex_free(struct kex *kex)
+@@ -605,6 +621,9 @@ kex_free(struct kex *kex)
  	sshbuf_free(kex->peer);
  	sshbuf_free(kex->my);
  	free(kex->session_id);
@@ -1485,10 +1430,9 @@ index 6a94bc53..d8708684 100644
  	free(kex->client_version_string);
  	free(kex->server_version_string);
  	free(kex->failed_choice);
-diff --git a/kex.h b/kex.h
-index 3794f212..fd56171d 100644
---- a/kex.h
-+++ b/kex.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/kex.h openssh-7.5p1/kex.h
+--- openssh-7.5p1~/kex.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/kex.h	2017-10-06 12:34:44.917098053 +0000
 @@ -99,6 +99,9 @@ enum kex_exchange {
  	KEX_DH_GEX_SHA256,
  	KEX_ECDH_SHA2,
@@ -1524,11 +1468,9 @@ index 3794f212..fd56171d 100644
  int	 kex_dh_hash(int, const char *, const char *,
      const u_char *, size_t, const u_char *, size_t, const u_char *, size_t,
      const BIGNUM *, const BIGNUM *, const BIGNUM *, u_char *, size_t *);
-diff --git a/kexgssc.c b/kexgssc.c
-new file mode 100644
-index 00000000..a77d3712
---- /dev/null
-+++ b/kexgssc.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/kexgssc.c openssh-7.5p1/kexgssc.c
+--- openssh-7.5p1~/kexgssc.c	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/kexgssc.c	2017-10-06 12:34:44.917247424 +0000
 @@ -0,0 +1,339 @@
 +/*
 + * Copyright (c) 2001-2009 Simon Wilkinson. All rights reserved.
@@ -1869,11 +1811,9 @@ index 00000000..a77d3712
 +}
 +
 +#endif /* GSSAPI */
-diff --git a/kexgsss.c b/kexgsss.c
-new file mode 100644
-index 00000000..0e5ff55b
---- /dev/null
-+++ b/kexgsss.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/kexgsss.c openssh-7.5p1/kexgsss.c
+--- openssh-7.5p1~/kexgsss.c	1970-01-01 01:00:00.000000000 +0000
++++ openssh-7.5p1/kexgsss.c	2017-10-06 12:34:44.917400975 +0000
 @@ -0,0 +1,296 @@
 +/*
 + * Copyright (c) 2001-2009 Simon Wilkinson. All rights reserved.
@@ -2171,11 +2111,10 @@ index 00000000..0e5ff55b
 +	return 0;
 +}
 +#endif /* GSSAPI */
-diff --git a/monitor.c b/monitor.c
-index 8f044f4e..b0c9b4f4 100644
---- a/monitor.c
-+++ b/monitor.c
-@@ -160,6 +160,8 @@ int mm_answer_gss_setup_ctx(int, Buffer *);
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor.c openssh-7.5p1/monitor.c
+--- openssh-7.5p1~/monitor.c	2017-10-06 12:34:44.705762546 +0000
++++ openssh-7.5p1/monitor.c	2017-10-06 12:34:44.917851167 +0000
+@@ -160,6 +160,8 @@ int mm_answer_gss_setup_ctx(int, Buffer
  int mm_answer_gss_accept_ctx(int, Buffer *);
  int mm_answer_gss_userok(int, Buffer *);
  int mm_answer_gss_checkmic(int, Buffer *);
@@ -2184,7 +2123,7 @@ index 8f044f4e..b0c9b4f4 100644
  #endif
  
  #ifdef SSH_AUDIT_EVENTS
-@@ -240,11 +242,18 @@ struct mon_table mon_dispatch_proto20[] = {
+@@ -240,11 +242,18 @@ struct mon_table mon_dispatch_proto20[]
      {MONITOR_REQ_GSSSTEP, 0, mm_answer_gss_accept_ctx},
      {MONITOR_REQ_GSSUSEROK, MON_ONCE|MON_AUTHDECIDE, mm_answer_gss_userok},
      {MONITOR_REQ_GSSCHECKMIC, MON_ONCE, mm_answer_gss_checkmic},
@@ -2203,7 +2142,7 @@ index 8f044f4e..b0c9b4f4 100644
  #ifdef WITH_OPENSSL
      {MONITOR_REQ_MODULI, 0, mm_answer_moduli},
  #endif
-@@ -311,6 +320,10 @@ monitor_child_preauth(Authctxt *_authctxt, struct monitor *pmonitor)
+@@ -312,6 +321,10 @@ monitor_child_preauth(Authctxt *_authctx
  	/* Permit requests for moduli and signatures */
  	monitor_permit(mon_dispatch, MONITOR_REQ_MODULI, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_SIGN, 1);
@@ -2214,7 +2153,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	/* The first few requests do not require asynchronous access */
  	while (!authenticated) {
-@@ -442,6 +455,10 @@ monitor_child_postauth(struct monitor *pmonitor)
+@@ -444,6 +457,10 @@ monitor_child_postauth(struct monitor *p
  	monitor_permit(mon_dispatch, MONITOR_REQ_MODULI, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_SIGN, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_TERM, 1);
@@ -2225,7 +2164,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	if (!no_pty_flag) {
  		monitor_permit(mon_dispatch, MONITOR_REQ_PTY, 1);
-@@ -1666,6 +1683,13 @@ monitor_apply_keystate(struct monitor *pmonitor)
+@@ -1671,6 +1688,13 @@ monitor_apply_keystate(struct monitor *p
  # endif
  #endif /* WITH_OPENSSL */
  		kex->kex[KEX_C25519_SHA256] = kexc25519_server;
@@ -2239,7 +2178,7 @@ index 8f044f4e..b0c9b4f4 100644
  		kex->load_host_public_key=&get_hostkey_public_by_type;
  		kex->load_host_private_key=&get_hostkey_private_by_type;
  		kex->host_key_index=&get_hostkey_index;
-@@ -1745,8 +1769,8 @@ mm_answer_gss_setup_ctx(int sock, Buffer *m)
+@@ -1750,8 +1774,8 @@ mm_answer_gss_setup_ctx(int sock, Buffer
  	OM_uint32 major;
  	u_int len;
  
@@ -2250,7 +2189,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	goid.elements = buffer_get_string(m, &len);
  	goid.length = len;
-@@ -1775,8 +1799,8 @@ mm_answer_gss_accept_ctx(int sock, Buffer *m)
+@@ -1780,8 +1804,8 @@ mm_answer_gss_accept_ctx(int sock, Buffe
  	OM_uint32 flags = 0; /* GSI needs this */
  	u_int len;
  
@@ -2261,7 +2200,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	in.value = buffer_get_string(m, &len);
  	in.length = len;
-@@ -1795,6 +1819,7 @@ mm_answer_gss_accept_ctx(int sock, Buffer *m)
+@@ -1800,6 +1824,7 @@ mm_answer_gss_accept_ctx(int sock, Buffe
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSSTEP, 0);
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSUSEROK, 1);
  		monitor_permit(mon_dispatch, MONITOR_REQ_GSSCHECKMIC, 1);
@@ -2269,7 +2208,7 @@ index 8f044f4e..b0c9b4f4 100644
  	}
  	return (0);
  }
-@@ -1806,8 +1831,8 @@ mm_answer_gss_checkmic(int sock, Buffer *m)
+@@ -1811,8 +1836,8 @@ mm_answer_gss_checkmic(int sock, Buffer
  	OM_uint32 ret;
  	u_int len;
  
@@ -2280,7 +2219,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	gssbuf.value = buffer_get_string(m, &len);
  	gssbuf.length = len;
-@@ -1835,10 +1860,11 @@ mm_answer_gss_userok(int sock, Buffer *m)
+@@ -1840,10 +1865,11 @@ mm_answer_gss_userok(int sock, Buffer *m
  {
  	int authenticated;
  
@@ -2295,7 +2234,7 @@ index 8f044f4e..b0c9b4f4 100644
  
  	buffer_clear(m);
  	buffer_put_int(m, authenticated);
-@@ -1851,5 +1877,76 @@ mm_answer_gss_userok(int sock, Buffer *m)
+@@ -1856,5 +1882,76 @@ mm_answer_gss_userok(int sock, Buffer *m
  	/* Monitor loop will terminate if authenticated */
  	return (authenticated);
  }
@@ -2372,10 +2311,9 @@ index 8f044f4e..b0c9b4f4 100644
 +
  #endif /* GSSAPI */
  
-diff --git a/monitor.h b/monitor.h
-index 36e73f79..bcf9f125 100644
---- a/monitor.h
-+++ b/monitor.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor.h openssh-7.5p1/monitor.h
+--- openssh-7.5p1~/monitor.h	2017-10-06 12:34:44.705846682 +0000
++++ openssh-7.5p1/monitor.h	2017-10-06 12:34:44.917933803 +0000
 @@ -68,6 +68,8 @@ enum monitor_reqtype {
  #ifdef PAM_ENHANCEMENT
  	MONITOR_REQ_AUTHMETHOD = 114,
@@ -2385,11 +2323,10 @@ index 36e73f79..bcf9f125 100644
  };
  
  struct monitor {
-diff --git a/monitor_wrap.c b/monitor_wrap.c
-index bc6382f3..6cacbbab 100644
---- a/monitor_wrap.c
-+++ b/monitor_wrap.c
-@@ -942,7 +942,7 @@ mm_ssh_gssapi_checkmic(Gssctxt *ctx, gss_buffer_t gssbuf, gss_buffer_t gssmic)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor_wrap.c openssh-7.5p1/monitor_wrap.c
+--- openssh-7.5p1~/monitor_wrap.c	2017-10-06 12:34:44.705989906 +0000
++++ openssh-7.5p1/monitor_wrap.c	2017-10-06 12:34:44.918100396 +0000
+@@ -942,7 +942,7 @@ mm_ssh_gssapi_checkmic(Gssctxt *ctx, gss
  }
  
  int
@@ -2449,11 +2386,10 @@ index bc6382f3..6cacbbab 100644
 +
  #endif /* GSSAPI */
  
-diff --git a/monitor_wrap.h b/monitor_wrap.h
-index db5902f5..8f9dd896 100644
---- a/monitor_wrap.h
-+++ b/monitor_wrap.h
-@@ -55,8 +55,10 @@ int mm_key_verify(Key *, u_char *, u_int, u_char *, u_int);
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor_wrap.h openssh-7.5p1/monitor_wrap.h
+--- openssh-7.5p1~/monitor_wrap.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/monitor_wrap.h	2017-10-06 12:34:44.918187394 +0000
+@@ -55,8 +55,10 @@ int mm_key_verify(Key *, u_char *, u_int
  OM_uint32 mm_ssh_gssapi_server_ctx(Gssctxt **, gss_OID);
  OM_uint32 mm_ssh_gssapi_accept_ctx(Gssctxt *,
     gss_buffer_desc *, gss_buffer_desc *, OM_uint32 *);
@@ -2465,11 +2401,10 @@ index db5902f5..8f9dd896 100644
  #endif
  
  #ifdef USE_PAM
-diff --git a/readconf.c b/readconf.c
-index e6fd1420..1efbab9b 100644
---- a/readconf.c
-+++ b/readconf.c
-@@ -160,6 +160,8 @@
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.c openssh-7.5p1/readconf.c
+--- openssh-7.5p1~/readconf.c	2017-10-06 12:34:44.763714825 +0000
++++ openssh-7.5p1/readconf.c	2017-10-06 12:34:44.918551128 +0000
+@@ -160,6 +160,8 @@ typedef enum {
  	oClearAllForwardings, oNoHostAuthenticationForLocalhost,
  	oEnableSSHKeysign, oRekeyLimit, oVerifyHostKeyDNS, oConnectTimeout,
  	oAddressFamily, oGssAuthentication, oGssDelegateCreds,
@@ -2478,7 +2413,7 @@ index e6fd1420..1efbab9b 100644
  	oServerAliveInterval, oServerAliveCountMax, oIdentitiesOnly,
  	oSendEnv, oControlPath, oControlMaster, oControlPersist,
  	oHashKnownHosts,
-@@ -199,10 +201,19 @@
+@@ -199,10 +201,19 @@ static struct {
  	/* Sometimes-unsupported options */
  #if defined(GSSAPI)
  	{ "gssapiauthentication", oGssAuthentication },
@@ -2498,7 +2433,7 @@ index e6fd1420..1efbab9b 100644
  #endif
  #ifdef ENABLE_PKCS11
  	{ "smartcarddevice", oPKCS11Provider },
-@@ -1008,10 +1019,30 @@
+@@ -1008,10 +1019,30 @@ parse_time:
  		intptr = &options->gss_authentication;
  		goto parse_flag;
  
@@ -2529,7 +2464,7 @@ index e6fd1420..1efbab9b 100644
  	case oBatchMode:
  		intptr = &options->batch_mode;
  		goto parse_flag;
-@@ -1840,7 +1871,12 @@
+@@ -1840,7 +1871,12 @@ initialize_options(Options * options)
  	options->pubkey_authentication = -1;
  	options->challenge_response_authentication = -1;
  	options->gss_authentication = -1;
@@ -2542,7 +2477,7 @@ index e6fd1420..1efbab9b 100644
  	options->password_authentication = -1;
  	options->kbd_interactive_authentication = -1;
  	options->kbd_interactive_devices = NULL;
-@@ -1995,8 +2031,14 @@
+@@ -1995,8 +2031,14 @@ fill_default_options(Options * options)
  #else
  		options->gss_authentication = 0;
  #endif
@@ -2557,10 +2492,9 @@ index e6fd1420..1efbab9b 100644
  	if (options->password_authentication == -1)
  		options->password_authentication = 1;
  	if (options->kbd_interactive_authentication == -1)
-diff --git a/readconf.h b/readconf.h
-index 8005ebdd..35fb4ad0 100644
---- a/readconf.h
-+++ b/readconf.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/readconf.h openssh-7.5p1/readconf.h
+--- openssh-7.5p1~/readconf.h	2017-10-06 12:34:44.609835612 +0000
++++ openssh-7.5p1/readconf.h	2017-10-06 12:34:44.918654507 +0000
 @@ -45,7 +45,12 @@ typedef struct {
  	int     challenge_response_authentication;
  					/* Try S/Key or TIS, authentication. */
@@ -2574,11 +2508,10 @@ index 8005ebdd..35fb4ad0 100644
  	int     password_authentication;	/* Try password
  						 * authentication. */
  	int     kbd_interactive_authentication; /* Try keyboard-interactive auth. */
-diff --git a/servconf.c b/servconf.c
-index c0aba508..881edd95 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -113,8 +113,10 @@ initialize_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.812538966 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:44.919037973 +0000
+@@ -113,8 +113,10 @@ initialize_server_options(ServerOptions
  	options->kerberos_ticket_cleanup = -1;
  	options->kerberos_get_afs_token = -1;
  	options->gss_authentication=-1;
@@ -2589,7 +2522,7 @@ index c0aba508..881edd95 100644
  	options->password_authentication = -1;
  	options->kbd_interactive_authentication = -1;
  	options->challenge_response_authentication = -1;
-@@ -292,10 +294,14 @@ fill_default_server_options(ServerOptions *options)
+@@ -292,10 +294,14 @@ fill_default_server_options(ServerOption
  #else
  		options->gss_authentication = 0;
  #endif
@@ -2598,8 +2531,7 @@ index c0aba508..881edd95 100644
  	if (options->gss_cleanup_creds == -1)
  		options->gss_cleanup_creds = 1;
  	if (options->gss_strict_acceptor == -1)
--		options->gss_strict_acceptor = 1;
-+		options->gss_strict_acceptor = 1;
+ 		options->gss_strict_acceptor = 1;
 +	if (options->gss_store_rekey == -1)
 +		options->gss_store_rekey = 0;
  	if (options->password_authentication == -1)
@@ -2634,7 +2566,7 @@ index c0aba508..881edd95 100644
  	{ "passwordauthentication", sPasswordAuthentication, SSHCFG_ALL },
  	{ "kbdinteractiveauthentication", sKbdInteractiveAuthentication, SSHCFG_ALL },
  	{ "challengeresponseauthentication", sChallengeResponseAuthentication, SSHCFG_GLOBAL },
-@@ -1281,6 +1296,10 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1291,6 +1306,10 @@ process_server_config_line(ServerOptions
  		intptr = &options->gss_authentication;
  		goto parse_flag;
  
@@ -2645,7 +2577,7 @@ index c0aba508..881edd95 100644
  	case sGssCleanupCreds:
  		intptr = &options->gss_cleanup_creds;
  		goto parse_flag;
-@@ -1289,6 +1308,10 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1299,6 +1318,10 @@ process_server_config_line(ServerOptions
  		intptr = &options->gss_strict_acceptor;
  		goto parse_flag;
  
@@ -2656,7 +2588,7 @@ index c0aba508..881edd95 100644
  	case sPasswordAuthentication:
  		intptr = &options->password_authentication;
  		goto parse_flag;
-@@ -2353,7 +2376,10 @@ dump_config(ServerOptions *o)
+@@ -2355,7 +2378,10 @@ dump_config(ServerOptions *o)
  #endif
  #ifdef GSSAPI
  	dump_cfg_fmtint(sGssAuthentication, o->gss_authentication);
@@ -2667,10 +2599,9 @@ index c0aba508..881edd95 100644
  #endif
  	dump_cfg_fmtint(sPasswordAuthentication, o->password_authentication);
  	dump_cfg_fmtint(sKbdInteractiveAuthentication,
-diff --git a/servconf.h b/servconf.h
-index 104852f7..729819e7 100644
---- a/servconf.h
-+++ b/servconf.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.h openssh-7.5p1/servconf.h
+--- openssh-7.5p1~/servconf.h	2017-10-06 12:34:44.706473218 +0000
++++ openssh-7.5p1/servconf.h	2017-10-06 12:34:44.920699352 +0000
 @@ -116,8 +116,10 @@ typedef struct {
  	int     kerberos_get_afs_token;		/* If true, try to get AFS token if
  						 * authenticated with Kerberos. */
@@ -2682,10 +2613,9 @@ index 104852f7..729819e7 100644
  	int     password_authentication;	/* If true, permit password
  						 * authentication. */
  	int     kbd_interactive_authentication;	/* If true, permit */
-diff --git a/ssh-gss.h b/ssh-gss.h
-index a99d7f08..914701bc 100644
---- a/ssh-gss.h
-+++ b/ssh-gss.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-gss.h openssh-7.5p1/ssh-gss.h
+--- openssh-7.5p1~/ssh-gss.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-gss.h	2017-10-06 12:34:44.920962910 +0000
 @@ -1,6 +1,6 @@
  /* $OpenBSD: ssh-gss.h,v 1.11 2014/02/26 20:28:44 djm Exp $ */
  /*
@@ -2785,10 +2715,9 @@ index a99d7f08..914701bc 100644
  #endif /* GSSAPI */
  
  #endif /* _SSH_GSS_H */
-diff --git a/ssh_config b/ssh_config
-index 90fb63f0..4e879cd2 100644
---- a/ssh_config
-+++ b/ssh_config
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh_config openssh-7.5p1/ssh_config
+--- openssh-7.5p1~/ssh_config	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh_config	2017-10-06 12:34:44.921108527 +0000
 @@ -26,6 +26,8 @@
  #   HostbasedAuthentication no
  #   GSSAPIAuthentication no
@@ -2798,11 +2727,10 @@ index 90fb63f0..4e879cd2 100644
  #   BatchMode no
  #   CheckHostIP yes
  #   AddressFamily any
-diff --git a/ssh_config.4 b/ssh_config.4
-index 0953f11c..4492ecaf 100644
---- a/ssh_config.4
-+++ b/ssh_config.4
-@@ -759,10 +759,42 @@ The default is
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh_config.4 openssh-7.5p1/ssh_config.4
+--- openssh-7.5p1~/ssh_config.4	2017-10-06 12:34:44.764299993 +0000
++++ openssh-7.5p1/ssh_config.4	2017-10-06 12:34:44.921474638 +0000
+@@ -763,10 +763,42 @@ The default is
  Specifies whether user authentication based on GSSAPI is allowed.
  The default on OmniOS is
  .Dq yes .
@@ -2845,11 +2773,10 @@ index 0953f11c..4492ecaf 100644
  .It Cm HashKnownHosts
  Indicates that
  .Xr ssh 1
-diff --git a/sshconnect2.c b/sshconnect2.c
-index 56942ca7..7959d048 100644
---- a/sshconnect2.c
-+++ b/sshconnect2.c
-@@ -166,6 +166,11 @@ ssh_kex2(char *host, struct sockaddr *hostaddr, u_short port)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshconnect2.c openssh-7.5p1/sshconnect2.c
+--- openssh-7.5p1~/sshconnect2.c	2017-10-06 12:34:44.610914892 +0000
++++ openssh-7.5p1/sshconnect2.c	2017-10-06 12:34:44.921927563 +0000
+@@ -166,6 +166,11 @@ ssh_kex2(char *host, struct sockaddr *ho
  	struct kex *kex;
  	int r;
  
@@ -2861,7 +2788,7 @@ index 56942ca7..7959d048 100644
  	xxx_host = host;
  	xxx_hostaddr = hostaddr;
  
-@@ -196,6 +201,35 @@ ssh_kex2(char *host, struct sockaddr *hostaddr, u_short port)
+@@ -196,6 +201,35 @@ ssh_kex2(char *host, struct sockaddr *ho
  		    order_hostkeyalgs(host, hostaddr, port));
  	}
  
@@ -2895,9 +2822,9 @@ index 56942ca7..7959d048 100644
 +#endif
 +
  	if (options.rekey_limit || options.rekey_interval)
- 		packet_set_rekey_limits((u_int32_t)options.rekey_limit,
- 		    (time_t)options.rekey_interval);
-@@ -217,15 +251,41 @@ ssh_kex2(char *host, struct sockaddr *hostaddr, u_short port)
+ 		packet_set_rekey_limits(options.rekey_limit,
+ 		    options.rekey_interval);
+@@ -217,15 +251,41 @@ ssh_kex2(char *host, struct sockaddr *ho
  # endif
  #endif
  	kex->kex[KEX_C25519_SHA256] = kexc25519_client;
@@ -2939,7 +2866,7 @@ index 56942ca7..7959d048 100644
  	if ((r = kex_prop2buf(kex->my, myproposal)) != 0)
  		fatal("kex_prop2buf: %s", ssh_err(r));
  
-@@ -315,6 +375,7 @@ int	input_gssapi_token(int type, u_int32_t, void *);
+@@ -315,6 +375,7 @@ int	input_gssapi_token(int type, u_int32
  int	input_gssapi_hash(int type, u_int32_t, void *);
  int	input_gssapi_error(int, u_int32_t, void *);
  int	input_gssapi_errtok(int, u_int32_t, void *);
@@ -3002,7 +2929,7 @@ index 56942ca7..7959d048 100644
  	if (!ok)
  		return 0;
  
-@@ -784,8 +865,8 @@ input_gssapi_response(int type, u_int32_t plen, void *ctxt)
+@@ -784,8 +865,8 @@ input_gssapi_response(int type, u_int32_
  {
  	Authctxt *authctxt = ctxt;
  	Gssctxt *gssctxt;
@@ -3013,7 +2940,7 @@ index 56942ca7..7959d048 100644
  
  	if (authctxt == NULL)
  		fatal("input_gssapi_response: no authentication context");
-@@ -898,6 +979,48 @@ input_gssapi_error(int type, u_int32_t plen, void *ctxt)
+@@ -898,6 +979,48 @@ input_gssapi_error(int type, u_int32_t p
  	free(lang);
  	return 0;
  }
@@ -3062,10 +2989,9 @@ index 56942ca7..7959d048 100644
  #endif /* GSSAPI */
  
  int
-diff --git a/sshd.c b/sshd.c
-index eee363ab..e460c238 100644
---- a/sshd.c
-+++ b/sshd.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.c openssh-7.5p1/sshd.c
+--- openssh-7.5p1~/sshd.c	2017-10-06 12:34:44.860941468 +0000
++++ openssh-7.5p1/sshd.c	2017-10-06 12:34:44.922304665 +0000
 @@ -123,6 +123,10 @@
  #include "version.h"
  #include "ssherr.h"
@@ -3086,7 +3012,7 @@ index eee363ab..e460c238 100644
  		ssh_gssapi_prepare_supported_oids();
  #endif
  
-@@ -1705,10 +1709,13 @@ main(int ac, char **av)
+@@ -1719,10 +1723,13 @@ main(int ac, char **av)
  		    key ? "private" : "agent", i, sshkey_ssh_name(pubkey), fp);
  		free(fp);
  	}
@@ -3100,7 +3026,7 @@ index eee363ab..e460c238 100644
  
  	/*
  	 * Load certificates. They are stored in an array at identical
-@@ -1978,6 +1985,60 @@ main(int ac, char **av)
+@@ -1992,6 +1999,60 @@ main(int ac, char **av)
  	    remote_ip, remote_port, laddr,  ssh_local_port(ssh));
  	free(laddr);
  
@@ -3161,7 +3087,7 @@ index eee363ab..e460c238 100644
  	/*
  	 * We don't want to listen forever unless the other side
  	 * successfully authenticates itself.  So we set up an alarm which is
-@@ -2179,6 +2240,48 @@ do_ssh2_kex(void)
+@@ -2193,6 +2254,48 @@ do_ssh2_kex(void)
  	myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = compat_pkalg_proposal(
  	    list_hostkey_types());
  
@@ -3210,7 +3136,7 @@ index eee363ab..e460c238 100644
  	/* start key exchange */
  	if ((r = kex_setup(active_state, myproposal)) != 0)
  		fatal("kex_setup: %s", ssh_err(r));
-@@ -2196,6 +2299,13 @@ do_ssh2_kex(void)
+@@ -2210,6 +2313,13 @@ do_ssh2_kex(void)
  # endif
  #endif
  	kex->kex[KEX_C25519_SHA256] = kexc25519_server;
@@ -3224,10 +3150,9 @@ index eee363ab..e460c238 100644
  	kex->server = 1;
  	kex->client_version_string=client_version_string;
  	kex->server_version_string=server_version_string;
-diff --git a/sshd_config b/sshd_config
-index 9f09e4a6..00e5a728 100644
---- a/sshd_config
-+++ b/sshd_config
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config openssh-7.5p1/sshd_config
+--- openssh-7.5p1~/sshd_config	2017-10-06 12:34:44.215245761 +0000
++++ openssh-7.5p1/sshd_config	2017-10-06 12:34:44.922385596 +0000
 @@ -70,6 +70,8 @@ AuthorizedKeysFile	.ssh/authorized_keys
  # GSSAPI options
  #GSSAPIAuthentication no
@@ -3237,11 +3162,10 @@ index 9f09e4a6..00e5a728 100644
  
  # Set this to 'yes' to enable PAM authentication, account processing,
  # and session processing. If this is enabled, PAM authentication will
-diff --git a/sshd_config.4 b/sshd_config.4
-index 45c54629..de03ac5e 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
-@@ -623,6 +623,11 @@ The default is
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-10-06 12:34:44.764541314 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:44.922628030 +0000
+@@ -627,6 +627,11 @@ The default is
  Specifies whether user authentication based on GSSAPI is allowed.
  The default on OmniOS is
  .Cm yes .
@@ -3253,7 +3177,7 @@ index 45c54629..de03ac5e 100644
  .It Cm GSSAPICleanupCredentials
  Specifies whether to automatically destroy the user's credentials cache
  on logout.
-@@ -642,6 +647,11 @@ machine's default store.
+@@ -646,6 +651,11 @@ machine's default store.
  This facility is provided to assist with operation on multi homed machines.
  The default is
  .Cm yes .
@@ -3265,11 +3189,10 @@ index 45c54629..de03ac5e 100644
  .It Cm HostbasedAcceptedKeyTypes
  Specifies the key types that will be accepted for hostbased authentication
  as a comma-separated pattern list.
-diff --git a/sshkey.c b/sshkey.c
-index c01da6c3..377d72fa 100644
---- a/sshkey.c
-+++ b/sshkey.c
-@@ -114,6 +114,7 @@ static const struct keytype keytypes[] = {
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshkey.c openssh-7.5p1/sshkey.c
+--- openssh-7.5p1~/sshkey.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshkey.c	2017-10-06 12:34:44.923223797 +0000
+@@ -116,6 +116,7 @@ static const struct keytype keytypes[] =
  #  endif /* OPENSSL_HAS_NISTP521 */
  # endif /* OPENSSL_HAS_ECC */
  #endif /* WITH_OPENSSL */
@@ -3277,19 +3200,18 @@ index c01da6c3..377d72fa 100644
  	{ NULL, NULL, -1, -1, 0, 0 }
  };
  
-@@ -202,7 +203,7 @@ sshkey_alg_list(int certs_only, int plain_only, char sep)
+@@ -204,7 +205,7 @@ sshkey_alg_list(int certs_only, int plai
  	const struct keytype *kt;
  
  	for (kt = keytypes; kt->type != -1; kt++) {
 -		if (kt->name == NULL)
 +		if (kt->name == NULL || kt->type == KEY_NULL)
  			continue;
- 		if ((certs_only && !kt->cert) || (plain_only && kt->cert))
+ 		if (!include_sigonly && kt->sigonly)
  			continue;
-diff --git a/sshkey.h b/sshkey.h
-index f3936384..7eb2a139 100644
---- a/sshkey.h
-+++ b/sshkey.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshkey.h openssh-7.5p1/sshkey.h
+--- openssh-7.5p1~/sshkey.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshkey.h	2017-10-06 12:34:44.923315178 +0000
 @@ -62,6 +62,7 @@ enum sshkey_types {
  	KEY_DSA_CERT,
  	KEY_ECDSA_CERT,
@@ -3298,6 +3220,3 @@ index f3936384..7eb2a139 100644
  	KEY_UNSPEC
  };
  
--- 
-2.11.0
-

--- a/build/openssh/patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
+++ b/build/openssh/patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
@@ -3,20 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:38:19 -0700
 Subject: [PATCH 15/34] Enable login to a role if PAM is ok with it
 
----
- auth-pam.c        | 14 ++++++++++++++
- auth-pam.h        |  4 ++++
- auth.h            |  3 +++
- auth2-hostbased.c | 10 ++++++++++
- auth2.c           |  8 ++++++++
- monitor.c         | 15 ++++++++++++++-
- 6 files changed, 53 insertions(+), 1 deletion(-)
-
-diff --git a/auth-pam.c b/auth-pam.c
-index 70a25c19..46bf722e 100644
---- a/auth-pam.c
-+++ b/auth-pam.c
-@@ -1069,6 +1069,20 @@ do_pam_account(void)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-pam.c openssh-7.5p1/auth-pam.c
+--- openssh-7.5p1~/auth-pam.c	2017-10-06 12:34:44.705025561 +0000
++++ openssh-7.5p1/auth-pam.c	2017-10-06 12:34:44.987230847 +0000
+@@ -1071,6 +1071,20 @@ do_pam_account(void)
  	return (sshpam_account_status);
  }
  
@@ -37,10 +27,9 @@ index 70a25c19..46bf722e 100644
  void
  do_pam_setcred(int init)
  {
-diff --git a/auth-pam.h b/auth-pam.h
-index c47b442e..892a27bc 100644
---- a/auth-pam.h
-+++ b/auth-pam.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-pam.h openssh-7.5p1/auth-pam.h
+--- openssh-7.5p1~/auth-pam.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth-pam.h	2017-10-06 12:34:44.987515678 +0000
 @@ -29,6 +29,10 @@ void start_pam(Authctxt *);
  void finish_pam(void);
  u_int do_pam_account(void);
@@ -52,10 +41,9 @@ index c47b442e..892a27bc 100644
  void do_pam_setcred(int );
  void do_pam_chauthtok(void);
  int do_pam_putenv(char *, char *);
-diff --git a/auth.h b/auth.h
-index 4a7f2c1f..b4efc255 100644
---- a/auth.h
-+++ b/auth.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth.h openssh-7.5p1/auth.h
+--- openssh-7.5p1~/auth.h	2017-10-06 12:34:44.705125374 +0000
++++ openssh-7.5p1/auth.h	2017-10-06 12:34:44.987596386 +0000
 @@ -84,6 +84,9 @@ struct Authctxt {
  #ifdef PAM_ENHANCEMENT
  	char		*authmethod_name;
@@ -66,10 +54,9 @@ index 4a7f2c1f..b4efc255 100644
  };
  /*
   * Every authentication method has to handle authentication requests for
-diff --git a/auth2-hostbased.c b/auth2-hostbased.c
-index 1b3c3b20..2c51bd2b 100644
---- a/auth2-hostbased.c
-+++ b/auth2-hostbased.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2-hostbased.c openssh-7.5p1/auth2-hostbased.c
+--- openssh-7.5p1~/auth2-hostbased.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth2-hostbased.c	2017-10-06 12:34:44.987705791 +0000
 @@ -85,6 +85,9 @@ userauth_hostbased(Authctxt *authctxt)
  	buffer_dump(&b);
  	buffer_free(&b);
@@ -94,11 +81,10 @@ index 1b3c3b20..2c51bd2b 100644
  	buffer_free(&b);
  done:
  	debug2("userauth_hostbased: authenticated %d", authenticated);
-diff --git a/auth2.c b/auth2.c
-index 6a9f936b..e68aa6d3 100644
---- a/auth2.c
-+++ b/auth2.c
-@@ -339,6 +339,14 @@ userauth_finish(Authctxt *authctxt, int authenticated, const char *method,
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2.c openssh-7.5p1/auth2.c
+--- openssh-7.5p1~/auth2.c	2017-10-06 12:34:44.914808161 +0000
++++ openssh-7.5p1/auth2.c	2017-10-06 12:34:44.987833997 +0000
+@@ -344,6 +344,14 @@ userauth_finish(Authctxt *authctxt, int
  #endif
  	}
  
@@ -113,11 +99,10 @@ index 6a9f936b..e68aa6d3 100644
  	if (authenticated && options.num_auth_methods != 0) {
  
  #if defined(USE_PAM) && defined(PAM_ENHANCEMENT)
-diff --git a/monitor.c b/monitor.c
-index b0c9b4f4..d2ad5425 100644
---- a/monitor.c
-+++ b/monitor.c
-@@ -404,6 +404,12 @@ monitor_child_preauth(Authctxt *_authctxt, struct monitor *pmonitor)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/monitor.c openssh-7.5p1/monitor.c
+--- openssh-7.5p1~/monitor.c	2017-10-06 12:34:44.917851167 +0000
++++ openssh-7.5p1/monitor.c	2017-10-06 12:34:44.988175924 +0000
+@@ -405,6 +405,12 @@ monitor_child_preauth(Authctxt *_authctx
  		}
  	}
  
@@ -130,7 +115,7 @@ index b0c9b4f4..d2ad5425 100644
  	if (!authctxt->valid)
  		fatal("%s: authenticated invalid user", __func__);
  	if (strcmp(auth_method, "unknown") == 0)
-@@ -603,12 +609,14 @@ monitor_reset_key_state(void)
+@@ -605,12 +611,14 @@ monitor_reset_key_state(void)
  {
  	/* reset state */
  	free(key_blob);
@@ -146,7 +131,7 @@ index b0c9b4f4..d2ad5425 100644
  	hostbased_chost = NULL;
  }
  
-@@ -1066,6 +1074,11 @@ mm_answer_pam_account(int sock, Buffer *m)
+@@ -1071,6 +1079,11 @@ mm_answer_pam_account(int sock, Buffer *
  	if (!options.use_pam)
  		fatal("%s: PAM not enabled", __func__);
  
@@ -158,6 +143,3 @@ index b0c9b4f4..d2ad5425 100644
  	ret = do_pam_account();
  
  	buffer_put_int(m, ret);
--- 
-2.11.0
-

--- a/build/openssh/patches/0016-PAM-setcred-failures.patch
+++ b/build/openssh/patches/0016-PAM-setcred-failures.patch
@@ -15,15 +15,10 @@ Subject: [PATCH 16/34] PAM setcred failures
 # In the future, if these bug fixes are accepted by the upsteam in a later
 # release, we will remove this patch when we upgrade to that release.
 #
----
- auth-pam.c | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
-
-diff --git a/auth-pam.c b/auth-pam.c
-index 46bf722e..dcd0f208 100644
---- a/auth-pam.c
-+++ b/auth-pam.c
-@@ -1102,12 +1102,19 @@ do_pam_setcred(int init)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth-pam.c openssh-7.5p1/auth-pam.c
+--- openssh-7.5p1~/auth-pam.c	2017-10-06 12:34:44.987230847 +0000
++++ openssh-7.5p1/auth-pam.c	2017-10-06 12:34:45.036937766 +0000
+@@ -1104,12 +1104,19 @@ do_pam_setcred(int init)
  		sshpam_cred_established = 1;
  		return;
  	}
@@ -43,7 +38,7 @@ index 46bf722e..dcd0f208 100644
  }
  
  static int
-@@ -1200,10 +1207,16 @@ do_pam_session(void)
+@@ -1202,10 +1209,16 @@ do_pam_session(void)
  	if (sshpam_err == PAM_SUCCESS)
  		sshpam_session_open = 1;
  	else {
@@ -60,6 +55,3 @@ index 46bf722e..dcd0f208 100644
  	}
  
  }
--- 
-2.11.0
-

--- a/build/openssh/patches/0017-Don-t-call-do_pam_setcred-twice.patch
+++ b/build/openssh/patches/0017-Don-t-call-do_pam_setcred-twice.patch
@@ -25,15 +25,10 @@ Subject: [PATCH 17/34] Don't call do_pam_setcred twice
 # In short, this additional call to do_pam_setcred() is Linux-specific and
 # shouldn't be called on Solaris.
 #
----
- platform.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/platform.c b/platform.c
-index 973a63e4..fc9c079e 100644
---- a/platform.c
-+++ b/platform.c
-@@ -145,7 +145,7 @@ platform_setusercontext(struct passwd *pw)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/platform.c openssh-7.5p1/platform.c
+--- openssh-7.5p1~/platform.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/platform.c	2017-10-06 12:34:45.083771236 +0000
+@@ -145,7 +145,7 @@ platform_setusercontext(struct passwd *p
  void
  platform_setusercontext_post_groups(struct passwd *pw)
  {
@@ -42,6 +37,3 @@ index 973a63e4..fc9c079e 100644
  	/*
  	 * PAM credentials may take the form of supplementary groups.
  	 * These will have been wiped by the above initgroups() call.
--- 
-2.11.0
-

--- a/build/openssh/patches/0018-Per-session-xauthfile.patch
+++ b/build/openssh/patches/0018-Per-session-xauthfile.patch
@@ -10,15 +10,9 @@ We have contributed back this fix to the OpenSSH upstream community. For
 more information, see https://bugzilla.mindrot.org/show_bug.cgi?id=2440
 In the future, if this fix is accepted by the upsteam in a later release, we
 will remove this patch when we upgrade to that release.
----
- session.c | 138 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
- session.h |   3 ++
- 2 files changed, 137 insertions(+), 4 deletions(-)
-
-diff --git a/session.c b/session.c
-index a08aa69d..9586901e 100644
---- a/session.c
-+++ b/session.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/session.c openssh-7.5p1/session.c
+--- openssh-7.5p1~/session.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/session.c	2017-10-06 12:34:45.131205136 +0000
 @@ -63,6 +63,10 @@
  #include <unistd.h>
  #include <limits.h>
@@ -30,7 +24,7 @@ index a08aa69d..9586901e 100644
  #include "openbsd-compat/sys-queue.h"
  #include "xmalloc.h"
  #include "ssh.h"
-@@ -131,6 +135,11 @@ static void do_authenticated2(Authctxt *);
+@@ -131,6 +135,11 @@ static void do_authenticated2(Authctxt *
  
  static int session_pty_req(Session *);
  
@@ -42,7 +36,7 @@ index a08aa69d..9586901e 100644
  /* import */
  extern ServerOptions options;
  extern char *__progname;
-@@ -1056,6 +1065,11 @@ do_setup_env(Session *s, const char *shell)
+@@ -1056,6 +1065,11 @@ do_setup_env(Session *s, const char *she
  	if (getenv("TZ"))
  		child_set_env(&env, &envsize, "TZ", getenv("TZ"));
  
@@ -79,7 +73,7 @@ index a08aa69d..9586901e 100644
  		success = 0;
  		error("Invalid X11 forwarding data");
 +		goto out;
-+	}
+ 	}
 +
 +#ifdef PER_SESSION_XAUTHFILE
 +	/*
@@ -129,7 +123,7 @@ index a08aa69d..9586901e 100644
 +		error("failed to create a directory for the temporary X "
 +		    "authority file: %.100s; will use the default xauth file",
 +		    strerror(errno));
- 	}
++	}
 +#endif
 +
 +	success = session_setup_x11fwd(s);
@@ -222,10 +216,9 @@ index a08aa69d..9586901e 100644
  	/*
  	 * Cleanup ptys/utmp only if privsep is disabled,
  	 * or if running in monitor.
-diff --git a/session.h b/session.h
-index 98e1dafe..f211c19c 100644
---- a/session.h
-+++ b/session.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/session.h openssh-7.5p1/session.h
+--- openssh-7.5p1~/session.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/session.h	2017-10-06 12:34:45.131290426 +0000
 @@ -49,6 +49,9 @@ struct Session {
  	char	*auth_display;
  	char	*auth_proto;
@@ -236,6 +229,3 @@ index 98e1dafe..f211c19c 100644
  	int	single_connection;
  
  	int	chanid;
--- 
-2.11.0
-

--- a/build/openssh/patches/0019-PubKeyPlugin-support.patch
+++ b/build/openssh/patches/0019-PubKeyPlugin-support.patch
@@ -6,16 +6,9 @@ Subject: [PATCH 19/34] PubKeyPlugin support
 This adds the PubKeyPlugin directive and associated code from
 SunSSH, allowing an in-process shared library to be called
 into to check public keys for authentication.
----
- auth2-pubkey.c | 139 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- servconf.c     |  15 +++++++
- servconf.h     |   1 +
- 3 files changed, 155 insertions(+)
-
-diff --git a/auth2-pubkey.c b/auth2-pubkey.c
-index 20f3309e..01daef4a 100644
---- a/auth2-pubkey.c
-+++ b/auth2-pubkey.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/auth2-pubkey.c openssh-7.5p1/auth2-pubkey.c
+--- openssh-7.5p1~/auth2-pubkey.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/auth2-pubkey.c	2017-10-06 12:34:45.178507079 +0000
 @@ -22,6 +22,11 @@
   * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
   * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -58,7 +51,7 @@ index 20f3309e..01daef4a 100644
  static int
  userauth_pubkey(Authctxt *authctxt)
  {
-@@ -1071,6 +1087,125 @@ user_key_command_allowed2(struct passwd *user_pw, Key *key)
+@@ -1084,6 +1100,125 @@ user_key_command_allowed2(struct passwd
  	return found_key;
  }
  
@@ -184,7 +177,7 @@ index 20f3309e..01daef4a 100644
  /*
   * Check whether key authenticates and authorises the user.
   */
-@@ -1089,6 +1224,10 @@ user_key_allowed(struct passwd *pw, Key *key, int auth_attempt)
+@@ -1102,6 +1237,10 @@ user_key_allowed(struct passwd *pw, Key
  	if (success)
  		return success;
  
@@ -195,11 +188,10 @@ index 20f3309e..01daef4a 100644
  	success = user_key_command_allowed2(pw, key);
  	if (success > 0)
  		return success;
-diff --git a/servconf.c b/servconf.c
-index 881edd95..b492f32b 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -178,6 +178,7 @@ initialize_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:44.919037973 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:45.179771853 +0000
+@@ -178,6 +178,7 @@ initialize_server_options(ServerOptions
  	 */
  	options->pam_service_per_authmethod = 1;
  #endif
@@ -223,7 +215,7 @@ index 881edd95..b492f32b 100644
  	{ NULL, sBadOption, 0 }
  };
  
-@@ -1964,6 +1967,18 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1970,6 +1973,18 @@ process_server_config_line(ServerOptions
  		}
  		break;
  
@@ -242,10 +234,9 @@ index 881edd95..b492f32b 100644
  	case sDeprecated:
  	case sIgnore:
  	case sUnsupported:
-diff --git a/servconf.h b/servconf.h
-index 729819e7..4197ffde 100644
---- a/servconf.h
-+++ b/servconf.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.h openssh-7.5p1/servconf.h
+--- openssh-7.5p1~/servconf.h	2017-10-06 12:34:44.920699352 +0000
++++ openssh-7.5p1/servconf.h	2017-10-06 12:34:45.179876726 +0000
 @@ -201,6 +201,7 @@ typedef struct {
  #endif
  
@@ -254,6 +245,3 @@ index 729819e7..4197ffde 100644
  }       ServerOptions;
  
  /* Information about the incoming connection as used by Match */
--- 
-2.11.0
-

--- a/build/openssh/patches/0020-Compatibility-fix-for-ListenAddress.patch
+++ b/build/openssh/patches/0020-Compatibility-fix-for-ListenAddress.patch
@@ -5,15 +5,10 @@ Subject: [PATCH 20/34] Compatibility fix for "ListenAddress ::"
 
 In SunSSH, a config that specifies only "ListenAddress ::" in
 fact will listen on both IPv4 and IPv6.
----
- servconf.c | 15 +++++++++++++--
- 1 file changed, 13 insertions(+), 2 deletions(-)
-
-diff --git a/servconf.c b/servconf.c
-index b492f32b..1501af6a 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -763,11 +763,22 @@ process_queued_listen_addrs(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:45.179771853 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:45.232461367 +0000
+@@ -763,11 +763,22 @@ process_queued_listen_addrs(ServerOption
  		options->address_family = AF_UNSPEC;
  
  	for (i = 0; i < options->num_queued_listens; i++) {
@@ -38,6 +33,3 @@ index b492f32b..1501af6a 100644
  	free(options->queued_listen_addrs);
  	options->queued_listen_addrs = NULL;
  	free(options->queued_listen_ports);
--- 
-2.11.0
-

--- a/build/openssh/patches/0021-Try-to-create-privsep-chroot-dir-if-it-doesn-t-exist.patch
+++ b/build/openssh/patches/0021-Try-to-create-privsep-chroot-dir-if-it-doesn-t-exist.patch
@@ -4,15 +4,10 @@ Date: Wed, 5 Aug 2015 12:25:15 -0700
 Subject: [PATCH 21/34] Try to create privsep chroot dir if it doesn't exist
  yet
 
----
- sshd.c | 25 ++++++++++++++++++++++---
- 1 file changed, 22 insertions(+), 3 deletions(-)
-
-diff --git a/sshd.c b/sshd.c
-index e460c238..67171704 100644
---- a/sshd.c
-+++ b/sshd.c
-@@ -1762,11 +1762,30 @@ main(int ac, char **av)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.c openssh-7.5p1/sshd.c
+--- openssh-7.5p1~/sshd.c	2017-10-06 12:34:44.922304665 +0000
++++ openssh-7.5p1/sshd.c	2017-10-06 12:34:45.278528289 +0000
+@@ -1776,11 +1776,30 @@ main(int ac, char **av)
  
  	if (use_privsep) {
  		struct stat st;
@@ -46,6 +41,3 @@ index e460c238..67171704 100644
  
  #ifdef HAVE_CYGWIN
  		if (check_ntsec(_PATH_PRIVSEP_CHROOT_DIR) &&
--- 
-2.11.0
-

--- a/build/openssh/patches/0024-Add-with-key-dir-configure-option-to-place-SSH-host-.patch
+++ b/build/openssh/patches/0024-Add-with-key-dir-configure-option-to-place-SSH-host-.patch
@@ -4,16 +4,9 @@ Date: Fri, 7 Aug 2015 13:32:53 -0700
 Subject: [PATCH 24/34] Add --with-key-dir configure option to place SSH host
  keys
 
----
- Makefile.in  | 12 +++++++-----
- configure.ac | 16 ++++++++++++++++
- pathnames.h  | 19 +++++++++++++------
- 3 files changed, 36 insertions(+), 11 deletions(-)
-
-diff --git a/Makefile.in b/Makefile.in
-index 1ab8bc90..3a2a840d 100644
---- a/Makefile.in
-+++ b/Makefile.in
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:44.914159718 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:45.328137892 +0000
 @@ -18,6 +18,7 @@ sysconfdir=@sysconfdir@
  piddir=@piddir@
  srcdir=@srcdir@
@@ -22,7 +15,7 @@ index 1ab8bc90..3a2a840d 100644
  
  DESTDIR=
  VPATH=@srcdir@
-@@ -130,11 +131,11 @@ PATHSUBS	= \
+@@ -128,11 +129,11 @@ PATHSUBS	= \
  	-e 's|/etc/ssh/sshd_config|$(sysconfdir)/sshd_config|g' \
  	-e 's|/usr/libexec|$(libexecdir)|g' \
  	-e 's|/etc/shosts.equiv|$(sysconfdir)/shosts.equiv|g' \
@@ -39,19 +32,18 @@ index 1ab8bc90..3a2a840d 100644
  	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
  	-e 's|/etc/moduli|$(sysconfdir)/moduli|g' \
  	-e 's|/etc/ssh/moduli|$(sysconfdir)/moduli|g' \
-@@ -370,6 +371,7 @@ install-files:
-	$(INSTALL) -m 644 ssh-keysign.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-keysign.1m
-	$(INSTALL) -m 644 ssh-pkcs11-helper.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-pkcs11-helper.1m
-	mkdir -p $(ROOTDLIBDIR64) && cp $(srcdir)/sftp64.d $(ROOTDLIBDIR64)/sftp64.d
+@@ -368,6 +369,7 @@ install-files:
+ 	$(INSTALL) -m 644 ssh-keysign.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-keysign.1m
+ 	$(INSTALL) -m 644 ssh-pkcs11-helper.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-pkcs11-helper.1m
+ 	mkdir -p $(ROOTDLIBDIR64) && cp $(srcdir)/sftp64.d $(ROOTDLIBDIR64)/sftp64.d
 +	mkdir -p $(DESTDIR)$(keydir)
  
  install-sysconf:
  	if [ ! -d $(DESTDIR)$(sysconfdir) ]; then \
-diff --git a/configure.ac b/configure.ac
-index 1635897c..c7a8e662 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -4780,6 +4780,20 @@ AC_DEFINE_UNQUOTED([_PATH_SSH_PIDDIR], ["$piddir"],
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:44.916058487 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:45.329111247 +0000
+@@ -4792,6 +4792,20 @@ AC_DEFINE_UNQUOTED([_PATH_SSH_PIDDIR], [
  	[Specify location of ssh.pid])
  AC_SUBST([piddir])
  
@@ -72,7 +64,7 @@ index 1635897c..c7a8e662 100644
  dnl allow user to disable some login recording features
  AC_ARG_ENABLE([lastlog],
  	[  --disable-lastlog       disable use of lastlog even if detected [no]],
-@@ -5085,12 +5099,14 @@ G=`eval echo ${piddir}` ; G=`eval echo ${G}`
+@@ -5097,12 +5111,14 @@ G=`eval echo ${piddir}` ; G=`eval echo $
  H=`eval echo ${PRIVSEP_PATH}` ; H=`eval echo ${H}`
  I=`eval echo ${user_path}` ; I=`eval echo ${I}`
  J=`eval echo ${superuser_path}` ; J=`eval echo ${J}`
@@ -87,10 +79,9 @@ index 1635897c..c7a8e662 100644
  echo "                   Askpass program: $E"
  echo "                      Manual pages: $F"
  echo "                          PID file: $G"
-diff --git a/pathnames.h b/pathnames.h
-index f5e11ab1..7915c405 100644
---- a/pathnames.h
-+++ b/pathnames.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/pathnames.h openssh-7.5p1/pathnames.h
+--- openssh-7.5p1~/pathnames.h	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/pathnames.h	2017-10-06 12:34:45.329253327 +0000
 @@ -22,6 +22,10 @@
  #define _PATH_SSH_PIDDIR		"/var/run"
  #endif
@@ -124,6 +115,3 @@ index f5e11ab1..7915c405 100644
  
  #ifndef _PATH_SSH_PROGRAM
  #define _PATH_SSH_PROGRAM		"/usr/bin/ssh"
--- 
-2.11.0
-

--- a/build/openssh/patches/0026-Don-t-use-krb5-config-to-check-for-GSSAPI-on-Illumos.patch
+++ b/build/openssh/patches/0026-Don-t-use-krb5-config-to-check-for-GSSAPI-on-Illumos.patch
@@ -3,15 +3,10 @@ From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 21 Aug 2015 18:47:46 -0700
 Subject: [PATCH 26/34] Don't use krb5-config to check for GSSAPI on Illumos
 
----
- configure.ac | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
-
-diff --git a/configure.ac b/configure.ac
-index c7a8e662..5e64db3b 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -4207,6 +4207,11 @@ AC_ARG_WITH([kerberos5],
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:45.329111247 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:45.377471723 +0000
+@@ -4219,6 +4219,11 @@ AC_ARG_WITH([kerberos5],
  		AC_PATH_TOOL([KRB5CONF], [krb5-config],
  			     [$KRB5ROOT/bin/krb5-config],
  			     [$KRB5ROOT/bin:$PATH])
@@ -23,7 +18,7 @@ index c7a8e662..5e64db3b 100644
  		if test -x $KRB5CONF ; then
  			K5CFLAGS="`$KRB5CONF --cflags`"
  			K5LIBS="`$KRB5CONF --libs`"
-@@ -4248,7 +4253,7 @@ AC_ARG_WITH([kerberos5],
+@@ -4260,7 +4265,7 @@ AC_ARG_WITH([kerberos5],
  					 AC_CHECK_LIB([des], [des_cbc_encrypt],
  					   [K5LIBS="$K5LIBS -ldes"])
  				       ], [ AC_MSG_RESULT([no])
@@ -32,6 +27,3 @@ index c7a8e662..5e64db3b 100644
  			])
  			AC_SEARCH_LIBS([dn_expand], [resolv])
  
--- 
-2.11.0
-

--- a/build/openssh/patches/0027-Set-default-sshd-options-based-on-etc-default-login.patch
+++ b/build/openssh/patches/0027-Set-default-sshd-options-based-on-etc-default-login.patch
@@ -3,16 +3,9 @@ From: Alex Wilson <alex.wilson@joyent.com>
 Date: Mon, 24 Aug 2015 18:57:27 -0700
 Subject: [PATCH 27/34] Set default sshd options based on /etc/default/login
 
----
- pathnames.h   |  1 +
- servconf.c    | 61 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- sshd_config.4 | 17 +++++++++++++++--
- 3 files changed, 77 insertions(+), 2 deletions(-)
-
-diff --git a/pathnames.h b/pathnames.h
-index 7915c405..40284a1f 100644
---- a/pathnames.h
-+++ b/pathnames.h
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/pathnames.h openssh-7.5p1/pathnames.h
+--- openssh-7.5p1~/pathnames.h	2017-10-06 12:34:45.329253327 +0000
++++ openssh-7.5p1/pathnames.h	2017-10-06 12:34:45.427083648 +0000
 @@ -47,6 +47,7 @@
  #define _PATH_HOST_ED25519_KEY_FILE	SSHKEYDIR "/ssh_host_ed25519_key"
  #define _PATH_HOST_RSA_KEY_FILE		SSHKEYDIR "/ssh_host_rsa_key"
@@ -21,10 +14,9 @@ index 7915c405..40284a1f 100644
  /* Backwards compatibility */
  #define _PATH_DH_PRIMES			SSHDIR "/primes"
  
-diff --git a/servconf.c b/servconf.c
-index 1501af6a..91f8c942 100644
---- a/servconf.c
-+++ b/servconf.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:45.232461367 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:45.427489973 +0000
 @@ -30,6 +30,7 @@
  #include <unistd.h>
  #include <limits.h>
@@ -98,7 +90,7 @@ index 1501af6a..91f8c942 100644
  static void
  assemble_algorithms(ServerOptions *o)
  {
-@@ -216,6 +275,8 @@ fill_default_server_options(ServerOptions *options)
+@@ -216,6 +275,8 @@ fill_default_server_options(ServerOption
  		options->use_pam = 0;
  #endif
  
@@ -107,11 +99,10 @@ index 1501af6a..91f8c942 100644
  	/* Standard Options */
  	if (options->num_host_key_files == 0) {
  		/* fill default hostkeys for protocols */
-diff --git a/sshd_config.4 b/sshd_config.4
-index 6a6f940b..0b2393dd 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
-@@ -1099,7 +1099,13 @@ Specifies the maximum number of authentication attempts permitted per
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-10-06 12:34:44.922628030 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:45.427736167 +0000
+@@ -1115,7 +1115,13 @@ Specifies the maximum number of authenti
  connection.
  Once the number of failures reaches half this value,
  additional failures are logged.
@@ -126,7 +117,7 @@ index 6a6f940b..0b2393dd 100644
  .It Cm MaxSessions
  Specifies the maximum number of open shell, login or subsystem (e.g. sftp)
  sessions permitted per network connection.
-@@ -1150,7 +1156,14 @@ The default is
+@@ -1166,7 +1172,14 @@ The default is
  When password authentication is allowed, it specifies whether the
  server allows login to accounts with empty password strings.
  The default is
@@ -142,6 +133,3 @@ index 6a6f940b..0b2393dd 100644
  .It Cm PermitOpen
  Specifies the destinations to which TCP port forwarding is permitted.
  The forwarding specification must be one of the following forms:
--- 
-2.11.0
-

--- a/build/openssh/patches/0028-Compatibility-for-SunSSH_1.5-should-include-old-DH-K.patch
+++ b/build/openssh/patches/0028-Compatibility-for-SunSSH_1.5-should-include-old-DH-K.patch
@@ -10,15 +10,10 @@ dh-group14 and -group1 algorithms.
 
 Without this, an old SunSSH client cannot connect to our
 new daemon.
----
- compat.c | 31 ++++++++++++++++++++++++++++++-
- 1 file changed, 30 insertions(+), 1 deletion(-)
-
-diff --git a/compat.c b/compat.c
-index 69a104fb..55fb3d93 100644
---- a/compat.c
-+++ b/compat.c
-@@ -93,7 +93,9 @@
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/compat.c openssh-7.5p1/compat.c
+--- openssh-7.5p1~/compat.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/compat.c	2017-10-06 12:34:45.475286605 +0000
+@@ -93,7 +93,9 @@ compat_datafellows(const char *version)
  		  "OpenSSH_3.0*,"
  		  "OpenSSH_3.1*",	SSH_BUG_EXTEOF|SSH_OLD_FORWARD_ADDR},
  		{ "OpenSSH_3.*",	SSH_OLD_FORWARD_ADDR },
@@ -29,7 +24,7 @@ index 69a104fb..55fb3d93 100644
  		{ "OpenSSH_4*",		0 },
  		{ "OpenSSH_5*",		SSH_NEW_OPENSSH|SSH_BUG_DYNAMIC_RPORT},
  		{ "OpenSSH_6.6.1*",	SSH_NEW_OPENSSH},
-@@ -279,6 +281,31 @@
+@@ -279,6 +281,31 @@ compat_pkalg_proposal(char *pkalg_prop)
  	return pkalg_prop;
  }
  
@@ -61,7 +56,7 @@ index 69a104fb..55fb3d93 100644
  char *
  compat_kex_proposal(char *p)
  {
-@@ -294,6 +321,8 @@
+@@ -294,6 +321,8 @@ compat_kex_proposal(char *p)
  		    "diffie-hellman-group-exchange-sha256,"
  		    "diffie-hellman-group-exchange-sha1")) == NULL)
  			fatal("match_filter_list failed");
@@ -70,6 +65,3 @@ index 69a104fb..55fb3d93 100644
  	}
  	debug2("%s: compat KEX proposal: %s", __func__, p);
  	if (*p == '\0')
--- 
-2.11.0
-

--- a/build/openssh/patches/0029-Accept-LANG-and-LC_-environment-variables-from-clien.patch
+++ b/build/openssh/patches/0029-Accept-LANG-and-LC_-environment-variables-from-clien.patch
@@ -6,18 +6,10 @@ Subject: [PATCH 29/34] Accept LANG and LC_* environment variables from clients
 
 This preserves most of the old SunSSH locale negotiation
 behaviour (at least the parts that are most commonly used).
----
- servconf.c    | 27 +++++++++++++++++++++++++--
- session.c     | 25 +++++++++++++++++++++++--
- sshd_config   |  4 ++++
- sshd_config.4 | 13 ++++++++++++-
- 4 files changed, 64 insertions(+), 5 deletions(-)
-
-diff --git a/servconf.c b/servconf.c
-index 91f8c942..6f1f0068 100644
---- a/servconf.c
-+++ b/servconf.c
-@@ -150,7 +150,7 @@ initialize_server_options(ServerOptions *options)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/servconf.c openssh-7.5p1/servconf.c
+--- openssh-7.5p1~/servconf.c	2017-10-06 12:34:45.427489973 +0000
++++ openssh-7.5p1/servconf.c	2017-10-06 12:34:45.521996421 +0000
+@@ -150,7 +150,7 @@ initialize_server_options(ServerOptions
  	options->client_alive_interval = -1;
  	options->client_alive_count_max = -1;
  	options->num_authkeys_files = 0;
@@ -26,7 +18,7 @@ index 91f8c942..6f1f0068 100644
  	options->permit_tun = -1;
  	options->num_permitted_opens = -1;
  	options->adm_forced_command = NULL;
-@@ -400,6 +400,25 @@ fill_default_server_options(ServerOptions *options)
+@@ -400,6 +400,25 @@ fill_default_server_options(ServerOption
  		options->max_sessions = DEFAULT_SESSIONS_MAX;
  	if (options->use_dns == -1)
  		options->use_dns = 0;
@@ -52,7 +44,7 @@ index 91f8c942..6f1f0068 100644
  	if (options->client_alive_interval == -1)
  		options->client_alive_interval = 0;
  	if (options->client_alive_count_max == -1)
-@@ -1748,11 +1767,15 @@ process_server_config_line(ServerOptions *options, char *line,
+@@ -1754,11 +1773,15 @@ process_server_config_line(ServerOptions
  			if (strchr(arg, '=') != NULL)
  				fatal("%s line %d: Invalid environment name.",
  				    filename, linenum);
@@ -68,7 +60,7 @@ index 91f8c942..6f1f0068 100644
  			options->accept_env[options->num_accept_env++] =
  			    xstrdup(arg);
  		}
-@@ -2224,7 +2247,7 @@ copy_set_server_options(ServerOptions *dst, ServerOptions *src, int preauth)
+@@ -2230,7 +2253,7 @@ copy_set_server_options(ServerOptions *d
  	} \
  } while(0)
  #define M_CP_STRARRAYOPT(n, num_n) do {\
@@ -77,11 +69,10 @@ index 91f8c942..6f1f0068 100644
  		for (dst->num_n = 0; dst->num_n < src->num_n; dst->num_n++) \
  			dst->n[dst->num_n] = xstrdup(src->n[dst->num_n]); \
  	} \
-diff --git a/session.c b/session.c
-index 9586901e..13ee4bbe 100644
---- a/session.c
-+++ b/session.c
-@@ -860,6 +860,18 @@ child_set_env(char ***envp, u_int *envsizep, const char *name,
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/session.c openssh-7.5p1/session.c
+--- openssh-7.5p1~/session.c	2017-10-06 12:34:45.131205136 +0000
++++ openssh-7.5p1/session.c	2017-10-06 12:34:45.522310521 +0000
+@@ -860,6 +860,18 @@ child_set_env(char ***envp, u_int *envsi
  }
  
  /*
@@ -100,7 +91,7 @@ index 9586901e..13ee4bbe 100644
   * Reads environment variables from the given file and adds/overrides them
   * into the environment.  If the file does not exist, this does nothing.
   * Otherwise, it must consist of empty lines, comments (line starts with '#')
-@@ -1022,6 +1034,16 @@ do_setup_env(Session *s, const char *shell)
+@@ -1022,6 +1034,16 @@ do_setup_env(Session *s, const char *she
  	ssh_gssapi_do_child(&env, &envsize);
  #endif
  
@@ -117,7 +108,7 @@ index 9586901e..13ee4bbe 100644
  	/* Set basic environment. */
  	for (i = 0; i < s->num_env; i++)
  		child_set_env(&env, &envsize, s->env[i].name, s->env[i].val);
-@@ -1062,8 +1084,7 @@ do_setup_env(Session *s, const char *shell)
+@@ -1062,8 +1084,7 @@ do_setup_env(Session *s, const char *she
  	/* Normal systems set SHELL by default. */
  	child_set_env(&env, &envsize, "SHELL", shell);
  
@@ -127,13 +118,12 @@ index 9586901e..13ee4bbe 100644
  
  #ifdef PER_SESSION_XAUTHFILE
          if (s->auth_file != NULL)
-diff --git a/sshd_config b/sshd_config
-index 62027108..9fcf2ca1 100644
---- a/sshd_config
-+++ b/sshd_config
-@@ -27,6 +27,10 @@ Port 22
- SyslogFacility AUTH
- LogLevel INFO
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config openssh-7.5p1/sshd_config
+--- openssh-7.5p1~/sshd_config	2017-10-06 12:34:44.922385596 +0000
++++ openssh-7.5p1/sshd_config	2017-10-06 12:34:45.522417407 +0000
+@@ -27,6 +27,10 @@
+ #SyslogFacility AUTH
+ #LogLevel INFO
  
 +# Use the client's locale/language settings
 +#AcceptEnv LANG LC_ALL LC_CTYPE LC_COLLATE LC_TIME LC_NUMERIC
@@ -142,10 +132,9 @@ index 62027108..9fcf2ca1 100644
  # Authentication:
  
  #LoginGraceTime 2m
-diff --git a/sshd_config.4 b/sshd_config.4
-index 0b2393dd..fbd9b1cd 100644
---- a/sshd_config.4
-+++ b/sshd_config.4
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config.4 openssh-7.5p1/sshd_config.4
+--- openssh-7.5p1~/sshd_config.4	2017-10-06 12:34:45.427736167 +0000
++++ openssh-7.5p1/sshd_config.4	2017-10-06 12:34:45.522716286 +0000
 @@ -85,7 +85,18 @@ directives.
  Be warned that some environment variables could be used to bypass restricted
  user environments.
@@ -165,7 +154,4 @@ index 0b2393dd..fbd9b1cd 100644
 +to specify that no environment variables should be passed.
  .It Cm AddressFamily
  Specifies which address family should be used by
- .Xr sshd 1M .
--- 
-2.11.0
-
+ .Xr sshd 8 .

--- a/build/openssh/patches/0030-Temporarily-set-ssh-keygen-and-ssh-add-to-old-FP-for.patch
+++ b/build/openssh/patches/0030-Temporarily-set-ssh-keygen-and-ssh-add-to-old-FP-for.patch
@@ -7,15 +7,9 @@ SDC and its users have a lot of scripts that expect ssh-add
 and ssh-keygen to return fingerprints in the old format.
 As a temporary measure, make us default to producing this
 same output until we have migrated everything over.
----
- ssh-add.c    | 13 +++++++++++--
- ssh-keygen.c | 22 ++++++++++++++++++----
- 2 files changed, 29 insertions(+), 6 deletions(-)
-
-diff --git a/ssh-add.c b/ssh-add.c
-index fb9a53e6..c63488a3 100644
---- a/ssh-add.c
-+++ b/ssh-add.c
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-add.c openssh-7.5p1/ssh-add.c
+--- openssh-7.5p1~/ssh-add.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-add.c	2017-10-06 12:34:45.571855208 +0000
 @@ -52,6 +52,7 @@
  #include <string.h>
  #include <unistd.h>
@@ -66,11 +60,10 @@ index fb9a53e6..c63488a3 100644
  			if (fingerprint_hash == -1)
  				fatal("Invalid hash algorithm \"%s\"", optarg);
  			break;
-diff --git a/ssh-keygen.c b/ssh-keygen.c
-index 2a7939bf..6c0355bb 100644
---- a/ssh-keygen.c
-+++ b/ssh-keygen.c
-@@ -37,6 +37,7 @@
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/ssh-keygen.c openssh-7.5p1/ssh-keygen.c
+--- openssh-7.5p1~/ssh-keygen.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/ssh-keygen.c	2017-10-06 12:34:45.572352139 +0000
+@@ -38,6 +38,7 @@
  #include <unistd.h>
  #include <limits.h>
  #include <locale.h>
@@ -78,7 +71,7 @@ index 2a7939bf..6c0355bb 100644
  
  #include "xmalloc.h"
  #include "sshkey.h"
-@@ -101,7 +102,8 @@ int print_fingerprint = 0;
+@@ -103,7 +104,8 @@ int print_fingerprint = 0;
  int print_bubblebabble = 0;
  
  /* Hash algorithm to use for fingerprints. */
@@ -88,7 +81,7 @@ index 2a7939bf..6c0355bb 100644
  
  /* The identity file name, given on the command line or entered by the user. */
  char identity_file[1024];
-@@ -773,6 +775,7 @@ do_download(struct passwd *pw)
+@@ -775,6 +777,7 @@ do_download(struct passwd *pw)
  	enum sshkey_fp_rep rep;
  	int fptype;
  	char *fp, *ra;
@@ -96,7 +89,7 @@ index 2a7939bf..6c0355bb 100644
  
  	fptype = print_bubblebabble ? SSH_DIGEST_SHA1 : fingerprint_hash;
  	rep =    print_bubblebabble ? SSH_FP_BUBBLEBABBLE : SSH_FP_DEFAULT;
-@@ -788,8 +791,13 @@ do_download(struct passwd *pw)
+@@ -790,8 +793,13 @@ do_download(struct passwd *pw)
  			    SSH_FP_RANDOMART);
  			if (fp == NULL || ra == NULL)
  				fatal("%s: sshkey_fingerprint fail", __func__);
@@ -111,7 +104,7 @@ index 2a7939bf..6c0355bb 100644
  			if (log_level >= SYSLOG_LEVEL_VERBOSE)
  				printf("%s\n", ra);
  			free(ra);
-@@ -833,7 +841,7 @@ try_read_key(char **cpp)
+@@ -835,7 +843,7 @@ try_read_key(char **cpp)
  static void
  fingerprint_one_key(const struct sshkey *public, const char *comment)
  {
@@ -120,7 +113,7 @@ index 2a7939bf..6c0355bb 100644
  	enum sshkey_fp_rep rep;
  	int fptype;
  
-@@ -843,7 +851,12 @@ fingerprint_one_key(const struct sshkey *public, const char *comment)
+@@ -845,7 +853,12 @@ fingerprint_one_key(const struct sshkey
  	ra = sshkey_fingerprint(public, fingerprint_hash, SSH_FP_RANDOMART);
  	if (fp == NULL || ra == NULL)
  		fatal("%s: sshkey_fingerprint failed", __func__);
@@ -134,7 +127,7 @@ index 2a7939bf..6c0355bb 100644
  	    comment ? comment : "no comment", sshkey_type(public));
  	if (log_level >= SYSLOG_LEVEL_VERBOSE)
  		printf("%s\n", ra);
-@@ -2303,6 +2316,7 @@ main(int argc, char **argv)
+@@ -2317,6 +2330,7 @@ main(int argc, char **argv)
  			break;
  		case 'E':
  			fingerprint_hash = ssh_digest_alg_by_name(optarg);
@@ -142,6 +135,3 @@ index 2a7939bf..6c0355bb 100644
  			if (fingerprint_hash == -1)
  				fatal("Invalid hash algorithm \"%s\"", optarg);
  			break;
--- 
-2.11.0
-

--- a/build/openssh/patches/0031-Restore-tcpwrappers-libwrap-support.patch
+++ b/build/openssh/patches/0031-Restore-tcpwrappers-libwrap-support.patch
@@ -5,17 +5,10 @@ Subject: [PATCH 31/34] Restore tcpwrappers/libwrap support
 
 This reverts commit f9696566fb41320820f3b257ab564fa321bb3751
 and commit f2719b7c2b8a3b14d778d8a6d8dc729b5174b054.
----
- configure.ac | 57 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- sshd.1m      |  7 +++++++
- sshd.c       | 29 +++++++++++++++++++++++++++++
- 3 files changed, 93 insertions(+)
-
-diff --git a/configure.ac b/configure.ac
-index 5e64db3b..bf9c5449 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -1494,6 +1494,62 @@ AC_ARG_WITH([skey],
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:45.377471723 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:45.622501723 +0000
+@@ -1497,6 +1497,62 @@ AC_ARG_WITH([skey],
  	]
  )
  
@@ -78,19 +71,18 @@ index 5e64db3b..bf9c5449 100644
  # Check whether user wants to use ldns
  LDNS_MSG="no"
  AC_ARG_WITH(ldns,
-@@ -5136,6 +5192,7 @@ echo "                 KerberosV support: $KRB5_MSG"
+@@ -5148,6 +5204,7 @@ echo "                 KerberosV support
  echo "                   SELinux support: $SELINUX_MSG"
  echo "                 Smartcard support: $SCARD_MSG"
  echo "                     S/KEY support: $SKEY_MSG"
 +echo "              TCP Wrappers support: $TCPW_MSG"
  echo "              MD5 password support: $MD5_MSG"
  echo "                   libedit support: $LIBEDIT_MSG"
- echo "  Solaris process contract support: $SPC_MSG"
-diff --git a/sshd.1m b/sshd.1m
-index 387ea69e..55cf3f0d 100644
---- a/sshd.1m
-+++ b/sshd.1m
-@@ -825,6 +825,12 @@ the user's home directory becomes accessible.
+ echo "                   libldns support: $LDNS_MSG"
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.1m openssh-7.5p1/sshd.1m
+--- openssh-7.5p1~/sshd.1m	2017-10-06 12:34:44.706646264 +0000
++++ openssh-7.5p1/sshd.1m	2017-10-06 12:34:45.622698705 +0000
+@@ -825,6 +825,12 @@ the user's home directory becomes access
  This file should be writable only by the user, and need not be
  readable by anyone else.
  .Pp
@@ -103,18 +95,17 @@ index 387ea69e..55cf3f0d 100644
  .It Pa /etc/hosts.equiv
  This file is for host-based authentication (see
  .Xr ssh 1 ) .
-@@ -956,6 +962,7 @@ Each SSHv2 userauth type has its own PAM service name:
+@@ -956,6 +962,7 @@ Each SSHv2 userauth type has its own PAM
  .Xr ssh-keygen 1 ,
  .Xr ssh-keyscan 1 ,
  .Xr chroot 2 ,
 +.Xr hosts_access 5 ,
  .Xr login.conf 5 ,
- .Xr moduli 4 ,
- .Xr sshd_config 4 ,
-diff --git a/sshd.c b/sshd.c
-index 67171704..75da16b7 100644
---- a/sshd.c
-+++ b/sshd.c
+ .Xr moduli 5 ,
+ .Xr sshd_config 5 ,
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd.c openssh-7.5p1/sshd.c
+--- openssh-7.5p1~/sshd.c	2017-10-06 12:34:45.278528289 +0000
++++ openssh-7.5p1/sshd.c	2017-10-06 12:34:45.622996300 +0000
 @@ -127,6 +127,17 @@
  #include <Security/AuthSession.h>
  #endif
@@ -133,7 +124,7 @@ index 67171704..75da16b7 100644
  /* Re-exec fds */
  #define REEXEC_DEVCRYPTO_RESERVED_FD	(STDERR_FILENO + 1)
  #define REEXEC_STARTUP_PIPE_FD		(STDERR_FILENO + 2)
-@@ -1997,6 +2008,24 @@ main(int ac, char **av)
+@@ -2011,6 +2022,24 @@ main(int ac, char **av)
  #ifdef SSH_AUDIT_EVENTS
  	audit_connection_from(remote_ip, remote_port);
  #endif
@@ -158,6 +149,3 @@ index 67171704..75da16b7 100644
  
  	/* Log the connection. */
  	laddr = get_local_ipaddr(sock_in);
--- 
-2.11.0
-

--- a/build/openssh/patches/0032-Let-us-put-a-fallback-copy-of-DH-moduli-in-a-system-.patch
+++ b/build/openssh/patches/0032-Let-us-put-a-fallback-copy-of-DH-moduli-in-a-system-.patch
@@ -8,16 +8,9 @@ Live distributions like SmartOS can't keep and update default
 config in directories like /etc/ssh very easily, so we should
 put the default "moduli" file in a system path and fall back to
 that if we can't find one in the SSHKEYDIR.
----
- Makefile.in  | 17 +++++------------
- configure.ac | 15 +++++++++++++++
- dh.c         |  6 +++++-
- 3 files changed, 25 insertions(+), 13 deletions(-)
-
-diff --git a/Makefile.in b/Makefile.in
-index 3a2a840d..e1f9d8a1 100644
---- a/Makefile.in
-+++ b/Makefile.in
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:45.328137892 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:45.673819660 +0000
 @@ -19,6 +19,7 @@ piddir=@piddir@
  srcdir=@srcdir@
  top_srcdir=@top_srcdir@
@@ -26,7 +19,7 @@ index 3a2a840d..e1f9d8a1 100644
  
  DESTDIR=
  VPATH=@srcdir@
-@@ -137,8 +138,8 @@ PATHSUBS	= \
+@@ -135,8 +136,8 @@ PATHSUBS	= \
  	-e 's|/etc/ssh/ssh_host_rsa_key|$(keydir)/ssh_host_rsa_key|g' \
  	-e 's|/etc/ssh/ssh_host_ed25519_key|$(keydir)/ssh_host_ed25519_key|g' \
  	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
@@ -37,16 +30,16 @@ index 3a2a840d..e1f9d8a1 100644
  	-e 's|/etc/ssh/sshrc|$(sysconfdir)/sshrc|g' \
  	-e 's|/usr/X11R6/bin/xauth|$(XAUTH_PATH)|g' \
  	-e 's|/var/empty|$(PRIVSEP_PATH)|g' \
-@@ -372,6 +373,8 @@ install-files:
- 	$(INSTALL) -m 555 smf/method.sh $(SMFMETHODDIR)/sshd
- 	$(INSTALL) -m 444 smf/manifest.xml $(SMFNETMANIDIR)/ssh.xml
+@@ -370,6 +371,8 @@ install-files:
+ 	$(INSTALL) -m 644 ssh-pkcs11-helper.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-pkcs11-helper.1m
+ 	mkdir -p $(ROOTDLIBDIR64) && cp $(srcdir)/sftp64.d $(ROOTDLIBDIR64)/sftp64.d
  	mkdir -p $(DESTDIR)$(keydir)
 +	$(srcdir)/mkinstalldirs $(DESTDIR)$(modulidir)
 +	$(INSTALL) -m 644 moduli.out $(DESTDIR)$(modulidir)/moduli
  
  install-sysconf:
  	if [ ! -d $(DESTDIR)$(sysconfdir) ]; then \
-@@ -387,16 +390,6 @@ install-sysconf:
+@@ -385,16 +388,6 @@ install-sysconf:
  	else \
  		echo "$(DESTDIR)$(sysconfdir)/sshd_config already exists, install will not overwrite"; \
  	fi
@@ -63,11 +56,10 @@ index 3a2a840d..e1f9d8a1 100644
  
  host-key: ssh-keygen$(EXEEXT)
  	@if [ -z "$(DESTDIR)" ] ; then \
-diff --git a/configure.ac b/configure.ac
-index bf9c5449..b9a7e7d5 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -4855,6 +4855,21 @@ AC_DEFINE_UNQUOTED([SSHKEYDIR], ["$keydir"],
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/configure.ac openssh-7.5p1/configure.ac
+--- openssh-7.5p1~/configure.ac	2017-10-06 12:34:45.622501723 +0000
++++ openssh-7.5p1/configure.ac	2017-10-06 12:34:45.674501959 +0000
+@@ -4867,6 +4867,21 @@ AC_DEFINE_UNQUOTED([SSHKEYDIR], ["$keydi
  	[Specify location of SSH host keys])
  AC_SUBST([keydir])
  
@@ -89,11 +81,10 @@ index bf9c5449..b9a7e7d5 100644
  dnl allow user to disable some login recording features
  AC_ARG_ENABLE([lastlog],
  	[  --disable-lastlog       disable use of lastlog even if detected [no]],
-diff --git a/dh.c b/dh.c
-index 47531242..0d3aca90 100644
---- a/dh.c
-+++ b/dh.c
-@@ -151,7 +151,11 @@ choose_dh(int min, int wantbits, int max)
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/dh.c openssh-7.5p1/dh.c
+--- openssh-7.5p1~/dh.c	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/dh.c	2017-10-06 12:34:45.674613750 +0000
+@@ -151,7 +151,11 @@ choose_dh(int min, int wantbits, int max
  	int linenum;
  	struct dhgroup dhg;
  
@@ -106,6 +97,3 @@ index 47531242..0d3aca90 100644
  		logit("WARNING: could not open %s (%s), using fixed modulus",
  		    _PATH_DH_MODULI, strerror(errno));
  		return (dh_new_group_fallback(max));
--- 
-2.11.0
-

--- a/build/openssh/patches/1001-dtrace32.patch
+++ b/build/openssh/patches/1001-dtrace32.patch
@@ -3,15 +3,10 @@ From: Alex Wilson <alex.wilson@joyent.com>
 Date: Tue, 22 Dec 2015 14:30:19 -0800
 Subject: [PATCH 1/2] SmartOS local: make dtrace lib 32-bit
 
----
- Makefile.in | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
-diff --git a/Makefile.in b/Makefile.in
-index 5e973f1..7d5d93c 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -28,7 +28,7 @@ ASKPASS_PROGRAM=$(libexecdir)/ssh-askpass
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/Makefile.in openssh-7.5p1/Makefile.in
+--- openssh-7.5p1~/Makefile.in	2017-10-06 12:34:45.673819660 +0000
++++ openssh-7.5p1/Makefile.in	2017-10-06 12:34:45.722447995 +0000
+@@ -28,7 +28,7 @@ ASKPASS_PROGRAM=$(libexecdir)/ssh-askpas
  SFTP_SERVER=$(libexecdir)/sftp-server
  SSH_KEYSIGN=$(libexecdir)/ssh-keysign
  SSH_PKCS11_HELPER=$(libexecdir)/ssh-pkcs11-helper
@@ -20,7 +15,7 @@ index 5e973f1..7d5d93c 100644
  PRIVSEP_PATH=@PRIVSEP_PATH@
  SSH_PRIVSEP_USER=@SSH_PRIVSEP_USER@
  STRIP_OPT=@STRIP_OPT@
-@@ -238,7 +238,7 @@ sftp_provider.h: $(srcdir)/sftp_provider.d
+@@ -236,7 +236,7 @@ sftp_provider.h: $(srcdir)/sftp_provider
  	    -o $(srcdir)/sftp_provider.h
  
  sftp_provider.o: sftp_provider.d sftp_provider.h sftp-server.o
@@ -29,15 +24,12 @@ index 5e973f1..7d5d93c 100644
  	    sftp-server.o -o sftp_provider.o
  
  # special case for sftp-server.o, it includes sftp_provider.h
-@@ -356,7 +356,7 @@ install-files:
+@@ -369,7 +369,7 @@ install-files:
  	$(INSTALL) -m 644 sftp-server.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/sftp-server.1m
  	$(INSTALL) -m 644 ssh-keysign.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-keysign.1m
  	$(INSTALL) -m 644 ssh-pkcs11-helper.1m.out $(DESTDIR)$(mandir)/$(mansubdir)1m/ssh-pkcs11-helper.1m
 -	mkdir -p $(ROOTDLIBDIR64) && cp $(srcdir)/sftp64.d $(ROOTDLIBDIR64)/sftp64.d
 +	mkdir -p $(ROOTDLIBDIR) && cp $(srcdir)/sftp64.d $(ROOTDLIBDIR)/sftp.d
-	mkdir -p $(DESTDIR)$(keydir)
-	$(srcdir)/mkinstalldirs $(DESTDIR)$(modulidir)
-	$(INSTALL) -m 644 moduli.out $(DESTDIR)$(modulidir)/moduli
--- 
-2.5.4 (Apple Git-61)
-
+ 	mkdir -p $(DESTDIR)$(keydir)
+ 	$(srcdir)/mkinstalldirs $(DESTDIR)$(modulidir)
+ 	$(INSTALL) -m 644 moduli.out $(DESTDIR)$(modulidir)/moduli

--- a/build/openssh/patches/2001-sftp-readonly.patch
+++ b/build/openssh/patches/2001-sftp-readonly.patch
@@ -1,0 +1,29 @@
+From 4d827f0d75a53d3952288ab882efbddea7ffadfe Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Tue, 4 Apr 2017 00:24:56 +0000
+Subject: [PATCH] upstream commit
+
+disallow creation (of empty files) in read-only mode;
+reported by Michal Zalewski, feedback & ok deraadt@
+
+Upstream-ID: 5d9c8f2fa8511d4ecf95322994ffe73e9283899b
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sftp-server.c openssh-7.5p1/sftp-server.c
+--- openssh-7.5p1~/sftp-server.c	2017-10-06 12:34:44.562482749 +0000
++++ openssh-7.5p1/sftp-server.c	2017-10-06 12:34:45.778540141 +0000
+@@ -1,4 +1,4 @@
+-/* $OpenBSD: sftp-server.c,v 1.110 2016/09/12 01:22:38 deraadt Exp $ */
++/* $OpenBSD: sftp-server.c,v 1.111 2017/04/04 00:24:56 djm Exp $ */
+ /*
+  * Copyright (c) 2000-2004 Markus Friedl.  All rights reserved.
+  *
+@@ -694,8 +694,8 @@ process_open(u_int32_t id)
+ 	logit("open \"%s\" flags %s mode 0%o",
+ 	    name, string_from_portable(pflags), mode);
+ 	if (readonly &&
+-	    ((flags & O_ACCMODE) == O_WRONLY ||
+-	    (flags & O_ACCMODE) == O_RDWR)) {
++	    ((flags & O_ACCMODE) != O_RDONLY ||
++	    (flags & (O_CREAT|O_TRUNC)) != 0)) {
+ 		verbose("Refusing open request in read-only mode");
+ 		status = SSH2_FX_PERMISSION_DENIED;
+ 	} else {

--- a/build/openssh/patches/series
+++ b/build/openssh/patches/series
@@ -29,3 +29,4 @@ sshd_config.patch
 0031-Restore-tcpwrappers-libwrap-support.patch
 0032-Let-us-put-a-fallback-copy-of-DH-moduli-in-a-system-.patch
 1001-dtrace32.patch
+2001-sftp-readonly.patch

--- a/build/openssh/patches/sshd_config.patch
+++ b/build/openssh/patches/sshd_config.patch
@@ -1,7 +1,8 @@
 diff -ru openssh-7.1p1.orig/sshd_config openssh-7.1p1/sshd_config
---- openssh-7.1p1.orig/sshd_config	Fri Aug 21 00:49:03 2015
-+++ openssh-7.1p1/sshd_config	Wed Sep  2 08:52:58 2015
-@@ -41,7 +41,7 @@
+diff -pruN '--exclude=*.orig' openssh-7.5p1~/sshd_config openssh-7.5p1/sshd_config
+--- openssh-7.5p1~/sshd_config	2017-03-20 03:39:27.000000000 +0000
++++ openssh-7.5p1/sshd_config	2017-10-06 12:34:44.215245761 +0000
+@@ -30,7 +30,7 @@
  # Authentication:
  
  #LoginGraceTime 2m
@@ -10,7 +11,7 @@ diff -ru openssh-7.1p1.orig/sshd_config openssh-7.1p1/sshd_config
  #StrictModes yes
  #MaxAuthTries 6
  #MaxSessions 10
-@@ -103,7 +103,7 @@
+@@ -89,7 +89,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
  #X11DisplayOffset 10
  #X11UseLocalhost yes
  #PermitTTY yes

--- a/build/openssh/testsuite.log
+++ b/build/openssh/testsuite.log
@@ -16,10 +16,9 @@ test_conversion: . 1 tests ok
 test_kex: ................................................................................................................................................................................................................................................................................................................................................................ 352 tests ok
 test_hostkeys: .................. 18 tests ok
 test_match: ...... 6 tests ok
-test_utf8: ..................
-regress/unittests/utf8/tests.c:27 test #19 "utf8_badarg"
-ASSERT_INT_EQ(len, -1) failed:
-         len = 1
-          -1 = -1
-gmake[1]: *** [Makefile:217: unit] Abort (core dumped)
-gmake: *** [Makefile:612: tests] Error 2
+test_utf8: .................................. 34 tests ok
+run test connect.sh ...
+ssh connect with protocol 2 failed
+failed simple connect
+gmake[1]: *** [Makefile:199: t-exec] Error 1
+gmake: *** [Makefile:606: tests] Error 2


### PR DESCRIPTION
patching OpenSSH with the following fix from 7.6p1:

```
disallow creation (of empty files) in read-only mode;
reported by Michal Zalewski, feedback & ok deraadt@
```

also rebasing patches.