### PR TITLE
Stop using temporary files for cache maintenance

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -191,9 +191,7 @@ start_built_listener() {
         if read line <$built_pipe; then
             [ $line = "quit" ] && break
             already_built+=([$line]=1)
-            [ -f "$BUILT_CACHE" ] && cp "$BUILT_CACHE" "${BUILT_CACHE}.$$"
-            echo $line >> "${BUILT_CACHE}.$$"
-            mv "${BUILT_CACHE}.$$" "${BUILT_CACHE}"
+            echo $line >> "$BUILT_CACHE"
         fi
     done &
 }
@@ -204,11 +202,9 @@ stop_built_listener() {
 
 restore_built() {
     [ -f "$BUILT_CACHE" ] || return
-    cp "$BUILT_CACHE" "${BUILT_CACHE}.$$"
-    for pkg in `cat "${BUILT_CACHE}.$$"`; do
+    for pkg in `cat "$BUILT_CACHE"`; do
         [ -n "${already_built[$pkg]}" ] || already_built+=([$pkg]=1)
     done
-    rm -f "${BUILT_CACHE}.$$"
 }
 
 is_built() {


### PR DESCRIPTION
The original built cache code used temporary files to try and avoid an unlikely race condition in restoring the built cache to a child process.
(there's no race in the writer since it runs in the master process and receives updates over a pipe).
However, the use of temporary files can occasionally cause entries to be lost between copies so I am removing that part of the function and just reading directly from the cache file. It's extremely unlikely that a restore would happen halfway through a new line being written but in that case all that would happen is that a package might be built twice if the build was restarted for any reason.