### PR TITLE
hg: update to 4.4.1

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -28,15 +28,12 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.4
+VER=4.4.1
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"
 
 DEPENDS_IPS="web/curl library/security/openssl"
-
-# For inet_ntop which isn't detected properly in the configure script
-CONFIGURE_OPTS=""
 
 PYTHONPATH=/usr
 PYTHON=$PYTHONPATH/bin/python2.7

--- a/doc/baseline
+++ b/doc/baseline
@@ -71,7 +71,7 @@ omnios developer/sunstudio12.1 12.1-0.151025
 omnios developer/swig 3.0.12-0.151025
 omnios developer/tnf 0.5.11-0.151025
 omnios developer/versioning/git 2.15.0-0.151025
-omnios developer/versioning/mercurial 4.4-0.151025
+omnios developer/versioning/mercurial 4.4.1-0.151025
 omnios developer/versioning/sccs 0.5.11-0.151025
 omnios diagnostic/cpu-counters 0.5.11-0.151025
 omnios diagnostic/diskinfo 0.5.11-0.151025

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -23,7 +23,7 @@
 | developer/parser/bison		| 3.0.4			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.15.0		| https://www.kernel.org/pub/software/scm/git
-| developer/versioning/mercurial	| 4.4			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/mercurial	| 4.4.1			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.0.586		| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.28			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags


### PR DESCRIPTION
fixing a security issue that got introduced with 4.4 (i.e. no backporting required).

```
hadfl@bloody-build:~$ hg version
Mercurial Distributed SCM (version 4.4.1)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2017 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```