### PR TITLE
Report illumos stage during parallel build

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -388,6 +388,18 @@ parallel_build() {
                 logmsg "######################################################"
                 logmsg "-- Job status --"
                 now=`date +%s`
+
+                # If nightly is running, include that status too
+                nightly=$PREBUILT_ILLUMOS/log/nightly.lock
+                if [ -h "$nightly" ]; then
+                    nightly_pid="`readlink $nightly | cut -d. -f3`"
+                    if kill -0 $nightly_pid; then
+                        # Nightly running
+                        msg=`grep '^===' ${nightly/lock/log} | tail -1`
+                        logmsg "`printf "    [=] %8d -  nightly %s\n" \
+                            "$nightly_pid" "${msg:0:50}"`"
+                    fi
+                fi
                 for i in `seq 0 $threads`; do
                     [ -n "${slots[$i]}" ] || continue
                     ((tm = now - ${slotstart[$i]}))


### PR DESCRIPTION
In addition to showing the job slot status during a parallel build, include the illumos build status too if available:

```
######################################################
-- Job status --
    [=]    11736 -  nightly ==== Building OS-Net source at Mon Oct 23 08:27:07
    [0]    27891 - (   45s) (  1/182) archiver/gnu-tar
    [1]    28345 - (   43s) (  4/182) compress/p7zip
######################################################
```