### PR TITLE
Allow other packages to overwrite ntp.conf.

### DIFF
--- a/build/ntp/local.mog
+++ b/build/ntp/local.mog
@@ -27,6 +27,7 @@
 <transform file path=lib/svc/method/ntp$ -> set mode 0555>
 <transform file path=lib/svc/manifest/network/ntp.xml$ -> set mode 0444>
 <transform file path=etc/inet/ntp.conf -> set preserve true>
+<transform file path=etc/inet/ntp.conf -> set overlay allow>
 <transform dir  path=etc/security.* -> drop>
 <transform file path=etc/security/.*/ntp$ -> set mode 0444>
 <transform file path=usr/sbin/.* -> set mode 0555>


### PR DESCRIPTION
The Solaris standard was to ship a sample ntp configuration file as "/etc/inet/ntp.client". Recently OmniOS has started delivering a preconfigured ntp.conf file. This file may not be suitable for every installation. So we should allow other packages to overwrite the ntp.conf file by setting the IPS attribute "overlay" to "allow".

[This is the second try, this time without the big merge commit.  In the original PR, Andy Fiddaman commented: "I'm happy with this in principle. Looks like the pre-configured ntp.conf came in with r151022 and it seems like a good idea to have a working configuration out of the box, however I can see the benefit in allowing a local configuration package to overlay it."]
