### PR TITLE
sqlite3: update to 3.21.0

### DIFF
--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -16,7 +16,7 @@ depend fmri=compress/unzip@6.0,5.11-@PVER@ type=require
 depend fmri=compress/xz@5.2,5.11-@PVER@ type=require
 depend fmri=compress/zip@3.0,5.11-@PVER@ type=require
 depend fmri=web/ca-bundle@5.11,5.11-@PVER@ type=require
-depend fmri=database/sqlite-3@3.20,5.11-@PVER@ type=require
+depend fmri=database/sqlite-3@3.21,5.11-@PVER@ type=require
 depend fmri=developer/debug/mdb@0.5.11,5.11-@PVER@ type=require
 depend fmri=developer/linker@0.5.11,5.11-@PVER@ type=require
 depend fmri=diagnostic/cpu-counters@0.5.11,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -9,7 +9,7 @@ compress/unzip				6.0
 compress/xz				5.2
 compress/zip				3.0
 data/iso-codes				3.76
-database/sqlite-3			3.20
+database/sqlite-3			3.21
 developer/as				0.5.11
 developer/build/autoconf		2.69
 developer/build/automake		1.15

--- a/build/sqlite3/build.sh
+++ b/build/sqlite3/build.sh
@@ -28,14 +28,13 @@
 . ../../lib/functions.sh
 
 PROG=sqlite-autoconf
-VER=3200100
-VERHUMAN=3.20.1
+VER=3210000
+VERHUMAN=3.21.0
 PKG=database/sqlite-3
 SUMMARY="SQL database engine library"
 DESC="$SUMMARY"
 
-DEPENDS_IPS="SUNWcs library/readline system/library/gcc-5-runtime"
-CONFIGURE_OPTS_64="$CONFIGURE_OPTS_64 --includedir=/usr/include"
+CONFIGURE_OPTS_64+=" --includedir=/usr/include"
 LIBTOOL_NOSTDLIB=libtool
 LIBTOOL_NOSTDLIB_EXTRAS=-lc
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -9,7 +9,7 @@
 | compress/xz				| 5.2.3			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| http://www.info-zip.org/Zip.html
 | data/iso-codes			| 3.76			| http://pkg-isocodes.alioth.debian.org/downloads/
-| database/sqlite-3			| 3200100		| https://www.sqlite.org/download.html
+| database/sqlite-3			| 3210000		| https://www.sqlite.org/download.html
 | developer/bmake			| 20170812		| http://www.crufty.net/ftp/pub/sjg/
 | developer/build/autoconf		| 2.69			| https://git.savannah.gnu.org/cgit/autoconf.git/refs/tags
 | developer/build/automake		| 1.15.1		| https://git.savannah.gnu.org/cgit/automake.git/refs/tags


### PR DESCRIPTION
```
% sqlite3
SQLite version 3.21.0 2017-10-24 18:55:49
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite>
```