### PR TITLE
Fix baseline sqlite3 version

### DIFF
--- a/doc/baseline
+++ b/doc/baseline
@@ -16,7 +16,7 @@ omnios consolidation/osnet/osnet-message-files 0.5.11-0.151023
 omnios consolidation/osnet/osnet-redistributable 0.5.11-0.151023
 omnios consolidation/sunpro/sunpro-incorporation 0.5.11-0.151023
 omnios data/iso-codes 3.76-0.151023
-omnios database/sqlite-3 3.20.1-0.151023
+omnios database/sqlite-3 3.21.0-0.151023
 omnios developer/acpi 0.5.11-0.151023
 omnios developer/appcert 0.5.11-0.151023
 omnios developer/apptrace 0.5.11-0.151023


### PR DESCRIPTION
Missed this in #333 
but full build currently says:

```
***
*** Checking baseline
***
--- /build/omnios-build/build/../lib/../doc/baseline    Mon Oct 30 15:45:39 2017
+++ /build/tmp/baseline.167775  Mon Oct 30 18:42:50 2017
@@ -19,1 +19,1 @@
-omnios database/sqlite-3 3.20.1-0.151023
+omnios database/sqlite-3 3.21.0-0.151023
Package list does not match baseline
```