### PR TITLE
Prevent log file clobber when building with -p

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -125,8 +125,8 @@ logcmd() {
         echo Running: "$@" >> $LOGFILE
         "$@" >> $LOGFILE 2>&1
     else
-        echo Running: "$@" | tee $LOGFILE
-        "$@" | tee $LOGFILE 2>&1
+        echo Running: "$@" | tee -a $LOGFILE
+        "$@" | tee -a $LOGFILE 2>&1
         return ${PIPESTATUS[0]}
     fi
 }


### PR DESCRIPTION
It's sometimes useful to run a package build with `-p` to see full build output on screen, but this causes the log file to be overwritten for each command run.