### PR TITLE
Remove old function call

### DIFF
--- a/build/net-snmp/build.sh
+++ b/build/net-snmp/build.sh
@@ -105,7 +105,6 @@ patch_source
 prep_build
 build
 install_smf application/management net-snmp.xml svc-net-snmp
-place_smf_files
 strip_install
 make_package
 clean_up


### PR DESCRIPTION
The function was removed in an earlier commit and replaced by the new `install_smf` action but the function call was missed.