### PR TITLE
Automatically show differences between new and old packages

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -38,6 +38,10 @@ export LC_ALL=C
 # If $MIRROR begins with a '/', it is treated as a local directory.
 MIRROR=https://mirrors.omniosce.org
 
+# The production IPS repository for this branch (may be overriden in site.sh)
+# Used for package contents diffing.
+IPS_REPO=https://pkg.omniosce.org/bloody/core
+
 # Default prefix for packages (may be overridden)
 PREFIX=/usr
 


### PR DESCRIPTION
To easily check what has changed during package version upgrades. This is not done for batch builds.

```diff
--- Published system/library/mozilla-nss/header-nss@3.33,5.11-0.151023
--- Comparing old package with new

-dir  path=usr/lib/mps/amd64 owner=root group=bin mode=0755
-dir  path=usr/lib/mps/secv1 owner=root group=bin mode=0755
-dir  path=usr/lib/mps/secv1/amd64 owner=root group=bin mode=0755

***
*** Differences found between old and new packages
***
Do you wish to continue anyway? (y/n)
```