### PR TITLE
Centrally discard GNU info files

### DIFF
--- a/build/autoconf/local.mog
+++ b/build/autoconf/local.mog
@@ -24,7 +24,6 @@
 # Use is subject to license terms.
 #
 
-<transform file path=usr/share/info/standards.info -> drop>
 license COPYING license=GPL
 license COPYING.EXCEPTION license=GPL.EXCEPTION
 license COPYINGv3 license=GPLv3

--- a/build/automake/local.mog
+++ b/build/automake/local.mog
@@ -23,6 +23,4 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-<transform dir path=usr/share/info$ -> drop>
-<transform file path=usr/share/info -> drop>
 license COPYING license=GPL

--- a/build/coreutils/local.mog
+++ b/build/coreutils/local.mog
@@ -25,7 +25,6 @@
 #
 <transform file dir path=usr/gnu/bin/amd64 -> drop>
 <transform file path=license -> drop>
-<transform file dir link path=usr/gnu/share/info -> drop>
 license COPYING license=GPLv3
 
 hardlink path=usr/bin/[			target=../gnu/bin/[

--- a/build/gcc5/libgmp.mog
+++ b/build/gcc5/libgmp.mog
@@ -1,5 +1,3 @@
 
-<transform file dir link path=.*/share/info -> drop>
-
 license COPYING license=GPLv3
 license COPYING.LESSERv3 license=LGPLv3

--- a/build/gcc5/libmpc.mog
+++ b/build/gcc5/libmpc.mog
@@ -1,3 +1,1 @@
-<transform file dir link path=.*/share/info -> drop>
-
 license files/COPYING.LIB license=LGPLv2.1

--- a/build/gcc6/libgmp.mog
+++ b/build/gcc6/libgmp.mog
@@ -1,5 +1,3 @@
 
-<transform file dir link path=.*/share/info -> drop>
-
 license COPYING license=GPLv3
 license COPYING.LESSERv3 license=LGPLv3

--- a/build/gcc6/libmpc.mog
+++ b/build/gcc6/libmpc.mog
@@ -1,3 +1,1 @@
-<transform file dir link path=.*/share/info -> drop>
-
 license files/COPYING.LIB license=LGPLv2.1

--- a/build/grep/local.mog
+++ b/build/grep/local.mog
@@ -23,15 +23,7 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-<transform dir path=usr/share/doc$ -> drop>
-<transform dir path=usr/share/doc/.* -> drop>
-<transform file path=usr/share/doc/.* -> drop>
-<transform link path=usr/share/doc/.* -> drop>
-
-<transform dir path=usr/share/info$ -> drop>
-<transform dir path=usr/share/info/.* -> drop>
-<transform file path=usr/share/info/.* -> drop>
-<transform link path=usr/share/info/.* -> drop>
+<transform file link dir path=usr/share/doc -> drop>
 
 <transform file path=license$ -> drop>
 license license license=GPLv3

--- a/build/groff/local.mog
+++ b/build/groff/local.mog
@@ -23,15 +23,7 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-<transform dir path=usr/share/doc$ -> drop>
-<transform dir path=usr/share/doc/.* -> drop>
-<transform file path=usr/share/doc/.* -> drop>
-<transform link path=usr/share/doc/.* -> drop>
-
-<transform dir path=usr/share/info$ -> drop>
-<transform dir path=usr/share/info/.* -> drop>
-<transform file path=usr/share/info/.* -> drop>
-<transform link path=usr/share/info/.* -> drop>
+<transform file dir link path=usr/share/doc -> drop>
 
 <transform file path=license$ -> drop>
 license license license=GPLv3

--- a/build/m4/local.mog
+++ b/build/m4/local.mog
@@ -1,7 +1,5 @@
 license COPYING license=GPLv3
 
-<transform file dir path=usr/share/info -> drop>
-
 dir group=bin mode=0755 owner=root path=usr/sfw/bin
 dir group=bin mode=0755 owner=root path=usr/share/man/man1
 link path=usr/bin/gm4 target=../gnu/bin/m4

--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -42,8 +42,10 @@
 <transform dir path=usr/share/locale/.* -> set group other>
 <transform dir path=usr/share/locale$ -> set group other>
 
-# drop GNU info dir files
+# drop GNU info files
 <transform file path=.*/share/info/dir$ -> drop>
+<transform file dir link path=usr/gnu/share/info -> drop>
+<transform file dir link path=usr/share/info -> drop>
 
 # We don't want any libtool archives packaging
 <transform file path=.*/lib/.*\.la$ -> drop>


### PR DESCRIPTION
GNU info files are excluded from a number of packages but not all, and excluded in differing ways.
Centralise this into the global mog file and remove the individual package exclusions.