### PR TITLE
ncurses: update to 20111104

### DIFF
--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,8 +18,7 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
@@ -28,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=ncurses
-VER=6.0-20171014
+VER=6.0-20171104
 VERHUMAN=$VER
 BUILDDIR=$PROG-$VER
 VER=${VER/-/.}
@@ -64,14 +63,12 @@ CONFIGURE_OPTS_64="
     --libdir=$GPREFIX/lib/$ISAPART64"
 
 gnu_links() {
-    mkdir -p $DESTDIR/$GPREFIX/bin
-    for cmd in captoinfo clear infocmp infotocap reset tic toe tput tset ; do
-        ln -s ../../bin/g$cmd $DESTDIR/$GPREFIX/bin/$cmd
-    done
-    # put libncurses* in PREFIX/lib so other programs don't need to link with rpath
+    # put libncurses* in PREFIX/lib so other programs don't need to link
+    # with rpath
     mkdir -p $DESTDIR/$PREFIX/lib/$ISAPART64
     mv $DESTDIR/$GPREFIX/lib/libncurses* $DESTDIR/$PREFIX/lib
-    mv $DESTDIR/$GPREFIX/lib/$ISAPART64/libncurses* $DESTDIR/$PREFIX/lib/$ISAPART64
+    mv $DESTDIR/$GPREFIX/lib/$ISAPART64/libncurses* \
+       $DESTDIR/$PREFIX/lib/$ISAPART64
 }
 
 save_function make_install make_install_orig
@@ -105,4 +102,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/ncurses/local.mog
+++ b/build/ncurses/local.mog
@@ -1,1 +1,12 @@
 license AUTHORS license=MIT
+
+link path=usr/gnu/bin/captoinfo target=../../bin/gcaptoinfo
+link path=usr/gnu/bin/clear target=../../bin/gclear
+link path=usr/gnu/bin/infocmp target=../../bin/ginfocmp
+link path=usr/gnu/bin/infotocap target=../../bin/ginfotocap
+link path=usr/gnu/bin/reset target=../../bin/greset
+link path=usr/gnu/bin/tic target=../../bin/gtic
+link path=usr/gnu/bin/toe target=../../bin/gtoe
+link path=usr/gnu/bin/tput target=../../bin/gtput
+link path=usr/gnu/bin/tset target=../../bin/gtset
+

--- a/build/ncurses/patches/xterm-no-rep.patch
+++ b/build/ncurses/patches/xterm-no-rep.patch
@@ -9,15 +9,12 @@ See also http://invisible-island.net/ncurses/ncurses.faq.html#xterm_generic
 
 --- ncurses-6.0-20170729/misc/terminfo.src	2017-07-30 00:10:59.000000000 +0000
 +++ ncurses-6.0-20170722/misc/terminfo.src	2017-05-14 01:32:04.000000000 +0000
-@@ -4180,9 +4180,8 @@
+@@ -4282,7 +4282,7 @@
  xterm-new|modern xterm terminal emulator,
  	npc,
  	indn=\E[%p1%dS, kb2=\EOE, kcbt=\E[Z, kent=\EOM,
 -	rin=\E[%p1%dT, use=ansi+rep, use=ansi+enq,
--	use=xterm+pcfkeys, use=xterm+tmux, use=ecma+strikeout,
--	use=xterm-basic,
-+	rin=\E[%p1%dT, use=ansi+enq, use=xterm+pcfkeys,
-+	use=xterm+tmux, use=ecma+strikeout, use=xterm-basic,
++	rin=\E[%p1%dT, use=ansi+enq,
+ 	use=xterm+pcfkeys, use=xterm+tmux, use=ecma+strikeout,
+ 	use=xterm-basic,
  
- # This fragment is for people who cannot agree on what the backspace key
- # should send.

--- a/doc/baseline
+++ b/doc/baseline
@@ -260,7 +260,7 @@ omnios library/libtecla 1.6.0-0.151025
 omnios library/libtool/libltdl 2.4.6-0.151025
 omnios library/libxml2 2.9.6-0.151025
 omnios library/libxslt 1.1.30-0.151025
-omnios library/ncurses 6.0.20171014-0.151025
+omnios library/ncurses 6.0.20171104-0.151025
 omnios library/nghttp2 1.26.0-0.151025
 omnios library/nspr 4.17-0.151025
 omnios library/nspr/header-nspr 4.17-0.151025

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -37,7 +37,7 @@
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
 | library/libxml2			| 2.9.6			| http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
-| library/ncurses			| 6.0.20171014		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/
+| library/ncurses			| 6.0.20171104		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.26.0		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.33			| https://ftp.mozilla.org/pub/security/nss/releases/
 | library/nspr				| 4.17			| http://archive.mozilla.org/pub/nspr/releases/


### PR DESCRIPTION
Also moving scripted symlinks to local.mog and taking the opportunity to simplify the terminfo patch for xterm to give it a better chance of applying cleanly against future versions.