### PR TITLE
Allow specifying any-version dependencies

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -837,6 +837,11 @@ make_package() {
                     ;;
             esac
             case $i in
+                *@)
+                    depname=${i%@}
+                    i=${i::-1}
+                    explicit_ver=true
+                    ;;
                 *@*)
                     depname=${i%@*}
                     explicit_ver=true


### PR DESCRIPTION
In the build system we can specify explicit minimum version dependencies by setting `RUN_DEPENDS_IPS=package/fmri@version` but we can't create dependencies that allow for any version. This change allows for this by specifying a trailing @ without a version number.

Test cases with this patch:

```
RUN_DEPENDS_IPS="library/ncurses"

--- Detected dependencies
depend fmri=pkg:/library/ncurses@6.0.20170722-0.151022 type=require
--- Final dependencies
depend type=require fmri=pkg:/library/ncurses@6.0.20170722-0.151022
```

```
RUN_DEPENDS_IPS="library/ncurses@"

--- Detected dependencies
depend fmri=pkg:/library/ncurses@6.0.20170722-0.151022 type=require
--- Final dependencies
depend type=require fmri=library/ncurses
```

```
RUN_DEPENDS_IPS="library/ncurses@6"

--- Detected dependencies
depend fmri=pkg:/library/ncurses@6.0.20170722-0.151022 type=require
--- Final dependencies
depend type=require fmri=library/ncurses@6

```