### PR TITLE
nss/nspr: update to 3.33/4.17 + fix sse alignment

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -141,7 +141,7 @@ depend fmri=library/libxml2@2.9,5.11-@PVER@ type=require
 depend fmri=library/libxslt@1.1.29,5.11-@PVER@ type=require
 depend fmri=library/ncurses@6,5.11-@PVER@ type=require
 depend fmri=library/nghttp2@1.21.1,5.11-@PVER@ type=require
-depend fmri=library/nspr@4.16,5.11-@PVER@ type=require
+depend fmri=library/nspr@4.17,5.11-@PVER@ type=require
 depend fmri=library/pcre@8.40,5.11-@PVER@ type=require
 depend fmri=library/python-2/cherrypy-27@3.2.2,5.11-@PVER@ type=require
 depend fmri=library/python-2/m2crypto-27@0.24,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.p5m
+++ b/build/jeos/omnios-userland.p5m
@@ -53,8 +53,8 @@ depend fmri=library/libxml2@2.9,5.11-@PVER@ type=incorporate
 depend fmri=library/libxslt@1.1.29,5.11-@PVER@ type=incorporate
 depend fmri=library/ncurses@6,5.11-@PVER@ type=incorporate
 depend fmri=library/nghttp2@1.21.1,5.11-@PVER@ type=incorporate
-depend fmri=library/nspr@4.16,5.11-@PVER@ type=incorporate
-depend fmri=library/nspr/header-nspr@4.16,5.11-@PVER@ type=incorporate
+depend fmri=library/nspr@4.17,5.11-@PVER@ type=incorporate
+depend fmri=library/nspr/header-nspr@4.17,5.11-@PVER@ type=incorporate
 depend fmri=library/pcre@8.40,5.11-@PVER@ type=incorporate
 depend fmri=library/perl-5/xml-parser@2.44,5.11-@PVER@ type=incorporate
 depend fmri=library/python-2/cherrypy-27@3.2.2,5.11-@PVER@ type=incorporate
@@ -108,8 +108,8 @@ depend fmri=system/library/iconv/utf-8/manual@0.5.11,5.11-@PVER@ type=incorporat
 depend fmri=system/library/iconv/xsh4/latin@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=system/library/libdbus@1.11.12,5.11-@PVER@ type=incorporate
 depend fmri=system/library/libdbus-glib@0.108,5.11-@PVER@ type=incorporate
-depend fmri=system/library/mozilla-nss@3.32,5.11-@PVER@ type=incorporate
-depend fmri=system/library/mozilla-nss/header-nss@3.32,5.11-@PVER@ type=incorporate
+depend fmri=system/library/mozilla-nss@3.33,5.11-@PVER@ type=incorporate
+depend fmri=system/library/mozilla-nss/header-nss@3.33,5.11-@PVER@ type=incorporate
 depend fmri=library/mtsk@0.5.11,5.11-@PVER@ type=incorporate
 depend fmri=system/library/pcap@1.8.1,5.11-@PVER@ type=incorporate
 depend fmri=system/management/ec2-api-tools@1.7.5,5.11-@PVER@ type=incorporate

--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -28,9 +28,9 @@
 . ../../lib/functions.sh
 
 PROG=nss
-VER=3.32.1
+VER=3.33
 # Include NSPR version since we're downloading a combined tarball.
-NSPRVER=4.16
+NSPRVER=4.17
 # But set BUILDDIR to just be the NSS version.
 BUILDDIR=$PROG-$VER
 VERHUMAN=$VER
@@ -45,7 +45,13 @@ DIST64=SunOS5.11_i86pc_gcc_64_OPT.OBJ
 
 BUILD_DEPENDS_IPS="library/nspr/header-nspr"
 
-MAKE_OPTS="BUILD_OPT=1 NS_USE_GCC=1 NO_MDUPDATE=1 NSDISTMODE=copy"
+MAKE_OPTS="
+    BUILD_OPT=1
+    NS_USE_GCC=1
+    NO_MDUPDATE=1
+    NSDISTMODE=copy
+    XCFLAGS=-g
+"
 
 NSS_LIBS="libfreebl3.so libnss3.so
 	libnssckbi.so libnssdbm3.so

--- a/build/mozilla-nss-nspr/patches/endian.patch
+++ b/build/mozilla-nss-nspr/patches/endian.patch
@@ -1,0 +1,10 @@
+--- nss-3.33~/nss/lib/freebl/verified/kremlib.h	2017-09-20 06:47:27.000000000 +0000
++++ nss-3.33/nss/lib/freebl/verified/kremlib.h	2017-09-20 13:38:53.908505774 +0000
+@@ -17,6 +17,7 @@
+ 
+ #include <inttypes.h>
+ #include <stdlib.h>
++#include <endian.h>
+ 
+ #include <stdbool.h>
+ #include <stdio.h>

--- a/build/mozilla-nss-nspr/patches/series
+++ b/build/mozilla-nss-nspr/patches/series
@@ -1,2 +1,4 @@
 nss-modernize.patch
 nss-makefile.patch
+sse-align.patch
+endian.patch

--- a/build/mozilla-nss-nspr/patches/sse-align.patch
+++ b/build/mozilla-nss-nspr/patches/sse-align.patch
@@ -1,0 +1,45 @@
+
+GCC optimises the memcpy() instruction in this function to use SSE
+instructions - in particular it introduces movaps which requires
+16-byte aligned arguments..
+
+However, in 32-bit, the stack is only 8-byte aligned so there is no
+guarantee that the local newIV variable will be properly aligned.
+
+This was causing crashes in /usr/sbin/nscd with ldap enabled in
+nsswitch.conf with the following stack trace:
+
+	libfreebl3.so`rijndael_decryptCBC+0x23
+	libfreebl3.so`AES_Decrypt+0x5b
+	libsoftokn3.so`AES_Decrypt+0x37
+	libsoftokn3.so`NSC_DecryptUpdate+0xce
+	libnss3.so`PK11_CipherOp+0x15a
+	libssl3.so`ssl3_HandleRecord+0x89f
+	libssl3.so`ssl3_GatherCompleteHandshake+0x263
+	libssl3.so`ssl3_GatherAppDataRecord+0x34
+	libssl3.so`ssl_SecureRecv+0x2a3
+	libssl3.so`ssl_Recv+0x57
+	libnspr4.so`PR_Recv+0x1b
+	libldap.so.5`prldap_read+0x33
+	... elided ...
+
+From GCC documentation:
+
+	force_align_arg_pointer
+
+	On x86 targets, the force_align_arg_pointer attribute may be applied
+	to individual function definitions, generating an alternate prologue
+	and epilogue that realigns the run-time stack if necessary. This
+	supports mixing legacy codes that run with a 4-byte aligned stack with
+	modern codes that keep a 16-byte stack for SSE compatibility.
+
+--- nss-3.33~/nss/lib/freebl/rijndael.c	2017-09-20 06:47:27.000000000 +0000
++++ nss-3.33/nss/lib/freebl/rijndael.c	2017-10-25 09:34:34.628062306 +0000
+@@ -968,6 +968,7 @@
+     return SECSuccess;
+ }
+ 
++__attribute__((force_align_arg_pointer))
+ static SECStatus
+ rijndael_decryptCBC(AESContext *cx, unsigned char *output,
+                     unsigned int *outputLen, unsigned int maxOutputLen,


### PR DESCRIPTION
This updates nss & nspr to the latest version and fixes a crash bug that was being experienced by an OmniOS user. See note in sse-align.patch for more details on the latter.