### PR TITLE
Revert "Remove old gcc 4.8 obsoleted runtimes"

### DIFF
--- a/build/gcc.obs/g++4-obs.p5m
+++ b/build/gcc.obs/g++4-obs.p5m
@@ -1,0 +1,5 @@
+set name=pkg.fmri value=system/library/g++-4-runtime@4.8.1-0.@RELVER@
+set name=pkg.renamed value=true
+set name=pkg.description value="g++ runtime dependencies libstc++/libssp"
+set name=pkg.summary value="g++ runtime dependencies libstc++/libssp"
+depend fmri=system/library/g++-5-runtime@5,5.11-@PVER@ type=require

--- a/build/gcc.obs/gcc4-obs.p5m
+++ b/build/gcc.obs/gcc4-obs.p5m
@@ -1,0 +1,5 @@
+set name=pkg.fmri value=system/library/gcc-4-runtime@4.8.1-0.@RELVER@
+set name=pkg.renamed value=true
+set name=pkg.description value="gcc 4.8 runtime"
+set name=pkg.summary value="gcc 4.8 runtime"
+depend fmri=system/library/gcc-5-runtime@5,5.11-@PVER@ type=require


### PR DESCRIPTION
This reverts commit 7e56ce9a85d6dba558f9e4cc65980976d78481a7.

Any packages built pre-gcc5 may have dependencies on these obsoleted (actually renamed) packages so they need to stay.

This needs doing in the r151024 branch too.