### PR TITLE
When rebasing patches, remove old diff lines

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -551,7 +551,7 @@ rebase_patches() {
         # Extract the original patch header text
         sed -n '
             /^---/q
-            /^diff -pruN/q
+            /^diff -/q
             p
             ' < $patchfile~ > $patchfile
         gdiff -pruN --exclude='*.orig' $BUILDDIR~ $BUILDDIR >> $patchfile


### PR DESCRIPTION
Fix bug in rebasing patches where old diff lines could be retained.