### PR TITLE
Add python-vcversioner package (required for python-jsonschema)

### DIFF
--- a/build/omnios-build-tools/omnios-build-tools.p5m
+++ b/build/omnios-build-tools/omnios-build-tools.p5m
@@ -51,4 +51,5 @@ depend fmri=text/gnu-sed type=require
 depend fmri=text/intltool type=require
 depend fmri=library/idnkit/header-idnkit type=require
 depend fmri=system/pciutils/pci.ids type=require
+depend fmri=library/python-2/vcversioner-27 type=require
 

--- a/build/python-vcversioner/build.sh
+++ b/build/python-vcversioner/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=vcversioner
+VER=2.16.0.0
+SUMMARY="Use version control tags to discover version numbers"
+DESC="$SUMMARY"
+
+XFORM_ARGS="-D PYTHONVER=$PYTHONVER"
+PKG=library/python-2/vcversioner-27
+RUN_DEPENDS_IPS="runtime/python-27"
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+python_build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:

--- a/build/python-vcversioner/local.mog
+++ b/build/python-vcversioner/local.mog
@@ -1,0 +1,1 @@
+license PKG-INFO license=ISCL


### PR DESCRIPTION
It seems that building the `jsonschema` python package has in the past automatically downloaded and used a local copy of `vcversioner` during the build. This is still happening (and working) in bloody/r151024.

However, the old version of `setuptools` in r151022 attempts to do the download over plain HTTP and recently the source server has been updated to enforce HTTPS, and so the download fails.

So, in order to continue allowing r151022 to build, add this additional python package to the repository (and `omnios-build-tools`)

I won't add this to other versions since they continue to build fine and download the dependency temporarily via HTTPS during build.