### PR TITLE
screen: Use ncurses, update /etc/screenrc

### DIFF
--- a/build/screen/local.mog
+++ b/build/screen/local.mog
@@ -21,7 +21,13 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
+
+<transform link path=usr/bin/screen -> drop>
+<transform file path=usr/bin/screen-.* -> set path usr/bin/screen>
+<transform file dir link path=usr/man -> edit path usr/man usr/share/man>
+
 <transform file path=etc/screenrc$ -> set preserve renamenew>
 license COPYING license=GPLv2

--- a/build/screen/patches/Makefile.in.patch
+++ b/build/screen/patches/Makefile.in.patch
@@ -1,7 +1,8 @@
---- Makefile.in.orig	Wed Jan  7 15:18:56 2009
-+++ Makefile.in	Wed Jan  7 15:19:26 2009
-@@ -15,7 +15,7 @@
- exec_prefix = @exec_prefix@
+diff -pruN '--exclude=*.orig' screen-4.6.1~/Makefile.in screen-4.6.1/Makefile.in
+--- screen-4.6.1~/Makefile.in	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/Makefile.in	2017-10-18 10:04:34.021872031 +0000
+@@ -17,7 +17,7 @@ datarootdir = @datarootdir@
+ datadir = @datadir@
  
  # don't forget to change mandir and infodir in doc/Makefile.
 -bindir  = $(exec_prefix)/bin

--- a/build/screen/patches/ncurses.patch
+++ b/build/screen/patches/ncurses.patch
@@ -1,0 +1,46 @@
+This patch makes configure check for ncurses before curses so that screen
+can take advantage of the latest terminal type information from our
+ncurses package.
+
+diff -pruN '--exclude=*.orig' screen-4.6.1~/configure screen-4.6.1/configure
+--- screen-4.6.1~/configure	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/configure	2017-10-18 10:04:34.096877437 +0000
+@@ -4825,7 +4825,7 @@ if ac_fn_c_try_link "$LINENO"; then :
+ 
+ else
+   olibs="$LIBS"
+-LIBS="-lcurses $olibs"
++LIBS="-lncurses $olibs"
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking libcurses..." >&5
+ $as_echo "$as_me: checking libcurses..." >&6;}
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -4916,7 +4916,7 @@ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+ 
+ else
+-  LIBS="-lncurses $olibs"
++  LIBS="-lcurses $olibs"
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking libncurses..." >&5
+ $as_echo "$as_me: checking libncurses..." >&6;}
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+diff -pruN '--exclude=*.orig' screen-4.6.1~/configure.ac screen-4.6.1/configure.ac
+--- screen-4.6.1~/configure.ac	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/configure.ac	2017-10-18 10:04:34.097268379 +0000
+@@ -631,7 +631,7 @@ dnl
+ AC_CHECKING(for tgetent)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+ olibs="$LIBS"
+-LIBS="-lcurses $olibs"
++LIBS="-lncurses $olibs"
+ AC_CHECKING(libcurses)
+ AC_TRY_LINK(,[
+ #ifdef __hpux
+@@ -652,7 +652,7 @@ AC_TRY_LINK(,tgetent((char *)0, (char *)
+ LIBS="-ltinfow $olibs"
+ AC_CHECKING(libtinfow)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+-LIBS="-lncurses $olibs"
++LIBS="-lcurses $olibs"
+ AC_CHECKING(libncurses)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+ LIBS="-ltinfo $olibs"

--- a/build/screen/patches/series
+++ b/build/screen/patches/series
@@ -1,2 +1,3 @@
-Makefile.in.patch -p0
-xnet-hack.patch -p1
+Makefile.in.patch
+xnet-hack.patch
+ncurses.patch

--- a/build/screen/patches/xnet-hack.patch
+++ b/build/screen/patches/xnet-hack.patch
@@ -1,5 +1,6 @@
---- screen-4.6.1/socket.c	Mon Jul 10 19:26:25 2017
-+++ screen-4.6.1.patched/socket.c	Sat Jul 15 20:03:50 2017
+diff -pruN '--exclude=*.orig' screen-4.6.1~/socket.c screen-4.6.1/socket.c
+--- screen-4.6.1~/socket.c	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/socket.c	2017-10-18 10:04:34.059604565 +0000
 @@ -33,7 +33,9 @@
  #include <sys/types.h>
  #include <sys/stat.h>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -18,6 +18,12 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
 * `libdiskmgt` and therefore `diskinfo` now recognises nvme, sata and xen
   controllers
 
+* The `/etc/screenrc` file delivered by the `screen` package is now based on
+  the recommended global template as delivered by the authors; you may wish
+  to check that it still meets your needs. If you have previously customised
+  this file then it will not be updated but the new template file will be
+  installed as `/etc/screenrc.new`.
+
 ### LX zones
 
 * Report that `/proc/sys` is writable to keep systemd happy.


### PR DESCRIPTION
Build screen against `libncurses` instead of `libcurses` so it can access the latest terminal information and support more recent terminal types such as _iTerm_ and _PuTTY_.

Replace `/etc/screenrc` with the recommended global template that comes with the source. It was previously the recommended user `.screenrc` (Release notes updated to explain what users may need to do, see below).

Move gnu_cleanup() commands to actions in local.mog

Remove build_isa line since we're only building this as 32-bit (the line previously printed an error and did nothing)

Re-base patches.