### PR TITLE
Remove old gcc 4.8 obsoleted runtimes

### DIFF
--- a/build/gcc.obs/g++4-obs.p5m
+++ b/build/gcc.obs/g++4-obs.p5m
@@ -1,5 +1,0 @@
-set name=pkg.fmri value=system/library/g++-4-runtime@4.8.1-0.@RELVER@
-set name=pkg.renamed value=true
-set name=pkg.description value="g++ runtime dependencies libstc++/libssp"
-set name=pkg.summary value="g++ runtime dependencies libstc++/libssp"
-depend fmri=system/library/g++-5-runtime@5,5.11-@PVER@ type=require

--- a/build/gcc.obs/gcc4-obs.p5m
+++ b/build/gcc.obs/gcc4-obs.p5m
@@ -1,5 +1,0 @@
-set name=pkg.fmri value=system/library/gcc-4-runtime@4.8.1-0.@RELVER@
-set name=pkg.renamed value=true
-set name=pkg.description value="gcc 4.8 runtime"
-set name=pkg.summary value="gcc 4.8 runtime"
-depend fmri=system/library/gcc-5-runtime@5,5.11-@PVER@ type=require


### PR DESCRIPTION
Two more obsoleted packages which are no longer required.