### PR TITLE
coreutils: clean up & add uname

### DIFF
--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -34,7 +34,6 @@ PKG=file/gnu-coreutils  # Package name (without prefix)
 SUMMARY="coreutils - GNU core utilities"
 DESC="GNU core utilities ($VER)"
 
-#NO_PARALLEL_MAKE=1
 BUILD_DEPENDS_IPS="compress/xz library/gmp"
 
 CPPFLAGS="-I/usr/include/gmp"
@@ -49,11 +48,15 @@ export ac_cv_func_inotify_init=no
 # OS as reported by `uname -o`
 export gl_cv_host_operating_system=illumos
 
+TESTSUITE_FILTER='^[A-Z#][A-Z ]'
+[ -n "$BATCH" ] && SKIP_TESTSUITE=1
+
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+run_testsuite check
 make_package
 clean_up
 

--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions
@@ -33,37 +34,26 @@ PKG=file/gnu-coreutils  # Package name (without prefix)
 SUMMARY="coreutils - GNU core utilities"
 DESC="GNU core utilities ($VER)"
 
-NO_PARALLEL_MAKE=1
-BUILD_DEPENDS_IPS="compress/xz"
-DEPENDS_IPS="library/gmp system/library"
+#NO_PARALLEL_MAKE=1
+BUILD_DEPENDS_IPS="compress/xz library/gmp"
 
 CPPFLAGS="-I/usr/include/gmp"
 PREFIX=/usr/gnu
 reset_configure_opts
-CONFIGURE_OPTS="$CONFIGURE_OPTS --with-openssl=auto"
-CONFIGURE_OPTS_32="$CONFIGURE_OPTS_32 --libexecdir=/usr/lib --bindir=/usr/gnu/bin"
-CONFIGURE_OPTS_64="$CONFIGURE_OPTS_64 --libexecdir=/usr/lib/$ISAPART64"
+CONFIGURE_OPTS+=" --with-openssl=auto"
+CONFIGURE_OPTS_32+=" --libexecdir=/usr/lib --bindir=/usr/gnu/bin"
+CONFIGURE_OPTS_64+=" --libexecdir=/usr/lib/$ISAPART64"
 
+# coreutils incorrectly detects inotify support
 export ac_cv_func_inotify_init=no
-
-link_in_usr_bin() {
-    logmsg "Making links to /usr/bin"
-    logcmd mkdir -p $DESTDIR/usr/bin
-    for cmd in [ base64 dir dircolors install md5sum nproc pinky printenv \
-	ptx readlink seq sha1sum sha224sum sha256sum sha384sum sha512sum \
-	shred shuf stat stdbuf tac timeout truncate users vdir whoami 
-    do
-        logcmd ln $DESTDIR/usr/gnu/bin/$cmd $DESTDIR/usr/bin/$cmd
-    done
-}
+# OS as reported by `uname -o`
+export gl_cv_host_operating_system=illumos
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
-link_in_usr_bin
 make_package
 clean_up
 

--- a/build/coreutils/local.mog
+++ b/build/coreutils/local.mog
@@ -23,9 +23,36 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-<transform dir path=^usr/gnu/bin/amd64 -> drop>
-<transform file path=^usr/gnu/bin/amd64.* -> drop>
-<transform file path=^usr/gnu/bin/uname -> drop>
-<transform file path=^usr/gnu/share/man/man1/uname.1 -> drop>
-<transform file path=^license -> drop>
+<transform file dir path=usr/gnu/bin/amd64 -> drop>
+<transform file path=license -> drop>
+<transform file dir link path=usr/gnu/share/info -> drop>
 license COPYING license=GPLv3
+
+hardlink path=usr/bin/[			target=../gnu/bin/[
+hardlink path=usr/bin/base64		target=../gnu/bin/base64
+hardlink path=usr/bin/dir		target=../gnu/bin/dir
+hardlink path=usr/bin/dircolors		target=../gnu/bin/dircolors
+hardlink path=usr/bin/install		target=../gnu/bin/install
+hardlink path=usr/bin/md5sum		target=../gnu/bin/md5sum
+hardlink path=usr/bin/nproc		target=../gnu/bin/nproc
+hardlink path=usr/bin/pinky		target=../gnu/bin/pinky
+hardlink path=usr/bin/printenv		target=../gnu/bin/printenv
+hardlink path=usr/bin/ptx		target=../gnu/bin/ptx
+hardlink path=usr/bin/readlink		target=../gnu/bin/readlink
+hardlink path=usr/bin/seq		target=../gnu/bin/seq
+hardlink path=usr/bin/sha1sum		target=../gnu/bin/sha1sum
+hardlink path=usr/bin/sha224sum		target=../gnu/bin/sha224sum
+hardlink path=usr/bin/sha256sum		target=../gnu/bin/sha256sum
+hardlink path=usr/bin/sha384sum		target=../gnu/bin/sha384sum
+hardlink path=usr/bin/sha512sum		target=../gnu/bin/sha512sum
+hardlink path=usr/bin/shred		target=../gnu/bin/shred
+hardlink path=usr/bin/shuf		target=../gnu/bin/shuf
+hardlink path=usr/bin/stat		target=../gnu/bin/stat
+hardlink path=usr/bin/stdbuf		target=../gnu/bin/stdbuf
+hardlink path=usr/bin/tac		target=../gnu/bin/tac
+hardlink path=usr/bin/timeout		target=../gnu/bin/timeout
+hardlink path=usr/bin/truncate		target=../gnu/bin/truncate
+hardlink path=usr/bin/users		target=../gnu/bin/users
+hardlink path=usr/bin/vdir		target=../gnu/bin/vdir
+hardlink path=usr/bin/whoami		target=../gnu/bin/whoami
+

--- a/build/coreutils/patches/Makefile.in.patch
+++ b/build/coreutils/patches/Makefile.in.patch
@@ -1,7 +1,7 @@
-diff -ru coreutils-8.20.orig/Makefile.in coreutils-8.20/Makefile.in
---- coreutils-8.20.orig/Makefile.in	Tue Oct 23 16:26:32 2012
-+++ coreutils-8.20/Makefile.in	Wed Oct 31 14:34:05 2012
-@@ -1253,7 +1253,7 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/Makefile.in coreutils-8.28/Makefile.in
+--- coreutils-8.28~/Makefile.in	2017-09-02 02:25:09.000000000 +0000
++++ coreutils-8.28/Makefile.in	2017-10-21 11:40:17.540512941 +0000
+@@ -2644,7 +2644,7 @@ distuninstallcheck_listfiles = find . -t
  am__distuninstallcheck_listfiles = $(distuninstallcheck_listfiles) \
    | sed 's|^\./|$(prefix)/|' | grep -v '$(infodir)/dir$$'
  distcleancheck_listfiles = find . -type f -print
@@ -10,10 +10,10 @@ diff -ru coreutils-8.20.orig/Makefile.in coreutils-8.20/Makefile.in
  
  # Use 'ginstall' in the definition of PROGRAMS and in dependencies to avoid
  # confusion with the 'install' target.  The install rule transforms 'ginstall'
-diff -ru coreutils-8.20.orig/gnulib-tests/Makefile.in coreutils-8.20/gnulib-tests/Makefile.in
---- coreutils-8.20.orig/gnulib-tests/Makefile.in	Tue Oct 23 14:22:00 2012
-+++ coreutils-8.20/gnulib-tests/Makefile.in	Wed Oct 31 14:34:05 2012
-@@ -2255,7 +2255,7 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/gnulib-tests/Makefile.in coreutils-8.28/gnulib-tests/Makefile.in
+--- coreutils-8.28~/gnulib-tests/Makefile.in	2017-09-01 07:17:11.000000000 +0000
++++ coreutils-8.28/gnulib-tests/Makefile.in	2017-10-21 11:40:17.542048931 +0000
+@@ -2404,7 +2404,7 @@ am__relativize = \
      dir1=`echo "$$dir1" | sed -e "$$sed_rest"`; \
    done; \
    reldir="$$dir2"

--- a/build/coreutils/patches/install.c.patch
+++ b/build/coreutils/patches/install.c.patch
@@ -1,6 +1,7 @@
---- coreutils-8.21/src/install.c.orig	2013-02-07 09:37:05.000000000 +0000
-+++ coreutils-8.21/src/install.c	2013-09-23 16:24:18.730351203 +0000
-@@ -602,8 +602,8 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/src/install.c coreutils-8.28/src/install.c
+--- coreutils-8.28~/src/install.c	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/src/install.c	2017-10-21 11:40:15.887970444 +0000
+@@ -635,8 +635,8 @@ Usage: %s [OPTION]... [-T] SOURCE DEST\n
  \n\
  This install program copies files (often just compiled) into destination\n\
  locations you choose.  If you want to download and install a ready-to-use\n\

--- a/build/coreutils/patches/man-sections.patch
+++ b/build/coreutils/patches/man-sections.patch
@@ -1,54 +1,61 @@
---- coreutils-8.21/man/mkfifo.x.orig	2011-08-23 13:44:01.000000000 +0000
-+++ coreutils-8.21/man/mkfifo.x	2013-09-23 17:21:38.168189790 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/mkfifo.x coreutils-8.28/man/mkfifo.x
+--- coreutils-8.28~/man/mkfifo.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/mkfifo.x	2017-10-21 11:40:16.373199566 +0000
+@@ -3,4 +3,4 @@ mkfifo \- make FIFOs (named pipes)
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]
 -mkfifo(3)
 +mkfifo(3C)
---- coreutils-8.21/man/mktemp.x.orig	2011-08-23 13:44:01.000000000 +0000
-+++ coreutils-8.21/man/mktemp.x	2013-09-23 17:21:57.897138693 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/mktemp.x coreutils-8.28/man/mktemp.x
+--- coreutils-8.28~/man/mktemp.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/mktemp.x	2017-10-21 11:40:16.373579431 +0000
+@@ -3,4 +3,4 @@ mktemp \- create a temporary file or dir
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]
 -mkstemp(3), mkdtemp(3), mktemp(3)
 +mkstemp(3C), mkdtemp(3C), mktemp(3C)
---- coreutils-8.21/man/printf.x.orig	2012-05-28 08:02:48.000000000 +0000
-+++ coreutils-8.21/man/printf.x	2013-09-23 17:22:09.736987075 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/printf.x coreutils-8.28/man/printf.x
+--- coreutils-8.28~/man/printf.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/printf.x	2017-10-21 11:40:16.373855076 +0000
+@@ -3,4 +3,4 @@ printf \- format and print data
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]
 -printf(3)
 +printf(3C)
---- coreutils-8.21/man/pwd.x.orig	2011-08-23 13:44:01.000000000 +0000
-+++ coreutils-8.21/man/pwd.x	2013-09-23 17:23:11.996352035 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/pwd.x coreutils-8.28/man/pwd.x
+--- coreutils-8.28~/man/pwd.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/pwd.x	2017-10-21 11:40:16.374133469 +0000
+@@ -3,4 +3,4 @@ pwd \- print name of current/working dir
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]
 -getcwd(3)
 +getcwd(3C)
---- coreutils-8.21/man/rm.x.orig	2013-01-31 00:46:24.000000000 +0000
-+++ coreutils-8.21/man/rm.x	2013-09-23 17:23:44.283395367 +0000
-@@ -28,4 +28,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/rm.x coreutils-8.28/man/rm.x
+--- coreutils-8.28~/man/rm.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/rm.x	2017-10-21 11:40:16.374438082 +0000
+@@ -28,4 +28,4 @@ prompts the user for whether to remove t
  not affirmative, the file is skipped.
  .SH OPTIONS
  [SEE ALSO]
 -unlink(1), unlink(2), chattr(1), shred(1)
 +unlink(1), unlink(2), shred(1)
---- coreutils-8.21/man/sleep.x.orig	2011-08-23 13:44:01.000000000 +0000
-+++ coreutils-8.21/man/sleep.x	2013-09-23 17:24:54.044935177 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/sleep.x coreutils-8.28/man/sleep.x
+--- coreutils-8.28~/man/sleep.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/sleep.x	2017-10-21 11:40:16.374750727 +0000
+@@ -3,4 +3,4 @@ sleep \- delay for a specified amount of
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]
 -sleep(3)
 +sleep(3C)
---- coreutils-8.21/man/truncate.x.orig	2012-05-28 08:02:48.000000000 +0000
-+++ coreutils-8.21/man/truncate.x	2013-09-23 17:30:10.902130179 +0000
-@@ -3,4 +3,4 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/man/truncate.x coreutils-8.28/man/truncate.x
+--- coreutils-8.28~/man/truncate.x	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/man/truncate.x	2017-10-21 11:40:16.429724260 +0000
+@@ -3,4 +3,4 @@ truncate \- shrink or extend the size of
  [DESCRIPTION]
  .\" Add any additional description here
  [SEE ALSO]

--- a/build/coreutils/patches/mountlist.c.patch
+++ b/build/coreutils/patches/mountlist.c.patch
@@ -1,6 +1,7 @@
---- coreutils-8.27/lib/mountlist.c.orig	Mon Apr 17 13:44:32 2017
-+++ coreutils-8.27/lib/mountlist.c	Mon Apr 17 13:46:28 2017
-@@ -222,11 +222,11 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/lib/mountlist.c coreutils-8.28/lib/mountlist.c
+--- coreutils-8.28~/lib/mountlist.c	2017-09-01 07:12:43.000000000 +0000
++++ coreutils-8.28/lib/mountlist.c	2017-10-21 11:40:16.923015710 +0000
+@@ -222,11 +222,11 @@ me_remote (char const *fs_name, char con
  #endif
  
  #ifndef ME_REMOTE

--- a/build/coreutils/patches/who.c.patch
+++ b/build/coreutils/patches/who.c.patch
@@ -1,6 +1,7 @@
---- coreutils-8.5/src/who.c.orig	Thu Nov 10 07:54:27 2011
-+++ coreutils-8.5/src/who.c	Thu Nov 10 07:55:13 2011
-@@ -524,8 +524,8 @@
+diff -pruN '--exclude=*.orig' coreutils-8.28~/src/who.c coreutils-8.28/src/who.c
+--- coreutils-8.28~/src/who.c	2017-09-01 07:11:03.000000000 +0000
++++ coreutils-8.28/src/who.c	2017-10-21 11:40:17.230504468 +0000
+@@ -517,8 +517,8 @@ print_runlevel (const STRUCT_UTMP *utmp_
    unsigned char curr = UT_PID (utmp_ent) % 256;
  
    if (!runlevline)

--- a/build/coreutils/testsuite.log
+++ b/build/coreutils/testsuite.log
@@ -1,0 +1,977 @@
+PASS: tests/misc/help-version.sh
+SKIP: tests/tail-2/inotify-race.sh
+SKIP: tests/tail-2/inotify-race2.sh
+PASS: tests/misc/invalid-opt.pl
+SKIP: tests/rm/ext3-perf.sh
+PASS: tests/rm/cycle.sh
+SKIP: tests/cp/link-heap.sh
+SKIP: tests/cp/no-ctx.sh
+SKIP: tests/misc/tty-eof.pl
+PASS: tests/tail-2/inotify-hash-abuse.sh
+PASS: tests/tail-2/inotify-hash-abuse2.sh
+PASS: tests/tail-2/F-vs-missing.sh
+PASS: tests/tail-2/F-vs-rename.sh
+PASS: tests/tail-2/F-headers.sh
+PASS: tests/tail-2/descriptor-vs-rename.sh
+SKIP: tests/tail-2/inotify-rotate.sh
+SKIP: tests/tail-2/inotify-rotate-resources.sh
+SKIP: tests/tail-2/inotify-dir-recreate.sh
+SKIP: tests/tail-2/inotify-only-regular.sh
+PASS: tests/chmod/no-x.sh
+SKIP: tests/chgrp/basic.sh
+PASS: tests/rm/dangling-symlink.sh
+PASS: tests/misc/ls-time.sh
+PASS: tests/rm/d-1.sh
+PASS: tests/rm/d-2.sh
+PASS: tests/rm/d-3.sh
+PASS: tests/rm/deep-1.sh
+PASS: tests/rm/deep-2.sh
+PASS: tests/rm/dir-no-w.sh
+PASS: tests/rm/dir-nonrecur.sh
+PASS: tests/rm/dot-rel.sh
+PASS: tests/rm/isatty.sh
+PASS: tests/rm/empty-inacc.sh
+PASS: tests/rm/empty-name.pl
+PASS: tests/rm/f-1.sh
+PASS: tests/rm/fail-eacces.sh
+PASS: tests/rm/fail-eperm.xpl
+PASS: tests/tail-2/assert.sh
+SKIP: tests/rm/hash.sh
+PASS: tests/rm/i-1.sh
+PASS: tests/rm/i-never.sh
+PASS: tests/rm/i-no-r.sh
+PASS: tests/rm/ignorable.sh
+PASS: tests/rm/inaccessible.sh
+PASS: tests/rm/interactive-always.sh
+PASS: tests/rm/interactive-once.sh
+PASS: tests/rm/ir-1.sh
+PASS: tests/rm/one-file-system2.sh
+PASS: tests/rm/r-1.sh
+PASS: tests/rm/r-2.sh
+PASS: tests/rm/r-3.sh
+PASS: tests/rm/r-4.sh
+SKIP: tests/rm/r-root.sh
+PASS: tests/rm/readdir-bug.sh
+PASS: tests/rm/rm1.sh
+PASS: tests/touch/empty-file.sh
+PASS: tests/rm/rm2.sh
+PASS: tests/rm/rm3.sh
+PASS: tests/rm/rm4.sh
+PASS: tests/rm/rm5.sh
+PASS: tests/rm/sunos-1.sh
+PASS: tests/rm/unread2.sh
+PASS: tests/rm/unread3.sh
+PASS: tests/rm/unreadable.pl
+PASS: tests/rm/v-slash.sh
+SKIP: tests/rm/many-dir-entries-vs-OOM.sh
+SKIP: tests/rm/rm-readdir-fail.sh
+SKIP: tests/chgrp/default-no-deref.sh
+SKIP: tests/chgrp/deref.sh
+SKIP: tests/chgrp/no-x.sh
+SKIP: tests/chgrp/posix-H.sh
+SKIP: tests/chgrp/recurse.sh
+PASS: tests/fmt/base.pl
+PASS: tests/fmt/long-line.sh
+PASS: tests/fmt/goal-option.sh
+PASS: tests/misc/env.sh
+PASS: tests/misc/ptx.pl
+PASS: tests/misc/test.pl
+PASS: tests/misc/seq.pl
+PASS: tests/misc/seq-epipe.sh
+SKIP: tests/misc/seq-io-errors.sh
+SKIP: tests/misc/seq-long-double.sh
+PASS: tests/misc/seq-precision.sh
+PASS: tests/misc/head.pl
+PASS: tests/misc/head-elide-tail.pl
+SKIP: tests/tail-2/tail-n0f.sh
+PASS: tests/misc/ls-misc.pl
+PASS: tests/misc/date.pl
+PASS: tests/misc/date-next-dow.pl
+PASS: tests/misc/ptx-overrun.sh
+PASS: tests/misc/xstrtol.pl
+PASS: tests/tail-2/overlay-headers.sh
+PASS: tests/tail-2/pid.sh
+PASS: tests/misc/od.pl
+PASS: tests/misc/od-endian.sh
+PASS: tests/misc/od-float.sh
+PASS: tests/misc/mktemp.pl
+SKIP: tests/misc/arch.sh
+PASS: tests/misc/join.pl
+PASS: tests/pr/pr-tests.pl
+PASS: tests/misc/pwd-option.sh
+PASS: tests/misc/chcon-fail.sh
+SKIP: tests/misc/coreutils.sh
+PASS: tests/misc/cut.pl
+PASS: tests/misc/cut-huge-range.sh
+PASS: tests/misc/wc.pl
+PASS: tests/misc/wc-files0-from.pl
+ERROR: tests/misc/wc-files0.sh
+SKIP: tests/misc/wc-parallel.sh
+PASS: tests/misc/wc-proc.sh
+SKIP: tests/misc/cat-proc.sh
+PASS: tests/misc/cat-buf.sh
+PASS: tests/misc/cat-self.sh
+PASS: tests/misc/base64.pl
+PASS: tests/misc/basename.pl
+PASS: tests/misc/close-stdout.sh
+PASS: tests/misc/chroot-fail.sh
+PASS: tests/misc/comm.pl
+PASS: tests/misc/csplit.sh
+PASS: tests/misc/csplit-1000.sh
+PASS: tests/misc/csplit-heap.sh
+SKIP: tests/misc/csplit-io-err.sh
+PASS: tests/misc/csplit-suppress-matched.pl
+PASS: tests/misc/date-debug.sh
+PASS: tests/misc/date-sec.sh
+PASS: tests/misc/date-tz.sh
+PASS: tests/misc/dircolors.pl
+PASS: tests/misc/dirname.pl
+PASS: tests/misc/env-null.sh
+PASS: tests/misc/expand.pl
+PASS: tests/misc/expr.pl
+PASS: tests/misc/expr-multibyte.pl
+PASS: tests/misc/factor.pl
+PASS: tests/misc/factor-parallel.sh
+PASS: tests/misc/false-status.sh
+PASS: tests/misc/fold.pl
+PASS: tests/misc/groups-dash.sh
+PASS: tests/misc/groups-process-all.sh
+PASS: tests/misc/groups-version.sh
+PASS: tests/misc/head-c.sh
+PASS: tests/misc/head-pos.sh
+SKIP: tests/misc/head-write-error.sh
+PASS: tests/misc/kill.sh
+PASS: tests/misc/b2sum.sh
+PASS: tests/misc/md5sum.pl
+PASS: tests/misc/md5sum-bsd.sh
+PASS: tests/misc/md5sum-newline.pl
+SKIP: tests/misc/md5sum-parallel.sh
+PASS: tests/misc/mknod.sh
+PASS: tests/misc/nice.sh
+PASS: tests/misc/nice-fail.sh
+PASS: tests/misc/nl.sh
+PASS: tests/misc/nohup.sh
+PASS: tests/misc/nproc-avail.sh
+PASS: tests/misc/nproc-positive.sh
+PASS: tests/misc/nproc-override.sh
+PASS: tests/misc/numfmt.pl
+PASS: tests/misc/od-N.sh
+PASS: tests/misc/od-j.sh
+PASS: tests/misc/od-multiple-t.sh
+PASS: tests/misc/od-x8.sh
+PASS: tests/misc/paste.pl
+PASS: tests/misc/pathchk1.sh
+PASS: tests/misc/printenv.sh
+PASS: tests/misc/printf.sh
+PASS: tests/misc/printf-cov.pl
+PASS: tests/misc/printf-hex.sh
+PASS: tests/misc/printf-surprise.sh
+PASS: tests/misc/printf-quote.sh
+PASS: tests/misc/pwd-long.sh
+PASS: tests/misc/readlink-fp-loop.sh
+PASS: tests/misc/readlink-root.sh
+PASS: tests/misc/realpath.sh
+PASS: tests/misc/runcon-no-reorder.sh
+PASS: tests/misc/sha1sum.pl
+PASS: tests/misc/sha1sum-vec.pl
+PASS: tests/misc/sha224sum.pl
+PASS: tests/misc/sha256sum.pl
+PASS: tests/misc/sha384sum.pl
+PASS: tests/misc/sha512sum.pl
+PASS: tests/misc/shred-exact.sh
+PASS: tests/misc/shred-passes.sh
+PASS: tests/misc/shred-remove.sh
+PASS: tests/misc/shred-size.sh
+PASS: tests/misc/shuf.sh
+SKIP: tests/misc/shuf-reservoir.sh
+PASS: tests/misc/sleep.sh
+PASS: tests/misc/sort.pl
+SKIP: tests/misc/sort-benchmark-random.sh
+PASS: tests/misc/sort-compress.sh
+SKIP: tests/misc/sort-compress-hang.sh
+SKIP: tests/misc/sort-compress-proc.sh
+PASS: tests/misc/sort-continue.sh
+PASS: tests/misc/sort-debug-keys.sh
+PASS: tests/misc/sort-debug-warn.sh
+PASS: tests/misc/sort-discrim.sh
+PASS: tests/misc/sort-files0-from.pl
+PASS: tests/misc/sort-float.sh
+SKIP: tests/misc/sort-h-thousands-sep.sh
+PASS: tests/misc/sort-merge.pl
+PASS: tests/misc/sort-merge-fdlimit.sh
+SKIP: tests/misc/sort-month.sh
+PASS: tests/misc/sort-exit-early.sh
+PASS: tests/misc/sort-rand.sh
+SKIP: tests/misc/sort-spinlock-abuse.sh
+SKIP: tests/misc/sort-stale-thread-mem.sh
+PASS: tests/misc/sort-unique.sh
+PASS: tests/misc/sort-unique-segv.sh
+PASS: tests/misc/sort-version.sh
+PASS: tests/misc/sort-NaN-infloop.sh
+SKIP: tests/misc/sort-u-FMR.sh
+SKIP: tests/split/filter.sh
+PASS: tests/split/suffix-auto-length.sh
+PASS: tests/split/suffix-length.sh
+PASS: tests/split/additional-suffix.sh
+PASS: tests/split/b-chunk.sh
+PASS: tests/split/fail.sh
+PASS: tests/split/lines.sh
+PASS: tests/split/line-bytes.sh
+PASS: tests/split/l-chunk.sh
+PASS: tests/split/r-chunk.sh
+PASS: tests/split/record-sep.sh
+PASS: tests/split/numeric.sh
+PASS: tests/split/guard-input.sh
+PASS: tests/misc/stat-birthtime.sh
+PASS: tests/misc/stat-fmt.sh
+PASS: tests/misc/stat-hyphen.sh
+PASS: tests/misc/stat-mount.sh
+PASS: tests/misc/stat-nanoseconds.sh
+PASS: tests/misc/stat-printf.pl
+PASS: tests/misc/stat-slash.sh
+PASS: tests/misc/stdbuf.sh
+SKIP: tests/misc/stty.sh
+PASS: tests/misc/stty-invalid.sh
+SKIP: tests/misc/stty-pairs.sh
+PASS: tests/misc/stty-row-col.sh
+PASS: tests/misc/sum.pl
+PASS: tests/misc/sum-sysv.sh
+PASS: tests/misc/sync.sh
+PASS: tests/misc/tac.pl
+SKIP: tests/misc/tac-continue.sh
+PASS: tests/misc/tac-2-nonseekable.sh
+PASS: tests/misc/tail.pl
+PASS: tests/misc/tee.sh
+PASS: tests/misc/test-diag.pl
+PASS: tests/misc/time-style.sh
+PASS: tests/misc/timeout.sh
+PASS: tests/misc/timeout-blocked.pl
+SKIP: tests/misc/timeout-group.sh
+PASS: tests/misc/timeout-parameters.sh
+PASS: tests/misc/tr.pl
+PASS: tests/misc/tr-case-class.sh
+PASS: tests/misc/truncate-dangling-symlink.sh
+PASS: tests/misc/truncate-dir-fail.sh
+PASS: tests/misc/truncate-fail-diag.sh
+PASS: tests/misc/truncate-fifo.sh
+PASS: tests/misc/truncate-no-create-missing.sh
+PASS: tests/misc/truncate-overflow.sh
+PASS: tests/misc/truncate-parameters.sh
+PASS: tests/misc/truncate-relative.sh
+PASS: tests/misc/tsort.pl
+PASS: tests/misc/tty.sh
+PASS: tests/misc/unexpand.pl
+PASS: tests/misc/uniq.pl
+PASS: tests/misc/uniq-perf.sh
+SKIP: tests/misc/xattr.sh
+PASS: tests/misc/yes.sh
+PASS: tests/tail-2/wait.sh
+PASS: tests/tail-2/retry.sh
+PASS: tests/tail-2/symlink.sh
+PASS: tests/tail-2/tail-c.sh
+PASS: tests/tail-2/truncate.sh
+PASS: tests/chmod/c-option.sh
+PASS: tests/chmod/equal-x.sh
+PASS: tests/chmod/equals.sh
+PASS: tests/chmod/inaccessible.sh
+PASS: tests/chmod/octal.sh
+PASS: tests/chmod/setgid.sh
+PASS: tests/chmod/silent.sh
+PASS: tests/chmod/thru-dangling.sh
+PASS: tests/chmod/umask-x.sh
+PASS: tests/chmod/usage.sh
+PASS: tests/chown/deref.sh
+PASS: tests/chown/preserve-root.sh
+PASS: tests/chown/separator.sh
+PASS: tests/cp/abuse.sh
+SKIP: tests/cp/acl.sh
+PASS: tests/cp/attr-existing.sh
+PASS: tests/cp/backup-1.sh
+FAIL: tests/cp/backup-dir.sh
+PASS: tests/cp/backup-is-src.sh
+PASS: tests/cp/cp-HL.sh
+PASS: tests/cp/cp-deref.sh
+PASS: tests/cp/cp-i.sh
+PASS: tests/cp/cp-mv-backup.sh
+FAIL: tests/cp/cp-parents.sh
+PASS: tests/cp/deref-slink.sh
+PASS: tests/cp/dir-rm-dest.sh
+PASS: tests/cp/dir-slash.sh
+PASS: tests/cp/dir-vs-file.sh
+PASS: tests/cp/existing-perm-dir.sh
+SKIP: tests/cp/existing-perm-race.sh
+PASS: tests/cp/fail-perm.sh
+SKIP: tests/cp/fiemap-extents.sh
+SKIP: tests/cp/fiemap-FMR.sh
+SKIP: tests/cp/fiemap-perf.sh
+SKIP: tests/cp/fiemap-2.sh
+PASS: tests/cp/file-perm-race.sh
+PASS: tests/cp/into-self.sh
+PASS: tests/cp/link.sh
+PASS: tests/cp/link-deref.sh
+PASS: tests/cp/link-no-deref.sh
+PASS: tests/cp/link-preserve.sh
+PASS: tests/cp/link-symlink.sh
+SKIP: tests/cp/nfs-removal-race.sh
+PASS: tests/cp/no-deref-link1.sh
+PASS: tests/cp/no-deref-link2.sh
+PASS: tests/cp/no-deref-link3.sh
+ERROR: tests/cp/parent-perm.sh
+FAIL: tests/cp/parent-perm-race.sh
+SKIP: tests/cp/perm.sh
+PASS: tests/cp/preserve-2.sh
+FAIL: tests/cp/preserve-link.sh
+PASS: tests/cp/preserve-mode.sh
+PASS: tests/cp/preserve-slink-time.sh
+SKIP: tests/cp/proc-short-read.sh
+PASS: tests/cp/proc-zero-len.sh
+PASS: tests/cp/r-vs-symlink.sh
+PASS: tests/cp/reflink-auto.sh
+PASS: tests/cp/reflink-perm.sh
+PASS: tests/cp/same-file.sh
+PASS: tests/cp/slink-2-slink.sh
+SKIP: tests/cp/sparse.sh
+SKIP: tests/cp/sparse-to-pipe.sh
+PASS: tests/cp/special-f.sh
+FAIL: tests/cp/src-base-dot.sh
+PASS: tests/cp/symlink-slash.sh
+PASS: tests/cp/thru-dangling.sh
+PASS: tests/df/header.sh
+PASS: tests/df/df-P.sh
+PASS: tests/df/df-output.sh
+SKIP: tests/df/df-symlink.sh
+PASS: tests/df/unreadable.sh
+PASS: tests/df/total-unprocessed.sh
+SKIP: tests/df/no-mtab-status.sh
+SKIP: tests/df/skip-duplicates.sh
+SKIP: tests/df/skip-rootfs.sh
+PASS: tests/dd/ascii.sh
+SKIP: tests/dd/direct.sh
+PASS: tests/dd/misc.sh
+PASS: tests/dd/no-allocate.sh
+PASS: tests/dd/nocache.sh
+PASS: tests/dd/not-rewound.sh
+PASS: tests/dd/reblock.sh
+PASS: tests/dd/skip-seek.pl
+PASS: tests/dd/skip-seek2.sh
+PASS: tests/dd/bytes.sh
+SKIP: tests/dd/skip-seek-past-file.sh
+SKIP: tests/dd/sparse.sh
+PASS: tests/dd/stderr.sh
+PASS: tests/dd/unblock.pl
+PASS: tests/dd/unblock-sync.sh
+PASS: tests/dd/stats.sh
+PASS: tests/df/total-verify.sh
+SKIP: tests/du/2g.sh
+SKIP: tests/du/8gb.sh
+PASS: tests/du/basic.sh
+PASS: tests/du/bigtime.sh
+PASS: tests/du/deref.sh
+PASS: tests/du/deref-args.sh
+PASS: tests/du/exclude.sh
+SKIP: tests/du/fd-leak.sh
+PASS: tests/du/files0-from.pl
+PASS: tests/du/files0-from-dir.sh
+PASS: tests/du/hard-link.sh
+PASS: tests/du/inacc-dest.sh
+PASS: tests/du/inacc-dir.sh
+PASS: tests/du/inaccessible-cwd.sh
+PASS: tests/du/inodes.sh
+PASS: tests/du/long-from-unreadable.sh
+PASS: tests/du/long-sloop.sh
+PASS: tests/du/max-depth.sh
+SKIP: tests/du/move-dir-while-traversing.sh
+PASS: tests/du/no-deref.sh
+PASS: tests/du/no-x.sh
+PASS: tests/du/one-file-system.sh
+PASS: tests/du/restore-wd.sh
+PASS: tests/du/slash.sh
+PASS: tests/du/threshold.sh
+PASS: tests/du/trailing-slash.sh
+PASS: tests/du/two-args.sh
+SKIP: tests/id/gnu-zero-uids.sh
+SKIP: tests/id/no-context.sh
+SKIP: tests/id/context.sh
+PASS: tests/id/uid.sh
+PASS: tests/id/zero.sh
+SKIP: tests/id/smack.sh
+PASS: tests/install/basic-1.sh
+PASS: tests/install/create-leading.sh
+PASS: tests/install/d-slashdot.sh
+PASS: tests/install/install-C.sh
+SKIP: tests/install/install-C-selinux.sh
+SKIP: tests/install/install-Z-selinux.sh
+PASS: tests/install/strip-program.sh
+PASS: tests/install/trap.sh
+PASS: tests/ln/backup-1.sh
+PASS: tests/ln/hard-backup.sh
+PASS: tests/ln/hard-to-sym.sh
+PASS: tests/ln/misc.sh
+PASS: tests/ln/relative.sh
+PASS: tests/ln/sf-1.sh
+PASS: tests/ln/slash-decorated-nonexistent-dest.sh
+PASS: tests/ln/target-1.sh
+PASS: tests/ls/abmon-align.sh
+PASS: tests/ls/block-size.sh
+PASS: tests/ls/color-clear-to-eol.sh
+PASS: tests/ls/color-dtype-dir.sh
+PASS: tests/ls/color-norm.sh
+PASS: tests/ls/color-term.sh
+PASS: tests/ls/dangle.sh
+PASS: tests/ls/dired.sh
+PASS: tests/ls/file-type.sh
+PASS: tests/ls/follow-slink.sh
+SKIP: tests/ls/getxattr-speedup.sh
+PASS: tests/ls/hex-option.sh
+PASS: tests/ls/infloop.sh
+PASS: tests/ls/inode.sh
+PASS: tests/ls/m-option.sh
+PASS: tests/ls/w-option.sh
+PASS: tests/ls/multihardlink.sh
+PASS: tests/ls/no-arg.sh
+SKIP: tests/ls/no-cap.sh
+PASS: tests/ls/proc-selinux-segfault.sh
+PASS: tests/ls/quote-align.sh
+PASS: tests/ls/readdir-mountpoint-inode.sh
+PASS: tests/ls/recursive.sh
+PASS: tests/ls/root-rel-symlink-color.sh
+PASS: tests/ls/rt-1.sh
+SKIP: tests/ls/slink-acl.sh
+SKIP: tests/ls/stat-dtype.sh
+PASS: tests/ls/stat-failed.sh
+SKIP: tests/ls/stat-free-color.sh
+SKIP: tests/ls/stat-free-symlinks.sh
+PASS: tests/ls/stat-vs-dirent.sh
+PASS: tests/ls/symlink-quote.sh
+PASS: tests/ls/symlink-slash.sh
+PASS: tests/ls/time-style-diag.sh
+PASS: tests/ls/x-option.sh
+PASS: tests/ls/hyperlink.sh
+PASS: tests/mkdir/p-1.sh
+PASS: tests/mkdir/p-2.sh
+PASS: tests/mkdir/p-3.sh
+SKIP: tests/mkdir/p-acl.sh
+PASS: tests/mkdir/p-slashdot.sh
+PASS: tests/mkdir/p-thru-slink.sh
+PASS: tests/mkdir/p-v.sh
+PASS: tests/mkdir/parents.sh
+PASS: tests/mkdir/perm.sh
+SKIP: tests/mkdir/selinux.sh
+SKIP: tests/mkdir/restorecon.sh
+PASS: tests/mkdir/special-1.sh
+PASS: tests/mkdir/t-slash.sh
+SKIP: tests/mkdir/smack-no-root.sh
+SKIP: tests/mv/acl.sh
+SKIP: tests/mv/atomic.sh
+SKIP: tests/mv/atomic2.sh
+PASS: tests/mv/backup-dir.sh
+PASS: tests/mv/backup-is-src.sh
+PASS: tests/mv/childproof.sh
+PASS: tests/mv/diag.sh
+PASS: tests/mv/dir-file.sh
+PASS: tests/mv/dir2dir.sh
+FAIL: tests/mv/dup-source.sh
+PASS: tests/mv/force.sh
+PASS: tests/mv/hard-2.sh
+PASS: tests/mv/hard-3.sh
+PASS: tests/mv/hard-4.sh
+PASS: tests/mv/hard-link-1.sh
+PASS: tests/mv/i-1.pl
+PASS: tests/mv/i-2.sh
+PASS: tests/mv/i-3.sh
+PASS: tests/mv/i-4.sh
+PASS: tests/mv/i-5.sh
+PASS: tests/mv/i-link-no.sh
+PASS: tests/mv/into-self.sh
+PASS: tests/mv/into-self-2.sh
+PASS: tests/mv/into-self-3.sh
+PASS: tests/mv/into-self-4.sh
+SKIP: tests/mv/leak-fd.sh
+PASS: tests/mv/mv-n.sh
+PASS: tests/mv/mv-special-1.sh
+PASS: tests/mv/no-target-dir.sh
+PASS: tests/mv/part-fail.sh
+PASS: tests/mv/part-hardlink.sh
+PASS: tests/mv/part-rename.sh
+PASS: tests/mv/part-symlink.sh
+PASS: tests/mv/partition-perm.sh
+PASS: tests/mv/perm-1.sh
+PASS: tests/mv/symlink-onto-hardlink.sh
+SKIP: tests/mv/symlink-onto-hardlink-to-self.sh
+PASS: tests/mv/to-symlink.sh
+PASS: tests/mv/trailing-slash.sh
+PASS: tests/mv/update.sh
+PASS: tests/readlink/can-e.sh
+PASS: tests/readlink/can-f.sh
+PASS: tests/readlink/can-m.sh
+PASS: tests/readlink/multi.sh
+PASS: tests/readlink/rl-1.sh
+PASS: tests/rmdir/fail-perm.sh
+PASS: tests/rmdir/ignore.sh
+PASS: tests/rmdir/t-slash.sh
+PASS: tests/tail-2/assert-2.sh
+SKIP: tests/tail-2/big-4gb.sh
+PASS: tests/tail-2/flush-initial.sh
+PASS: tests/tail-2/follow-name.sh
+PASS: tests/tail-2/follow-stdin.sh
+PASS: tests/tail-2/pipe-f.sh
+PASS: tests/tail-2/pipe-f2.sh
+PASS: tests/tail-2/proc-ksyms.sh
+PASS: tests/tail-2/start-middle.sh
+PASS: tests/touch/60-seconds.sh
+PASS: tests/touch/dangling-symlink.sh
+PASS: tests/touch/dir-1.sh
+PASS: tests/touch/fail-diag.sh
+PASS: tests/touch/fifo.sh
+PASS: tests/touch/no-create-missing.sh
+PASS: tests/touch/no-dereference.sh
+PASS: tests/touch/no-rights.sh
+PASS: tests/touch/not-owner.sh
+PASS: tests/touch/obsolescent.sh
+PASS: tests/touch/read-only.sh
+PASS: tests/touch/relative.sh
+PASS: tests/touch/trailing-slash.sh
+SKIP: tests/chown/basic.sh
+SKIP: tests/cp/cp-a-selinux.sh
+SKIP: tests/cp/preserve-gid.sh
+SKIP: tests/cp/special-bits.sh
+SKIP: tests/cp/cp-mv-enotsup-xattr.sh
+SKIP: tests/cp/capability.sh
+SKIP: tests/cp/sparse-fiemap.sh
+SKIP: tests/dd/skip-seek-past-dev.sh
+SKIP: tests/df/problematic-chars.sh
+SKIP: tests/df/over-mount-device.sh
+SKIP: tests/du/bind-mount-dir-cycle.sh
+SKIP: tests/du/bind-mount-dir-cycle-v2.sh
+SKIP: tests/id/setgid.sh
+SKIP: tests/install/install-C-root.sh
+SKIP: tests/ls/capability.sh
+SKIP: tests/ls/nameless-uid.sh
+SKIP: tests/misc/chcon.sh
+SKIP: tests/misc/chroot-credentials.sh
+SKIP: tests/misc/selinux.sh
+SKIP: tests/misc/truncate-owned-by-other.sh
+SKIP: tests/mkdir/writable-under-readonly.sh
+SKIP: tests/mkdir/smack-root.sh
+SKIP: tests/mv/hardlink-case.sh
+SKIP: tests/mv/sticky-to-xpart.sh
+SKIP: tests/rm/fail-2eperm.sh
+SKIP: tests/rm/no-give-up.sh
+SKIP: tests/rm/one-file-system.sh
+SKIP: tests/rm/read-only.sh
+SKIP: tests/tail-2/append-only.sh
+SKIP: tests/touch/now-owned-by-other.sh
+SKIP: tests/factor/t00.sh
+SKIP: tests/factor/t01.sh
+SKIP: tests/factor/t02.sh
+SKIP: tests/factor/t03.sh
+SKIP: tests/factor/t04.sh
+SKIP: tests/factor/t05.sh
+SKIP: tests/factor/t06.sh
+SKIP: tests/factor/t07.sh
+SKIP: tests/factor/t08.sh
+SKIP: tests/factor/t09.sh
+SKIP: tests/factor/t10.sh
+SKIP: tests/factor/t11.sh
+SKIP: tests/factor/t12.sh
+SKIP: tests/factor/t13.sh
+SKIP: tests/factor/t14.sh
+SKIP: tests/factor/t15.sh
+SKIP: tests/factor/t16.sh
+SKIP: tests/factor/t17.sh
+SKIP: tests/factor/t18.sh
+SKIP: tests/factor/t19.sh
+SKIP: tests/factor/t20.sh
+SKIP: tests/factor/t21.sh
+SKIP: tests/factor/t22.sh
+SKIP: tests/factor/t23.sh
+SKIP: tests/factor/t24.sh
+SKIP: tests/factor/t25.sh
+SKIP: tests/factor/t26.sh
+SKIP: tests/factor/t27.sh
+SKIP: tests/factor/t28.sh
+SKIP: tests/factor/t29.sh
+SKIP: tests/factor/t30.sh
+SKIP: tests/factor/t31.sh
+SKIP: tests/factor/t32.sh
+SKIP: tests/factor/t33.sh
+SKIP: tests/factor/t34.sh
+SKIP: tests/factor/t35.sh
+SKIP: tests/factor/t36.sh
+# TOTAL: 600
+# PASS:  436
+# SKIP:  156
+# XFAIL: 0
+# FAIL:  6
+# XPASS: 0
+# ERROR: 2
+SKIP: tests/tail-2/inotify-race
+SKIP tests/tail-2/inotify-race.sh (exit status: 77)
+SKIP: tests/tail-2/inotify-race2
+SKIP tests/tail-2/inotify-race2.sh (exit status: 77)
+SKIP: tests/rm/ext3-perf
+SKIP tests/rm/ext3-perf.sh (exit status: 77)
+SKIP: tests/cp/link-heap
+SKIP tests/cp/link-heap.sh (exit status: 77)
+SKIP: tests/cp/no-ctx
+SKIP tests/cp/no-ctx.sh (exit status: 77)
+SKIP: tests/misc/tty-eof
+SKIP tests/misc/tty-eof.pl (exit status: 77)
+SKIP: tests/tail-2/inotify-rotate
+SKIP tests/tail-2/inotify-rotate.sh (exit status: 77)
+SKIP: tests/tail-2/inotify-rotate-resources
+SKIP tests/tail-2/inotify-rotate-resources.sh (exit status: 77)
+SKIP: tests/tail-2/inotify-dir-recreate
+SKIP tests/tail-2/inotify-dir-recreate.sh (exit status: 77)
+SKIP: tests/tail-2/inotify-only-regular
+SKIP tests/tail-2/inotify-only-regular.sh (exit status: 77)
+SKIP: tests/chgrp/basic
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/basic.sh (exit status: 77)
+SKIP: tests/rm/hash
+SKIP tests/rm/hash.sh (exit status: 77)
+SKIP: tests/rm/r-root
+SKIP tests/rm/r-root.sh (exit status: 77)
+SKIP: tests/rm/many-dir-entries-vs-OOM
+SKIP tests/rm/many-dir-entries-vs-OOM.sh (exit status: 77)
+SKIP: tests/rm/rm-readdir-fail
+SKIP tests/rm/rm-readdir-fail.sh (exit status: 77)
+SKIP: tests/chgrp/default-no-deref
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/default-no-deref.sh (exit status: 77)
+SKIP: tests/chgrp/deref
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/deref.sh (exit status: 77)
+SKIP: tests/chgrp/no-x
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/no-x.sh (exit status: 77)
+SKIP: tests/chgrp/posix-H
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/posix-H.sh (exit status: 77)
+SKIP: tests/chgrp/recurse
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/recurse.sh (exit status: 77)
+SKIP: tests/misc/seq-io-errors
+SKIP tests/misc/seq-io-errors.sh (exit status: 77)
+SKIP: tests/misc/seq-long-double
+SKIP tests/misc/seq-long-double.sh (exit status: 77)
+SKIP: tests/tail-2/tail-n0f
+SKIP tests/tail-2/tail-n0f.sh (exit status: 77)
+SKIP: tests/misc/arch
+SKIP tests/misc/arch.sh (exit status: 77)
+SKIP: tests/misc/coreutils
+SKIP tests/misc/coreutils.sh (exit status: 77)
+ERROR: tests/misc/wc-files0
+ERROR tests/misc/wc-files0.sh (exit status: 99)
+SKIP: tests/misc/wc-parallel
+SKIP tests/misc/wc-parallel.sh (exit status: 77)
+SKIP: tests/misc/cat-proc
+SKIP tests/misc/cat-proc.sh (exit status: 77)
+SKIP: tests/misc/csplit-io-err
+SKIP tests/misc/csplit-io-err.sh (exit status: 77)
+SKIP: tests/misc/head-write-error
+SKIP tests/misc/head-write-error.sh (exit status: 77)
+SKIP: tests/misc/md5sum-parallel
+SKIP tests/misc/md5sum-parallel.sh (exit status: 77)
+SKIP: tests/misc/shuf-reservoir
+SKIP tests/misc/shuf-reservoir.sh (exit status: 77)
+SKIP: tests/misc/sort-benchmark-random
+SKIP tests/misc/sort-benchmark-random.sh (exit status: 77)
+SKIP: tests/misc/sort-compress-hang
+SKIP tests/misc/sort-compress-hang.sh (exit status: 77)
+SKIP: tests/misc/sort-compress-proc
+SKIP tests/misc/sort-compress-proc.sh (exit status: 77)
+SKIP: tests/misc/sort-h-thousands-sep
+SKIP tests/misc/sort-h-thousands-sep.sh (exit status: 77)
+SKIP: tests/misc/sort-month
+SKIP tests/misc/sort-month.sh (exit status: 77)
+SKIP: tests/misc/sort-spinlock-abuse
+SKIP tests/misc/sort-spinlock-abuse.sh (exit status: 77)
+SKIP: tests/misc/sort-stale-thread-mem
+SKIP tests/misc/sort-stale-thread-mem.sh (exit status: 77)
+SKIP: tests/misc/sort-u-FMR
+SKIP tests/misc/sort-u-FMR.sh (exit status: 77)
+SKIP: tests/split/filter
+SKIP tests/split/filter.sh (exit status: 77)
+SKIP: tests/misc/stty
+SKIP tests/misc/stty.sh (exit status: 77)
+SKIP: tests/misc/stty-pairs
+SKIP tests/misc/stty-pairs.sh (exit status: 77)
+SKIP: tests/misc/tac-continue
+SKIP tests/misc/tac-continue.sh (exit status: 77)
+SKIP: tests/misc/timeout-group
+SKIP tests/misc/timeout-group.sh (exit status: 77)
+SKIP: tests/misc/xattr
+SKIP tests/misc/xattr.sh (exit status: 77)
+SKIP: tests/cp/acl
+SKIP tests/cp/acl.sh (exit status: 77)
+FAIL: tests/cp/backup-dir
+FAIL tests/cp/backup-dir.sh (exit status: 1)
+FAIL: tests/cp/cp-parents
+FAIL tests/cp/cp-parents.sh (exit status: 1)
+SKIP: tests/cp/existing-perm-race
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/cp/existing-perm-race.sh (exit status: 77)
+SKIP: tests/cp/fiemap-extents
+SKIP tests/cp/fiemap-extents.sh (exit status: 77)
+SKIP: tests/cp/fiemap-FMR
+SKIP tests/cp/fiemap-FMR.sh (exit status: 77)
+SKIP: tests/cp/fiemap-perf
+SKIP tests/cp/fiemap-perf.sh (exit status: 77)
+SKIP: tests/cp/fiemap-2
+SKIP tests/cp/fiemap-2.sh (exit status: 77)
+SKIP: tests/cp/nfs-removal-race
+SKIP tests/cp/nfs-removal-race.sh (exit status: 77)
+ERROR: tests/cp/parent-perm
+ERROR tests/cp/parent-perm.sh (exit status: 99)
+FAIL: tests/cp/parent-perm-race
+FAIL tests/cp/parent-perm-race.sh (exit status: 1)
+SKIP: tests/cp/perm
+SKIP tests/cp/perm.sh (exit status: 77)
+FAIL: tests/cp/preserve-link
+FAIL tests/cp/preserve-link.sh (exit status: 1)
+SKIP: tests/cp/proc-short-read
+SKIP tests/cp/proc-short-read.sh (exit status: 77)
+SKIP: tests/cp/sparse
+SKIP tests/cp/sparse.sh (exit status: 77)
+SKIP: tests/cp/sparse-to-pipe
+SKIP tests/cp/sparse-to-pipe.sh (exit status: 77)
+FAIL: tests/cp/src-base-dot
+FAIL tests/cp/src-base-dot.sh (exit status: 1)
+SKIP: tests/df/df-symlink
+SKIP tests/df/df-symlink.sh (exit status: 77)
+SKIP: tests/df/no-mtab-status
+SKIP tests/df/no-mtab-status.sh (exit status: 77)
+SKIP: tests/df/skip-duplicates
+SKIP tests/df/skip-duplicates.sh (exit status: 77)
+SKIP: tests/df/skip-rootfs
+SKIP tests/df/skip-rootfs.sh (exit status: 77)
+SKIP: tests/dd/direct
+SKIP tests/dd/direct.sh (exit status: 77)
+SKIP: tests/dd/skip-seek-past-file
+SKIP tests/dd/skip-seek-past-file.sh (exit status: 77)
+SKIP: tests/dd/sparse
+SKIP tests/dd/sparse.sh (exit status: 77)
+SKIP: tests/du/2g
+SKIP tests/du/2g.sh (exit status: 77)
+SKIP: tests/du/8gb
+SKIP tests/du/8gb.sh (exit status: 77)
+SKIP: tests/du/fd-leak
+SKIP tests/du/fd-leak.sh (exit status: 77)
+SKIP: tests/du/move-dir-while-traversing
+SKIP tests/du/move-dir-while-traversing.sh (exit status: 77)
+SKIP: tests/id/gnu-zero-uids
+SKIP tests/id/gnu-zero-uids.sh (exit status: 77)
+SKIP: tests/id/no-context
+SKIP tests/id/no-context.sh (exit status: 77)
+SKIP: tests/id/context
+SKIP tests/id/context.sh (exit status: 77)
+SKIP: tests/id/smack
+SKIP tests/id/smack.sh (exit status: 77)
+SKIP: tests/install/install-C-selinux
+SKIP tests/install/install-C-selinux.sh (exit status: 77)
+SKIP: tests/install/install-Z-selinux
+SKIP tests/install/install-Z-selinux.sh (exit status: 77)
+SKIP: tests/ls/getxattr-speedup
+SKIP tests/ls/getxattr-speedup.sh (exit status: 77)
+SKIP: tests/ls/no-cap
+SKIP tests/ls/no-cap.sh (exit status: 77)
+SKIP: tests/ls/slink-acl
+SKIP tests/ls/slink-acl.sh (exit status: 77)
+SKIP: tests/ls/stat-dtype
+SKIP tests/ls/stat-dtype.sh (exit status: 77)
+SKIP: tests/ls/stat-free-color
+SKIP tests/ls/stat-free-color.sh (exit status: 77)
+SKIP: tests/ls/stat-free-symlinks
+SKIP tests/ls/stat-free-symlinks.sh (exit status: 77)
+SKIP: tests/mkdir/p-acl
+SKIP tests/mkdir/p-acl.sh (exit status: 77)
+SKIP: tests/mkdir/selinux
+SKIP tests/mkdir/selinux.sh (exit status: 77)
+SKIP: tests/mkdir/restorecon
+SKIP tests/mkdir/restorecon.sh (exit status: 77)
+SKIP: tests/mkdir/smack-no-root
+SKIP tests/mkdir/smack-no-root.sh (exit status: 77)
+SKIP: tests/mv/acl
+SKIP tests/mv/acl.sh (exit status: 77)
+SKIP: tests/mv/atomic
+SKIP tests/mv/atomic.sh (exit status: 77)
+SKIP: tests/mv/atomic2
+SKIP tests/mv/atomic2.sh (exit status: 77)
+FAIL: tests/mv/dup-source
+FAIL tests/mv/dup-source.sh (exit status: 1)
+SKIP: tests/mv/leak-fd
+SKIP tests/mv/leak-fd.sh (exit status: 77)
+SKIP: tests/mv/symlink-onto-hardlink-to-self
+SKIP tests/mv/symlink-onto-hardlink-to-self.sh (exit status: 77)
+SKIP: tests/tail-2/big-4gb
+SKIP tests/tail-2/big-4gb.sh (exit status: 77)
+SKIP: tests/chown/basic
+SKIP tests/chown/basic.sh (exit status: 77)
+SKIP: tests/cp/cp-a-selinux
+SKIP tests/cp/cp-a-selinux.sh (exit status: 77)
+SKIP: tests/cp/preserve-gid
+SKIP tests/cp/preserve-gid.sh (exit status: 77)
+SKIP: tests/cp/special-bits
+SKIP tests/cp/special-bits.sh (exit status: 77)
+SKIP: tests/cp/cp-mv-enotsup-xattr
+SKIP tests/cp/cp-mv-enotsup-xattr.sh (exit status: 77)
+SKIP: tests/cp/capability
+SKIP tests/cp/capability.sh (exit status: 77)
+SKIP: tests/cp/sparse-fiemap
+SKIP tests/cp/sparse-fiemap.sh (exit status: 77)
+SKIP: tests/dd/skip-seek-past-dev
+SKIP tests/dd/skip-seek-past-dev.sh (exit status: 77)
+SKIP: tests/df/problematic-chars
+SKIP tests/df/problematic-chars.sh (exit status: 77)
+SKIP: tests/df/over-mount-device
+SKIP tests/df/over-mount-device.sh (exit status: 77)
+SKIP: tests/du/bind-mount-dir-cycle
+SKIP tests/du/bind-mount-dir-cycle.sh (exit status: 77)
+SKIP: tests/du/bind-mount-dir-cycle-v2
+SKIP tests/du/bind-mount-dir-cycle-v2.sh (exit status: 77)
+SKIP: tests/id/setgid
+SKIP tests/id/setgid.sh (exit status: 77)
+SKIP: tests/install/install-C-root
+SKIP tests/install/install-C-root.sh (exit status: 77)
+SKIP: tests/ls/capability
+SKIP tests/ls/capability.sh (exit status: 77)
+SKIP: tests/ls/nameless-uid
+SKIP tests/ls/nameless-uid.sh (exit status: 77)
+SKIP: tests/misc/chcon
+SKIP tests/misc/chcon.sh (exit status: 77)
+SKIP: tests/misc/chroot-credentials
+SKIP tests/misc/chroot-credentials.sh (exit status: 77)
+SKIP: tests/misc/selinux
+SKIP tests/misc/selinux.sh (exit status: 77)
+SKIP: tests/misc/truncate-owned-by-other
+SKIP tests/misc/truncate-owned-by-other.sh (exit status: 77)
+SKIP: tests/mkdir/writable-under-readonly
+SKIP tests/mkdir/writable-under-readonly.sh (exit status: 77)
+SKIP: tests/mkdir/smack-root
+SKIP tests/mkdir/smack-root.sh (exit status: 77)
+SKIP: tests/mv/hardlink-case
+SKIP tests/mv/hardlink-case.sh (exit status: 77)
+SKIP: tests/mv/sticky-to-xpart
+SKIP tests/mv/sticky-to-xpart.sh (exit status: 77)
+SKIP: tests/rm/fail-2eperm
+SKIP tests/rm/fail-2eperm.sh (exit status: 77)
+SKIP: tests/rm/no-give-up
+SKIP tests/rm/no-give-up.sh (exit status: 77)
+SKIP: tests/rm/one-file-system
+SKIP tests/rm/one-file-system.sh (exit status: 77)
+SKIP: tests/rm/read-only
+SKIP tests/rm/read-only.sh (exit status: 77)
+SKIP: tests/tail-2/append-only
+SKIP tests/tail-2/append-only.sh (exit status: 77)
+SKIP: tests/touch/now-owned-by-other
+SKIP tests/touch/now-owned-by-other.sh (exit status: 77)
+SKIP: tests/factor/t00
+SKIP tests/factor/t00.sh (exit status: 77)
+SKIP: tests/factor/t01
+SKIP tests/factor/t01.sh (exit status: 77)
+SKIP: tests/factor/t02
+SKIP tests/factor/t02.sh (exit status: 77)
+SKIP: tests/factor/t03
+SKIP tests/factor/t03.sh (exit status: 77)
+SKIP: tests/factor/t04
+SKIP tests/factor/t04.sh (exit status: 77)
+SKIP: tests/factor/t05
+SKIP tests/factor/t05.sh (exit status: 77)
+SKIP: tests/factor/t06
+SKIP tests/factor/t06.sh (exit status: 77)
+SKIP: tests/factor/t07
+SKIP tests/factor/t07.sh (exit status: 77)
+SKIP: tests/factor/t08
+SKIP tests/factor/t08.sh (exit status: 77)
+SKIP: tests/factor/t09
+SKIP tests/factor/t09.sh (exit status: 77)
+SKIP: tests/factor/t10
+SKIP tests/factor/t10.sh (exit status: 77)
+SKIP: tests/factor/t11
+SKIP tests/factor/t11.sh (exit status: 77)
+SKIP: tests/factor/t12
+SKIP tests/factor/t12.sh (exit status: 77)
+SKIP: tests/factor/t13
+SKIP tests/factor/t13.sh (exit status: 77)
+SKIP: tests/factor/t14
+SKIP tests/factor/t14.sh (exit status: 77)
+SKIP: tests/factor/t15
+SKIP tests/factor/t15.sh (exit status: 77)
+SKIP: tests/factor/t16
+SKIP tests/factor/t16.sh (exit status: 77)
+SKIP: tests/factor/t17
+SKIP tests/factor/t17.sh (exit status: 77)
+SKIP: tests/factor/t18
+SKIP tests/factor/t18.sh (exit status: 77)
+SKIP: tests/factor/t19
+SKIP tests/factor/t19.sh (exit status: 77)
+SKIP: tests/factor/t20
+SKIP tests/factor/t20.sh (exit status: 77)
+SKIP: tests/factor/t21
+SKIP tests/factor/t21.sh (exit status: 77)
+SKIP: tests/factor/t22
+SKIP tests/factor/t22.sh (exit status: 77)
+SKIP: tests/factor/t23
+SKIP tests/factor/t23.sh (exit status: 77)
+SKIP: tests/factor/t24
+SKIP tests/factor/t24.sh (exit status: 77)
+SKIP: tests/factor/t25
+SKIP tests/factor/t25.sh (exit status: 77)
+SKIP: tests/factor/t26
+SKIP tests/factor/t26.sh (exit status: 77)
+SKIP: tests/factor/t27
+SKIP tests/factor/t27.sh (exit status: 77)
+SKIP: tests/factor/t28
+SKIP tests/factor/t28.sh (exit status: 77)
+SKIP: tests/factor/t29
+SKIP tests/factor/t29.sh (exit status: 77)
+SKIP: tests/factor/t30
+SKIP tests/factor/t30.sh (exit status: 77)
+SKIP: tests/factor/t31
+SKIP tests/factor/t31.sh (exit status: 77)
+SKIP: tests/factor/t32
+SKIP tests/factor/t32.sh (exit status: 77)
+SKIP: tests/factor/t33
+SKIP tests/factor/t33.sh (exit status: 77)
+SKIP: tests/factor/t34
+SKIP tests/factor/t34.sh (exit status: 77)
+SKIP: tests/factor/t35
+SKIP tests/factor/t35.sh (exit status: 77)
+SKIP: tests/factor/t36
+SKIP tests/factor/t36.sh (exit status: 77)
+# TOTAL: 600
+# PASS:  436
+# SKIP:  156
+# XFAIL: 0
+# FAIL:  6
+# XPASS: 0
+# ERROR: 2

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -34,6 +34,8 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
 
 ### Commands and Command Options
 
+* `/usr/gnu/bin/uname -o` reports `illumos` as the operating system.
+
 ### Developer Features
 
 * GCC version 7 is now available - `pkg install developer/gcc7` - and can be


### PR DESCRIPTION
* Re-adding the GNU version of `uname` in /usr/gnu/bin but reporting `illumos` for `-o`.
* Moving link commands to package mog file.
* Tidy mog file.
* Re-basing patches.
* Build with parallel make.
* Removing GNU info.
* Adding test-suite.

pkg contents diff:
```diff
124a125
> usr/gnu/bin/uname
139,140d139
< usr/gnu/share/info
< usr/gnu/share/info/coreutils.info
451a451
> usr/gnu/share/man/man1/uname.1
```

uname
```shell
% /usr/gnu/bin/uname -a
SunOS bloody 5.11 omnios-master-00b591cca2 i86pc i386 i86pc illumos
% /usr/gnu/bin/uname -o
illumos
```
