### PR TITLE
Add default code owner reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+
+* @citrus-it @hadfl @oetiker
+


### PR DESCRIPTION
Experimenting with this new GitHub feature which should automatically add reviewers.