### PR TITLE
Do not check version numbers in baseline

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -327,8 +327,8 @@ baseline() {
         $2 in seen { next }
         {
             seen[$2] = 1
-            # Remove package timestamp, NF as there can be 3/4 fields
-            sub(/:.*/, "", $NF)
+            # Remove package version, NF as there can be 3 or 4 fields
+            $(NF--) = ""
             print
         }
     ' | sort > $TMPDIR/baseline.$$

--- a/doc/baseline
+++ b/doc/baseline
@@ -1,678 +1,682 @@
-omnios SUNWcs 0.5.11-0.151025
-omnios SUNWcsd 0.5.11-0.151025
-omnios archiver/gnu-tar 1.29-0.151025
-omnios audio/audio-utilities 0.5.11-0.151025
-omnios benchmark/filebench o 0.5.11-0.151025
-omnios compatibility/ucb 0.5.11-0.151025
-omnios compress/bzip2 1.0.6-0.151025
-omnios compress/gzip 1.8-0.151025
-omnios compress/p7zip 16.2-0.151025
-omnios compress/unzip 6.0-0.151025
-omnios compress/xz 5.2.3-0.151025
-omnios compress/zip 3.0-0.151025
-omnios consolidation/man/man-incorporation o 0.5.11-0.151025
-omnios consolidation/osnet/osnet-incorporation 0.5.11-0.151025
-omnios consolidation/osnet/osnet-message-files 0.5.11-0.151025
-omnios consolidation/osnet/osnet-redistributable 0.5.11-0.151025
-omnios consolidation/sunpro/sunpro-incorporation 0.5.11-0.151025
-omnios data/iso-codes 3.76-0.151025
-omnios database/sqlite-3 3.21.0-0.151025
-omnios developer/acpi 0.5.11-0.151025
-omnios developer/appcert 0.5.11-0.151025
-omnios developer/apptrace 0.5.11-0.151025
-omnios developer/apptrace/ucblib 0.5.11-0.151025
-omnios developer/as 0.5.11-0.151025
-omnios developer/astdev 0.5.11-0.151025
-omnios developer/bmake 20171028-0.151025
-omnios developer/build/autoconf 2.69-0.151025
-omnios developer/build/automake 1.15.1-0.151025
-omnios developer/build/gnu-make 4.2.1-0.151025
-omnios developer/build/libtool 2.4.6-0.151025
-omnios developer/build/make 0.5.11-0.151025
-omnios developer/build/onbld 0.5.11-0.151025
-omnios developer/debug/mdb 0.5.11-0.151025
-omnios developer/debug/mdb/module/module-fibre-channel 0.5.11-0.151025
-omnios developer/debug/mdb/module/module-qlc 0.5.11-0.151025
-omnios developer/driver/ftsafe 0.5.11-0.151025
-omnios developer/dtrace 0.5.11-0.151025
-omnios developer/dtrace/toolkit 0.99-0.151025
-omnios developer/gcc44 4.4.4-0.151025
-omnios developer/gcc44/libgmp-gcc44 5.0.2-0.151025
-omnios developer/gcc44/libmpc-gcc44 0.8.2-0.151025
-omnios developer/gcc44/libmpfr-gcc44 3.1.0-0.151025
-omnios developer/gcc5 5.5.0-0.151025
-omnios developer/gcc5/libgmp-gcc5 6.1.2-0.151025
-omnios developer/gcc5/libmpc-gcc5 1.0.3-0.151025
-omnios developer/gcc5/libmpfr-gcc5 3.1.5-0.151025
-omnios developer/gcc51 r 5.1.0-0.151025
-omnios developer/gcc51/libgmp-gcc51 r 6.0.0-0.151025
-omnios developer/gcc51/libmpc-gcc51 r 1.0.3-0.151025
-omnios developer/gcc51/libmpfr-gcc51 r 3.1.2-0.151025
-omnios developer/gcc6 6.4.0-0.151025
-omnios developer/gcc6/libgmp-gcc6 6.1.2-0.151025
-omnios developer/gcc6/libmpc-gcc6 1.0.3-0.151025
-omnios developer/gcc6/libmpfr-gcc6 3.1.5-0.151025
-omnios developer/gnu-binutils 2.25-0.151025
-omnios developer/illumos-closed 5.11-0.151025
-omnios developer/illumos-tools 11-0.151025
-omnios developer/java/jdk 1.7.0.151.1-0.151025
-omnios developer/lexer/flex 2.6.4-0.151025
-omnios developer/library/lint 0.5.11-0.151025
-omnios developer/library/profiled-libc o 0.5.11-0.151025
-omnios developer/linker 0.5.11-0.151025
-omnios developer/macro/cpp 0.5.11-0.151025
-omnios developer/macro/gnu-m4 1.4.18-0.151025
-omnios developer/object-file 0.5.11-0.151025
-omnios developer/omnios-build-tools 11-0.151025
-omnios developer/opensolaris/osnet 0.5.11-0.151025
-omnios developer/parser/bison 3.0.4-0.151025
-omnios developer/pkg-config 0.29.2-0.151025
-omnios developer/sunstudio12.1 12.1-0.151025
-omnios developer/swig 3.0.12-0.151025
-omnios developer/tnf 0.5.11-0.151025
-omnios developer/versioning/git 2.15.0-0.151025
-omnios developer/versioning/mercurial 4.4.1-0.151025
-omnios developer/versioning/sccs 0.5.11-0.151025
-omnios diagnostic/cpu-counters 0.5.11-0.151025
-omnios diagnostic/diskinfo 0.5.11-0.151025
-omnios diagnostic/latencytop 0.5.11-0.151025
-omnios diagnostic/powertop 0.5.11-0.151025
-omnios driver/audio 0.5.11-0.151025
-omnios driver/audio/audio810 0.5.11-0.151025
-omnios driver/audio/audiocmi 0.5.11-0.151025
-omnios driver/audio/audiocmihd 0.5.11-0.151025
-omnios driver/audio/audioemu10k 0.5.11-0.151025
-omnios driver/audio/audiohd 0.5.11-0.151025
-omnios driver/audio/audioixp 0.5.11-0.151025
-omnios driver/audio/audiols 0.5.11-0.151025
-omnios driver/audio/audiop16x 0.5.11-0.151025
-omnios driver/audio/audiosolo 0.5.11-0.151025
-omnios driver/audio/audiovia823x 0.5.11-0.151025
-omnios driver/audio/audiovia97 o 0.5.11-0.151025
-omnios driver/crypto/dca 0.5.11-0.151025
-omnios driver/crypto/dprov 0.5.11-0.151025
-omnios driver/crypto/tpm 0.5.11-0.151025
-omnios driver/firewire 0.5.11-0.151025
-omnios driver/graphics/agpgart 0.5.11-0.151025
-omnios driver/graphics/atiatom 0.5.11-0.151025
-omnios driver/graphics/av1394 0.5.11-0.151025
-omnios driver/graphics/dcam1394 0.5.11-0.151025
-omnios driver/graphics/dcam1394/devfsadm-dcam1394 0.5.11-0.151025
-omnios driver/graphics/drm 0.5.11-0.151025
-omnios driver/graphics/usbvc 0.5.11-0.151025
-omnios driver/i86pc/fipe 0.5.11-0.151025
-omnios driver/i86pc/ioat 0.5.11-0.151025
-omnios driver/i86pc/platform 0.5.11-0.151025
-omnios driver/ipmi 0.5.11-0.151025
-omnios driver/misc/virtio 0.5.11-0.151025
-omnios driver/network/afe 0.5.11-0.151025
-omnios driver/network/amd8111s 0.5.11-0.151025
-omnios driver/network/arbel o 0.5.11-0.151025
-omnios driver/network/arn 0.5.11-0.151025
-omnios driver/network/atge 0.5.11-0.151025
-omnios driver/network/ath 0.5.11-0.151025
-omnios driver/network/atu 0.5.11-0.151025
-omnios driver/network/axf 0.5.11-0.151025
-omnios driver/network/bfe 0.5.11-0.151025
-omnios driver/network/bge 0.5.11-0.151025
-omnios driver/network/bnx 0.5.11-0.151025
-omnios driver/network/bnxe 0.5.11-0.151025
-omnios driver/network/bpf 0.5.11-0.151025
-omnios driver/network/chxge 0.5.11-0.151025
-omnios driver/network/cxgbe 0.5.11-0.151025
-omnios driver/network/dmfe 0.5.11-0.151025
-omnios driver/network/e1000g 0.5.11-0.151025
-omnios driver/network/efe 0.5.11-0.151025
-omnios driver/network/elxl 0.5.11-0.151025
-omnios driver/network/emlxs 0.5.11-0.151025
-omnios driver/network/eoib 0.5.11-0.151025
-omnios driver/network/fcip 0.5.11-0.151025
-omnios driver/network/fcoe 0.5.11-0.151025
-omnios driver/network/fcoei 0.5.11-0.151025
-omnios driver/network/fcoet 0.5.11-0.151025
-omnios driver/network/fcp 0.5.11-0.151025
-omnios driver/network/fcsm 0.5.11-0.151025
-omnios driver/network/fp 0.5.11-0.151025
-omnios driver/network/hermon 0.5.11-0.151025
-omnios driver/network/hme 0.5.11-0.151025
-omnios driver/network/hxge 0.5.11-0.151025
-omnios driver/network/i40e 0.5.11-0.151025
-omnios driver/network/ib 0.5.11-0.151025
-omnios driver/network/ibdma 0.5.11-0.151025
-omnios driver/network/ibp 0.5.11-0.151025
-omnios driver/network/igb 0.5.11-0.151025
-omnios driver/network/iprb 0.5.11-0.151025
-omnios driver/network/ipw 0.5.11-0.151025
-omnios driver/network/iwh 0.5.11-0.151025
-omnios driver/network/iwi 0.5.11-0.151025
-omnios driver/network/iwk 0.5.11-0.151025
-omnios driver/network/iwn 0.5.11-0.151025
-omnios driver/network/iwp 0.5.11-0.151025
-omnios driver/network/ixgb 0.5.11-0.151025
-omnios driver/network/ixgbe 0.5.11-0.151025
-omnios driver/network/llc2 o 0.5.11-0.151025
-omnios driver/network/mwl 0.5.11-0.151025
-omnios driver/network/mxfe 0.5.11-0.151025
-omnios driver/network/myri10ge 0.5.11-0.151025
-omnios driver/network/nge 0.5.11-0.151025
-omnios driver/network/ntxn 0.5.11-0.151025
-omnios driver/network/nxge 0.5.11-0.151025
-omnios driver/network/ofk 0.5.11-0.151025
-omnios driver/network/pcan o 0.5.11-0.151025
-omnios driver/network/pcn 0.5.11-0.151025
-omnios driver/network/pcwl o 0.5.11-0.151025
-omnios driver/network/platform 0.5.11-0.151025
-omnios driver/network/qlc 0.5.11-0.151025
-omnios driver/network/ral 0.5.11-0.151025
-omnios driver/network/rds 0.5.11-0.151025
-omnios driver/network/rdsv3 0.5.11-0.151025
-omnios driver/network/rge 0.5.11-0.151025
-omnios driver/network/rpcib 0.5.11-0.151025
-omnios driver/network/rtls 0.5.11-0.151025
-omnios driver/network/rtw 0.5.11-0.151025
-omnios driver/network/rum 0.5.11-0.151025
-omnios driver/network/rwd 0.5.11-0.151025
-omnios driver/network/rwn 0.5.11-0.151025
-omnios driver/network/sdp 0.5.11-0.151025
-omnios driver/network/sdpib 0.5.11-0.151025
-omnios driver/network/sfe 0.5.11-0.151025
-omnios driver/network/sfxge 0.5.11-0.151025
-omnios driver/network/srpt 0.5.11-0.151025
-omnios driver/network/tavor 0.5.11-0.151025
-omnios driver/network/uath 0.5.11-0.151025
-omnios driver/network/udmf 0.5.11-0.151025
-omnios driver/network/upf 0.5.11-0.151025
-omnios driver/network/ural 0.5.11-0.151025
-omnios driver/network/urf 0.5.11-0.151025
-omnios driver/network/urtw 0.5.11-0.151025
-omnios driver/network/usbecm 0.5.11-0.151025
-omnios driver/network/vioif 0.5.11-0.151025
-omnios driver/network/vmxnet3s 0.5.11-0.151025
-omnios driver/network/vr 0.5.11-0.151025
-omnios driver/network/wpi 0.5.11-0.151025
-omnios driver/network/xge 0.5.11-0.151025
-omnios driver/network/yge 0.5.11-0.151025
-omnios driver/network/zyd 0.5.11-0.151025
-omnios driver/pcmcia 0.5.11-0.151025
-omnios driver/serial/pcser o 0.5.11-0.151025
-omnios driver/serial/usbftdi 0.5.11-0.151025
-omnios driver/serial/usbsacm 0.5.11-0.151025
-omnios driver/serial/usbser 0.5.11-0.151025
-omnios driver/serial/usbser_edge 0.5.11-0.151025
-omnios driver/serial/usbsksp 0.5.11-0.151025
-omnios driver/serial/usbsksp/usbs49_fw 0.5.11-0.151025
-omnios driver/serial/usbsprl 0.5.11-0.151025
-omnios driver/storage/aac 0.5.11-0.151025
-omnios driver/storage/adpu320 0.5.11-0.151025
-omnios driver/storage/ahci 0.5.11-0.151025
-omnios driver/storage/amr 0.5.11-0.151025
-omnios driver/storage/arcmsr 0.5.11-0.151025
-omnios driver/storage/ata 0.5.11-0.151025
-omnios driver/storage/bcm_sata 0.5.11-0.151025
-omnios driver/storage/blkdev 0.5.11-0.151025
-omnios driver/storage/cpqary3 0.5.11-0.151025
-omnios driver/storage/glm 0.5.11-0.151025
-omnios driver/storage/lsimega 0.5.11-0.151025
-omnios driver/storage/marvell88sx 0.5.11-0.151025
-omnios driver/storage/mega_sas 0.5.11-0.151025
-omnios driver/storage/mpt_sas 0.5.11-0.151025
-omnios driver/storage/mr_sas 0.5.11-0.151025
-omnios driver/storage/nv_sata 0.5.11-0.151025
-omnios driver/storage/nvme 0.5.11-0.151025
-omnios driver/storage/pcata o 0.5.11-0.151025
-omnios driver/storage/pmcs 0.5.11-0.151025
-omnios driver/storage/pvscsi 0.5.11-0.151025
-omnios driver/storage/sbp2 0.5.11-0.151025
-omnios driver/storage/scsa1394 0.5.11-0.151025
-omnios driver/storage/sdcard 0.5.11-0.151025
-omnios driver/storage/ses 0.5.11-0.151025
-omnios driver/storage/si3124 0.5.11-0.151025
-omnios driver/storage/skd 0.5.11-0.151025
-omnios driver/storage/smp 0.5.11-0.151025
-omnios driver/storage/sv 0.5.11-0.151025
-omnios driver/storage/vioblk 0.5.11-0.151025
-omnios driver/tuntap 1.3.3-0.151025
-omnios driver/usb 0.5.11-0.151025
-omnios driver/usb/ugen 0.5.11-0.151025
-omnios driver/usb/usbgem 0.5.11-0.151025
-omnios driver/virtualization/kvm 1.0.5.11-0.151025
-omnios driver/x11/winlock 0.5.11-0.151025
-omnios driver/x11/xsvc 0.5.11-0.151025
-omnios driver/xvm/pv 0.5.11-0.151025
-omnios editor/vim 8.0.586-0.151025
-omnios entire 11-0.151025
-omnios file/gnu-coreutils 8.28-0.151025
-omnios file/gnu-findutils 4.6.0-0.151025
-omnios incorporation/jeos/illumos-gate 11-0.151025
-omnios incorporation/jeos/omnios-userland 11-0.151025
-omnios install/beadm 0.5.11-0.151025
-omnios library/c++/sigcpp 2.99.9-0.151025
-omnios library/demo/audio-samples 0.5.11-0.151025
-omnios library/expat 2.2.5-0.151025
-omnios library/glib2 2.54.2-0.151025
-omnios library/gmp 6.1.2-0.151025
-omnios library/idnkit 2.3-0.151025
-omnios library/idnkit/header-idnkit 2.3-0.151025
-omnios library/libadt_jni 0.5.11-0.151025
-omnios library/libffi 3.2.1-0.151025
-omnios library/libidn 1.33-0.151025
-omnios library/libtecla 1.6.0-0.151025
-omnios library/libtool/libltdl 2.4.6-0.151025
-omnios library/libxml2 2.9.6-0.151025
-omnios library/libxslt 1.1.30-0.151025
-omnios library/ncurses 6.0.20171104-0.151025
-omnios library/nghttp2 1.27.0-0.151025
-omnios library/nspr 4.17-0.151025
-omnios library/nspr/header-nspr 4.17-0.151025
-omnios library/pcre 8.41-0.151025
-omnios library/perl-5/xml-parser 2.44-0.151025
-omnios library/print/open-printing 0.5.11-0.151025
-omnios library/print/open-printing/ipp 0.5.11-0.151025
-omnios library/print/open-printing/lpd 0.5.11-0.151025
-omnios library/python-2/asn1crypto-27 0.23.0-0.151025
-omnios library/python-2/cffi-27 1.11.2-0.151025
-omnios library/python-2/cheroot-27 5.8.3-0.151025
-omnios library/python-2/cherrypy-27 11.0.0-0.151025
-omnios library/python-2/coverage-27 4.4.2-0.151025
-omnios library/python-2/cryptography-27 2.1.3-0.151025
-omnios library/python-2/enum-27 1.1.6-0.151025
-omnios library/python-2/functools32-27 3.2.3.2-0.151025
-omnios library/python-2/idna-27 2.6-0.151025
-omnios library/python-2/ipaddress-27 1.0.18-0.151025
-omnios library/python-2/jsonrpclib-27 0.1.7-0.151025
-omnios library/python-2/jsonschema-27 2.6.0-0.151025
-omnios library/python-2/lxml-27 4.1.1-0.151025
-omnios library/python-2/m2crypto-27 0.27.0-0.151025
-omnios library/python-2/mako-27 1.0.7-0.151025
-omnios library/python-2/numpy-27 1.13.3-0.151025
-omnios library/python-2/ply-27 3.10-0.151025
-omnios library/python-2/portend-27 2.2-0.151025
-omnios library/python-2/pybonjour-27 1.1.1-0.151025
-omnios library/python-2/pycurl-27 7.43.0-0.151025
-omnios library/python-2/pylint-27 1.7.4-0.151025
-omnios library/python-2/pyopenssl-27 17.3.0-0.151025
-omnios library/python-2/pyrex-27 0.9.9-0.151025
-omnios library/python-2/python-extra-27 0.5.11-0.151025
-omnios library/python-2/pytz-27 2017.3-0.151025
-omnios library/python-2/setuptools-27 36.6.0-0.151025
-omnios library/python-2/simplejson-27 3.12.0-0.151025
-omnios library/python-2/six-27 1.11.0-0.151025
-omnios library/python-2/tempora-27 1.9-0.151025
-omnios library/python-2/typing-27 3.6.2-0.151025
-omnios library/readline 7.0-0.151025
-omnios library/security/openssl 1.0.2.13-0.151025
-omnios library/security/tcp-wrapper 7.6-0.151025
-omnios library/security/trousers 0.3.14-0.151025
-omnios library/unixodbc 2.3.4-0.151025
-omnios library/zlib 1.2.11-0.151025
-omnios locale/af 0.5.11-0.151025
-omnios locale/ar 0.5.11-0.151025
-omnios locale/ar-extra o 0.5.11-0.151025
-omnios locale/as 0.5.11-0.151025
-omnios locale/az 0.5.11-0.151025
-omnios locale/be 0.5.11-0.151025
-omnios locale/bg 0.5.11-0.151025
-omnios locale/bg-extra 0.5.11-0.151025
-omnios locale/bn 0.5.11-0.151025
-omnios locale/bo 0.5.11-0.151025
-omnios locale/bs 0.5.11-0.151025
-omnios locale/ca 0.5.11-0.151025
-omnios locale/ca-extra 0.5.11-0.151025
-omnios locale/cs 0.5.11-0.151025
-omnios locale/cs-extra 0.5.11-0.151025
-omnios locale/da 0.5.11-0.151025
-omnios locale/da-extra 0.5.11-0.151025
-omnios locale/de 0.5.11-0.151025
-omnios locale/de-extra 0.5.11-0.151025
-omnios locale/el 0.5.11-0.151025
-omnios locale/el-extra 0.5.11-0.151025
-omnios locale/en 0.5.11-0.151025
-omnios locale/en-extra 0.5.11-0.151025
-omnios locale/es 0.5.11-0.151025
-omnios locale/es-extra 0.5.11-0.151025
-omnios locale/et 0.5.11-0.151025
-omnios locale/fi 0.5.11-0.151025
-omnios locale/fi-extra 0.5.11-0.151025
-omnios locale/fil 0.5.11-0.151025
-omnios locale/fr 0.5.11-0.151025
-omnios locale/fr-extra 0.5.11-0.151025
-omnios locale/ga 0.5.11-0.151025
-omnios locale/gu 0.5.11-0.151025
-omnios locale/he 0.5.11-0.151025
-omnios locale/hi 0.5.11-0.151025
-omnios locale/hr 0.5.11-0.151025
-omnios locale/hr-extra 0.5.11-0.151025
-omnios locale/hu 0.5.11-0.151025
-omnios locale/hu-extra 0.5.11-0.151025
-omnios locale/hy 0.5.11-0.151025
-omnios locale/id 0.5.11-0.151025
-omnios locale/ii 0.5.11-0.151025
-omnios locale/is 0.5.11-0.151025
-omnios locale/is-extra 0.5.11-0.151025
-omnios locale/it 0.5.11-0.151025
-omnios locale/it-extra 0.5.11-0.151025
-omnios locale/ja 0.5.11-0.151025
-omnios locale/ka 0.5.11-0.151025
-omnios locale/kk 0.5.11-0.151025
-omnios locale/km 0.5.11-0.151025
-omnios locale/kn 0.5.11-0.151025
-omnios locale/ko 0.5.11-0.151025
-omnios locale/kok 0.5.11-0.151025
-omnios locale/lt 0.5.11-0.151025
-omnios locale/lt-extra 0.5.11-0.151025
-omnios locale/lv 0.5.11-0.151025
-omnios locale/lv-extra 0.5.11-0.151025
-omnios locale/mk 0.5.11-0.151025
-omnios locale/mk-extra 0.5.11-0.151025
-omnios locale/ml 0.5.11-0.151025
-omnios locale/mn 0.5.11-0.151025
-omnios locale/mr 0.5.11-0.151025
-omnios locale/ms 0.5.11-0.151025
-omnios locale/mt 0.5.11-0.151025
-omnios locale/nb 0.5.11-0.151025
-omnios locale/ne 0.5.11-0.151025
-omnios locale/nl 0.5.11-0.151025
-omnios locale/nl-extra 0.5.11-0.151025
-omnios locale/nn 0.5.11-0.151025
-omnios locale/or 0.5.11-0.151025
-omnios locale/pa 0.5.11-0.151025
-omnios locale/pl 0.5.11-0.151025
-omnios locale/pl-extra 0.5.11-0.151025
-omnios locale/pt 0.5.11-0.151025
-omnios locale/pt-extra 0.5.11-0.151025
-omnios locale/ro 0.5.11-0.151025
-omnios locale/ru 0.5.11-0.151025
-omnios locale/ru-extra 0.5.11-0.151025
-omnios locale/sa 0.5.11-0.151025
-omnios locale/si 0.5.11-0.151025
-omnios locale/sk 0.5.11-0.151025
-omnios locale/sl 0.5.11-0.151025
-omnios locale/sq 0.5.11-0.151025
-omnios locale/sq-extra 0.5.11-0.151025
-omnios locale/sr 0.5.11-0.151025
-omnios locale/sv 0.5.11-0.151025
-omnios locale/sv-extra 0.5.11-0.151025
-omnios locale/ta 0.5.11-0.151025
-omnios locale/te 0.5.11-0.151025
-omnios locale/th 0.5.11-0.151025
-omnios locale/th-extra 0.5.11-0.151025
-omnios locale/tr 0.5.11-0.151025
-omnios locale/tr-extra 0.5.11-0.151025
-omnios locale/ug 0.5.11-0.151025
-omnios locale/uk 0.5.11-0.151025
-omnios locale/ur 0.5.11-0.151025
-omnios locale/vi 0.5.11-0.151025
-omnios locale/zh_cn 0.5.11-0.151025
-omnios locale/zh_cn-extra 0.5.11-0.151025
-omnios locale/zh_hk 0.5.11-0.151025
-omnios locale/zh_mo 0.5.11-0.151025
-omnios locale/zh_sg 0.5.11-0.151025
-omnios locale/zh_tw 0.5.11-0.151025
-omnios media/cdrtools 3.1-0.151025
-omnios media/cdrw 0.5.11-0.151025
-omnios naming/ldap 0.5.11-0.151025
-omnios network/bridging 0.5.11-0.151025
-omnios network/dhcp/dhcpmgr o 0.5.11-0.151025
-omnios network/dns/bind 9.10.6-0.151025
-omnios network/dns/idnconv 2.3-0.151025
-omnios network/ftp 0.5.11-0.151025
-omnios network/ipd 0.5.11-0.151025
-omnios network/ipfilter 0.5.11-0.151025
-omnios network/ipfilter/header-ipfilter 0.5.11-0.151025
-omnios network/iscsi/initiator 0.5.11-0.151025
-omnios network/iscsi/iser 0.5.11-0.151025
-omnios network/iscsi/target 0.5.11-0.151025
-omnios network/netcat 0.5.11-0.151025
-omnios network/openssh 7.5.1-0.151025
-omnios network/openssh-server 7.5.1-0.151025
-omnios network/rsync 3.1.2-0.151025
-omnios network/service/isc-dhcp 4.3.6-0.151025
-omnios network/telnet 0.5.11-0.151025
-omnios network/test/iperf 3.1.3-0.151025
-omnios network/test/netperf 2.7.0-0.151025
-omnios package/pkg 0.5.11-0.151025
-omnios package/pkg/zones-proxy o 0.5.11-0.151025
-omnios package/svr4 0.5.11-0.151025
-omnios print/lp 0.5.11-0.151025
-omnios print/lp/compatibility/sunos4 0.5.11-0.151025
-omnios print/lp/filter/postscript-lp-filter 0.5.11-0.151025
-omnios print/lp/ipp/libipp 0.5.11-0.151025
-omnios print/lp/print-client-commands 0.5.11-0.151025
-omnios print/lp/print-manager/legacy 0.5.11-0.151025
-omnios release/name 0.5.11-0.151025
-omnios release/notices 0.5.11-0.151025
-omnios runtime/java 1.7.0.151.1-0.151025
-omnios runtime/perl 5.24.3-0.151025
-omnios runtime/perl-64 5.24.3-0.151025
-omnios runtime/perl/manual 5.24.3-0.151025
-omnios runtime/perl/module/sun-solaris 0.5.11-0.151025
-omnios runtime/python-27 2.7.14-0.151025
-omnios security/bart 0.5.11-0.151025
-omnios security/sudo 1.8.21.2-0.151025
-omnios service/fault-management 0.5.11-0.151025
-omnios service/fault-management/smtp-notify 0.5.11-0.151025
-omnios service/fault-management/snmp-notify 0.5.11-0.151025
-omnios service/file-system/nfs 0.5.11-0.151025
-omnios service/file-system/smb 0.5.11-0.151025
-omnios service/hal 0.5.11-0.151025
-omnios service/network/dhcp o 0.5.11-0.151025
-omnios service/network/dhcp/datastore/binfiles o 0.5.11-0.151025
-omnios service/network/dns/mdns 0.5.11-0.151025
-omnios service/network/ftp o 0.5.11-0.151025
-omnios service/network/legacy 0.5.11-0.151025
-omnios service/network/load-balancer/ilb 0.5.11-0.151025
-omnios service/network/network-clients 0.5.11-0.151025
-omnios service/network/network-servers 0.5.11-0.151025
-omnios service/network/nis 0.5.11-0.151025
-omnios service/network/ntp 4.2.8.10-0.151025
-omnios service/network/slp 0.5.11-0.151025
-omnios service/network/smtp/sendmail 8.14.4-0.151025
-omnios service/network/snmp/mibiisa o 0.5.11-0.151025
-omnios service/network/telnet 0.5.11-0.151025
-omnios service/network/tftp 0.5.11-0.151025
-omnios service/network/uucp 0.5.11-0.151025
-omnios service/network/wpa 0.5.11-0.151025
-omnios service/picl 0.5.11-0.151025
-omnios service/resource-cap 0.5.11-0.151025
-omnios service/resource-pools 0.5.11-0.151025
-omnios service/resource-pools/poold 0.5.11-0.151025
-omnios service/security/gss 0.5.11-0.151025
-omnios service/security/kerberos-5 0.5.11-0.151025
-omnios service/storage/avs/cache-management 0.5.11-0.151025
-omnios service/storage/fibre-channel/fc-fabric 0.5.11-0.151025
-omnios service/storage/isns 0.5.11-0.151025
-omnios service/storage/media-volume-manager 0.5.11-0.151025
-omnios service/storage/ndmp 0.5.11-0.151025
-omnios service/storage/removable-media 0.5.11-0.151025
-omnios service/storage/virus-scan 0.5.11-0.151025
-omnios shell/bash 4.4.12-0.151025
-omnios shell/pipe-viewer 1.6.6-0.151025
-omnios shell/tcsh 6.20.0-0.151025
-omnios shell/zsh 5.4.2-0.151025
-omnios source/demo/mdb-examples 0.5.11-0.151025
-omnios source/demo/system 0.5.11-0.151025
-omnios source/network/pppdump o 0.5.11-0.151025
-omnios source/security/tcp-wrapper o 0.5.11-0.151025
-omnios source/system/grub 0.97-0.151025
-omnios storage/avs 0.1-0.151025
-omnios storage/avs/point-in-time-copy 0.5.11-0.151025
-omnios storage/avs/remote-mirror 0.5.11-0.151025
-omnios storage/metassist o 0.5.11-0.151025
-omnios storage/mpathadm 0.5.11-0.151025
-omnios storage/stmf 0.5.11-0.151025
-omnios storage/storage-nas o 0.1-0.151025
-omnios storage/storage-server o 0.1-0.151025
-omnios storage/svm o 0.5.11-0.151025
-omnios system/accounting/legacy 0.5.11-0.151025
-omnios system/boot/grub 0.97-0.151025
-omnios system/boot/loader 1.1-0.151025
-omnios system/boot/network 0.5.11-0.151025
-omnios system/boot/real-mode 0.5.11-0.151025
-omnios system/boot/wanboot 0.5.11-0.151025
-omnios system/boot/wanboot/internal 0.5.11-0.151025
-omnios system/data/console/fonts 0.5.11-0.151025
-omnios system/data/hardware-registry 0.5.11-0.151025
-omnios system/data/keyboard/keytables 0.5.11-0.151025
-omnios system/data/terminfo 0.5.11-0.151025
-omnios system/data/zoneinfo 2017.2-0.151025
-omnios system/dtrace/tests 0.5.11-0.151025
-omnios system/extended-system-utilities 0.5.11-0.151025
-omnios system/fault-management/eversholt-utilities 0.5.11-0.151025
-omnios system/ficl 4.1.0-0.151025
-omnios system/file-system/autofs 0.5.11-0.151025
-omnios system/file-system/nfs 0.5.11-0.151025
-omnios system/file-system/ntfsprogs o 2.0.0-0.151025
-omnios system/file-system/smb 0.5.11-0.151025
-omnios system/file-system/udfs 0.5.11-0.151025
-omnios system/file-system/zfs 0.5.11-0.151025
-omnios system/file-system/zfs/tests 0.5.11-0.151025
-omnios system/flash/fwflash 0.5.11-0.151025
-omnios system/fru-id 0.5.11-0.151025
-omnios system/fru-id/platform 0.5.11-0.151025
-omnios system/header 0.5.11-0.151025
-omnios system/header/header-agp 0.5.11-0.151025
-omnios system/header/header-audio 0.5.11-0.151025
-omnios system/header/header-firewire 0.5.11-0.151025
-omnios system/header/header-picl 0.5.11-0.151025
-omnios system/header/header-storage 0.5.11-0.151025
-omnios system/header/header-ugen 0.5.11-0.151025
-omnios system/header/header-usb 0.5.11-0.151025
-omnios system/install/kayak 1.1-0.151025
-omnios system/install/kayak-kernel 1.1-0.151025
-omnios system/io/tests 0.5.11-0.151025
-omnios system/ipc 0.5.11-0.151025
-omnios system/kernel 0.5.11-0.151025
-omnios system/kernel/cpu-counters 0.5.11-0.151025
-omnios system/kernel/dtrace/providers 0.5.11-0.151025
-omnios system/kernel/dtrace/providers/xdt 0.5.11-0.151025
-omnios system/kernel/dynamic-reconfiguration/i86pc 0.5.11-0.151025
-omnios system/kernel/platform 0.5.11-0.151025
-omnios system/kernel/power 0.5.11-0.151025
-omnios system/kernel/rsmops 0.5.11-0.151025
-omnios system/kernel/secure-rpc 0.5.11-0.151025
-omnios system/kernel/security/gss 0.5.11-0.151025
-omnios system/kernel/suspend-resume 0.5.11-0.151025
-omnios system/kernel/ultra-wideband o 0.5.11-0.151025
-omnios system/kvm 1.0.5.11-0.151025
-omnios system/library 0.5.11-0.151025
-omnios system/library/c++/sunpro 0.5.11-0.151025
-omnios system/library/c-runtime 0.5.11-0.151025
-omnios system/library/dbus 1.12.0-0.151025
-omnios system/library/g++-4-runtime r 4.8.1-0.151025
-omnios system/library/g++-5-runtime 5.5.0-0.151025
-omnios system/library/g++-6-runtime 6.4.0-0.151025
-omnios system/library/gcc-4-runtime r 4.8.1-0.151025
-omnios system/library/gcc-5-runtime 5.5.0-0.151025
-omnios system/library/gcc-6-runtime 6.4.0-0.151025
-omnios system/library/iconv/unicode 0.5.11-0.151025
-omnios system/library/iconv/utf-8 0.5.11-0.151025
-omnios system/library/iconv/utf-8/manual 0.5.11-0.151025
-omnios system/library/iconv/xsh4/latin 0.5.11-0.151025
-omnios system/library/install/libinstzones 0.5.11-0.151025
-omnios system/library/libdbus 1.12.0-0.151025
-omnios system/library/libdbus-glib 0.108-0.151025
-omnios system/library/libdiskmgt 0.5.11-0.151025
-omnios system/library/libdiskmgt/header-libdiskmgt 0.5.11-0.151025
-omnios system/library/libfcoe 0.5.11-0.151025
-omnios system/library/liblayout 0.5.11-0.151025
-omnios system/library/math 0.5.11-0.151025
-omnios system/library/math/header-math r 0.5.11-0.151025
-omnios system/library/mozilla-nss 3.33-0.151025
-omnios system/library/mozilla-nss/header-nss 3.33-0.151025
-omnios system/library/mtsk 0.5.11-0.151025
-omnios system/library/pcap 1.8.1-0.151025
-omnios system/library/platform 0.5.11-0.151025
-omnios system/library/policykit 0.5.11-0.151025
-omnios system/library/processor 0.5.11-0.151025
-omnios system/library/security/crypto/pkcs11_kms o 0.5.11-0.151025
-omnios system/library/security/gss 0.5.11-0.151025
-omnios system/library/security/gss/diffie-hellman 0.5.11-0.151025
-omnios system/library/security/gss/spnego 0.5.11-0.151025
-omnios system/library/security/libsasl 0.5.11-0.151025
-omnios system/library/security/rpcsec 0.5.11-0.151025
-omnios system/library/storage/fibre-channel/hbaapi 0.5.11-0.151025
-omnios system/library/storage/fibre-channel/libsun_fc 0.5.11-0.151025
-omnios system/library/storage/ima 0.5.11-0.151025
-omnios system/library/storage/ima/header-ima 0.5.11-0.151025
-omnios system/library/storage/libmpapi 0.5.11-0.151025
-omnios system/library/storage/libmpscsi_vhci 0.5.11-0.151025
-omnios system/library/storage/scsi-plugin r 0.5.11-0.151025
-omnios system/library/storage/scsi-plugins 0.5.11-0.151025
-omnios system/library/svm-rcm o 0.5.11-0.151025
-omnios system/man 0.5.11-0.151025
-omnios system/management/ec2-api-tools 1.7.5.1-0.151025
-omnios system/management/ec2-credential 1.0-0.151025
-omnios system/management/intel-amt o 0.5.11-0.151025
-omnios system/management/ipmitool 1.8.18-0.151025
-omnios system/management/mdata-client 20170105-0.151025
-omnios system/management/pcitool 0.5.11-0.151025
-omnios system/management/snmp/net-snmp 5.7.3-0.151025
-omnios system/management/snmp/sea o 0.5.11-0.151025
-omnios system/management/snmp/sea/sea-config o 0.5.11-0.151025
-omnios system/management/wbem/data-management 0.5.11-0.151025
-omnios system/management/wbem/resource-management o 0.5.11-0.151025
-omnios system/manual o 0.5.11-0.151025
-omnios system/monitoring/arcstat 0.5.11-0.151025
-omnios system/network 0.5.11-0.151025
-omnios system/network/http-cache-accelerator 0.5.11-0.151025
-omnios system/network/ipqos 0.5.11-0.151025
-omnios system/network/ipqos/ipqos-config 0.5.11-0.151025
-omnios system/network/mailwrapper 0.5.11-0.151025
-omnios system/network/nis 0.5.11-0.151025
-omnios system/network/ppp 0.5.11-0.151025
-omnios system/network/ppp/pppdump 0.5.11-0.151025
-omnios system/network/ppp/tunnel 0.5.11-0.151025
-omnios system/network/routing 0.5.11-0.151025
-omnios system/network/routing/vrrp 0.5.11-0.151025
-omnios system/network/spdadm 0.5.11-0.151025
-omnios system/network/udapl 0.5.11-0.151025
-omnios system/network/udapl/udapl-tavor 0.5.11-0.151025
-omnios system/network/wificonfig 0.5.11-0.151025
-omnios system/pciutils 3.5.5-0.151025
-omnios system/pciutils/pci.ids 2.2.20170423-0.151025
-omnios system/pkgtree 1.1-0.151025
-omnios system/prerequisite/gnu 0.5.11-0.151025
-omnios system/remote-shared-memory 0.5.11-0.151025
-omnios system/scheduler/fss 0.5.11-0.151025
-omnios system/security/kerberos-5 0.5.11-0.151025
-omnios system/storage/fibre-channel/port-utility 0.5.11-0.151025
-omnios system/storage/luxadm 0.5.11-0.151025
-omnios system/storage/parted o 1.8.8-0.151025
-omnios system/storage/sasinfo 0.5.11-0.151025
-omnios system/test/fio 3.2-0.151025
-omnios system/test/libctest 0.5.11-0.151025
-omnios system/test/ostest 0.5.11-0.151025
-omnios system/test/testrunner 0.5.11-0.151025
-omnios system/test/utiltest 0.5.11-0.151025
-omnios system/test/zfstest 0.5.11-0.151025
-omnios system/tnf 0.5.11-0.151025
-omnios system/trusted 0.5.11-0.151025
-omnios system/trusted/global-zone 0.5.11-0.151025
-omnios system/virtualization/open-vm-tools 10.1.15-0.151025
-omnios system/xopen/xcu4 0.5.11-0.151025
-omnios system/xopen/xcu6 0.5.11-0.151025
-omnios system/xvm/ipagent 0.5.11-0.151025
-omnios system/zones 0.5.11-0.151025
-omnios system/zones/brand/ipkg 0.5.11-0.151025
-omnios system/zones/brand/lipkg 0.5.11-0.151025
-omnios system/zones/brand/lx 0.5.11-0.151025
-omnios system/zones/brand/s10 0.5.11-0.151025
-omnios system/zones/brand/sn1 0.5.11-0.151025
-omnios system/zones/internal 0.5.11-0.151025
-omnios terminal/screen 4.6.2-0.151025
-omnios terminal/tmux 2.6-0.151025
-omnios text/auto_ef 0.5.11-0.151025
-omnios text/doctools 0.5.11-0.151025
-omnios text/gawk 4.2.0-0.151025
-omnios text/gnu-diffutils 3.6-0.151025
-omnios text/gnu-gettext 0.19.8.1-0.151025
-omnios text/gnu-grep 3.1-0.151025
-omnios text/gnu-patch 2.7.5-0.151025
-omnios text/gnu-sed 4.4-0.151025
-omnios text/groff 1.22.3-0.151025
-omnios text/intltool 0.51.0-0.151025
-omnios text/less 487-0.151025
-omnios text/locale 0.5.11-0.151025
-omnios web/ca-bundle 5.11-0.151025
-omnios web/curl 7.56.1-0.151025
-omnios web/wget 1.19.2-0.151025
+omnios SUNWcs 
+omnios SUNWcsd 
+omnios archiver/gnu-tar 
+omnios audio/audio-utilities 
+omnios benchmark/filebench o 
+omnios compatibility/ucb 
+omnios compress/bzip2 
+omnios compress/gzip 
+omnios compress/p7zip 
+omnios compress/unzip 
+omnios compress/xz 
+omnios compress/zip 
+omnios consolidation/man/man-incorporation o 
+omnios consolidation/osnet/osnet-incorporation 
+omnios consolidation/osnet/osnet-message-files 
+omnios consolidation/osnet/osnet-redistributable 
+omnios consolidation/sunpro/sunpro-incorporation 
+omnios data/iso-codes 
+omnios database/sqlite-3 
+omnios developer/acpi 
+omnios developer/appcert 
+omnios developer/apptrace 
+omnios developer/apptrace/ucblib 
+omnios developer/as 
+omnios developer/astdev 
+omnios developer/bmake 
+omnios developer/build/autoconf 
+omnios developer/build/automake 
+omnios developer/build/gnu-make 
+omnios developer/build/libtool 
+omnios developer/build/make 
+omnios developer/build/onbld 
+omnios developer/debug/mdb 
+omnios developer/debug/mdb/module/module-fibre-channel 
+omnios developer/debug/mdb/module/module-qlc 
+omnios developer/driver/ftsafe 
+omnios developer/dtrace 
+omnios developer/dtrace/toolkit 
+omnios developer/gcc44 
+omnios developer/gcc44/libgmp-gcc44 
+omnios developer/gcc44/libmpc-gcc44 
+omnios developer/gcc44/libmpfr-gcc44 
+omnios developer/gcc5 
+omnios developer/gcc5/libgmp-gcc5 o 
+omnios developer/gcc5/libmpc-gcc5 o 
+omnios developer/gcc5/libmpfr-gcc5 o 
+omnios developer/gcc51 r 
+omnios developer/gcc51/libgmp-gcc51 o 
+omnios developer/gcc51/libmpc-gcc51 o 
+omnios developer/gcc51/libmpfr-gcc51 o 
+omnios developer/gcc6 
+omnios developer/gcc6/libgmp-gcc6 o 
+omnios developer/gcc6/libmpc-gcc6 o 
+omnios developer/gcc6/libmpfr-gcc6 o 
+omnios developer/gnu-binutils 
+omnios developer/illumos-closed 
+omnios developer/illumos-tools 
+omnios developer/java/jdk 
+omnios developer/lexer/flex 
+omnios developer/library/lint 
+omnios developer/library/profiled-libc o 
+omnios developer/linker 
+omnios developer/macro/cpp 
+omnios developer/macro/gnu-m4 
+omnios developer/object-file 
+omnios developer/omnios-build-tools 
+omnios developer/opensolaris/osnet 
+omnios developer/parser/bison 
+omnios developer/pkg-config 
+omnios developer/sunstudio12.1 
+omnios developer/swig 
+omnios developer/tnf 
+omnios developer/versioning/git 
+omnios developer/versioning/mercurial 
+omnios developer/versioning/sccs 
+omnios diagnostic/cpu-counters 
+omnios diagnostic/diskinfo 
+omnios diagnostic/latencytop 
+omnios diagnostic/powertop 
+omnios driver/audio 
+omnios driver/audio/audio810 
+omnios driver/audio/audiocmi 
+omnios driver/audio/audiocmihd 
+omnios driver/audio/audioemu10k 
+omnios driver/audio/audiohd 
+omnios driver/audio/audioixp 
+omnios driver/audio/audiols 
+omnios driver/audio/audiop16x 
+omnios driver/audio/audiosolo 
+omnios driver/audio/audiovia823x 
+omnios driver/audio/audiovia97 o 
+omnios driver/crypto/dca 
+omnios driver/crypto/dprov 
+omnios driver/crypto/tpm 
+omnios driver/firewire 
+omnios driver/graphics/agpgart 
+omnios driver/graphics/atiatom 
+omnios driver/graphics/av1394 
+omnios driver/graphics/dcam1394 
+omnios driver/graphics/dcam1394/devfsadm-dcam1394 
+omnios driver/graphics/drm 
+omnios driver/graphics/usbvc 
+omnios driver/i86pc/fipe 
+omnios driver/i86pc/ioat 
+omnios driver/i86pc/platform 
+omnios driver/ipmi 
+omnios driver/misc/virtio 
+omnios driver/network/afe 
+omnios driver/network/amd8111s 
+omnios driver/network/arbel o 
+omnios driver/network/arn 
+omnios driver/network/atge 
+omnios driver/network/ath 
+omnios driver/network/atu 
+omnios driver/network/axf 
+omnios driver/network/bfe 
+omnios driver/network/bge 
+omnios driver/network/bnx 
+omnios driver/network/bnxe 
+omnios driver/network/bpf 
+omnios driver/network/chxge 
+omnios driver/network/cxgbe 
+omnios driver/network/dmfe 
+omnios driver/network/e1000g 
+omnios driver/network/efe 
+omnios driver/network/elxl 
+omnios driver/network/emlxs 
+omnios driver/network/eoib 
+omnios driver/network/fcip 
+omnios driver/network/fcoe 
+omnios driver/network/fcoei 
+omnios driver/network/fcoet 
+omnios driver/network/fcp 
+omnios driver/network/fcsm 
+omnios driver/network/fp 
+omnios driver/network/hermon 
+omnios driver/network/hme 
+omnios driver/network/hxge 
+omnios driver/network/i40e 
+omnios driver/network/ib 
+omnios driver/network/ibdma 
+omnios driver/network/ibp 
+omnios driver/network/igb 
+omnios driver/network/iprb 
+omnios driver/network/ipw 
+omnios driver/network/iwh 
+omnios driver/network/iwi 
+omnios driver/network/iwk 
+omnios driver/network/iwn 
+omnios driver/network/iwp 
+omnios driver/network/ixgb 
+omnios driver/network/ixgbe 
+omnios driver/network/llc2 o 
+omnios driver/network/mwl 
+omnios driver/network/mxfe 
+omnios driver/network/myri10ge 
+omnios driver/network/nge 
+omnios driver/network/ntxn 
+omnios driver/network/nxge 
+omnios driver/network/ofk 
+omnios driver/network/pcan o 
+omnios driver/network/pcn 
+omnios driver/network/pcwl o 
+omnios driver/network/platform 
+omnios driver/network/qlc 
+omnios driver/network/ral 
+omnios driver/network/rds 
+omnios driver/network/rdsv3 
+omnios driver/network/rge 
+omnios driver/network/rpcib 
+omnios driver/network/rtls 
+omnios driver/network/rtw 
+omnios driver/network/rum 
+omnios driver/network/rwd 
+omnios driver/network/rwn 
+omnios driver/network/sdp 
+omnios driver/network/sdpib 
+omnios driver/network/sfe 
+omnios driver/network/sfxge 
+omnios driver/network/srpt 
+omnios driver/network/tavor 
+omnios driver/network/uath 
+omnios driver/network/udmf 
+omnios driver/network/upf 
+omnios driver/network/ural 
+omnios driver/network/urf 
+omnios driver/network/urtw 
+omnios driver/network/usbecm 
+omnios driver/network/vioif 
+omnios driver/network/vmxnet3s 
+omnios driver/network/vr 
+omnios driver/network/wpi 
+omnios driver/network/xge 
+omnios driver/network/yge 
+omnios driver/network/zyd 
+omnios driver/pcmcia 
+omnios driver/serial/pcser o 
+omnios driver/serial/usbftdi 
+omnios driver/serial/usbsacm 
+omnios driver/serial/usbser 
+omnios driver/serial/usbser_edge 
+omnios driver/serial/usbsksp 
+omnios driver/serial/usbsksp/usbs49_fw 
+omnios driver/serial/usbsprl 
+omnios driver/storage/aac 
+omnios driver/storage/adpu320 
+omnios driver/storage/ahci 
+omnios driver/storage/amr 
+omnios driver/storage/arcmsr 
+omnios driver/storage/ata 
+omnios driver/storage/bcm_sata 
+omnios driver/storage/blkdev 
+omnios driver/storage/cpqary3 
+omnios driver/storage/glm 
+omnios driver/storage/lsimega 
+omnios driver/storage/marvell88sx 
+omnios driver/storage/mega_sas 
+omnios driver/storage/mpt_sas 
+omnios driver/storage/mr_sas 
+omnios driver/storage/nv_sata 
+omnios driver/storage/nvme 
+omnios driver/storage/pcata o 
+omnios driver/storage/pmcs 
+omnios driver/storage/pvscsi 
+omnios driver/storage/sbp2 
+omnios driver/storage/scsa1394 
+omnios driver/storage/sdcard 
+omnios driver/storage/ses 
+omnios driver/storage/si3124 
+omnios driver/storage/skd 
+omnios driver/storage/smp 
+omnios driver/storage/sv 
+omnios driver/storage/vioblk 
+omnios driver/tuntap 
+omnios driver/usb 
+omnios driver/usb/ugen 
+omnios driver/usb/usbgem 
+omnios driver/virtualization/kvm 
+omnios driver/x11/winlock 
+omnios driver/x11/xsvc 
+omnios driver/xvm/pv 
+omnios editor/vim 
+omnios entire 
+omnios file/gnu-coreutils 
+omnios file/gnu-findutils 
+omnios incorporation/jeos/illumos-gate 
+omnios incorporation/jeos/omnios-userland 
+omnios install/beadm 
+omnios library/c++/sigcpp 
+omnios library/demo/audio-samples 
+omnios library/expat 
+omnios library/glib2 
+omnios library/gmp 
+omnios library/idnkit 
+omnios library/idnkit/header-idnkit 
+omnios library/libadt_jni 
+omnios library/libffi 
+omnios library/libidn 
+omnios library/libtecla 
+omnios library/libtool/libltdl 
+omnios library/libxml2 
+omnios library/libxslt 
+omnios library/mpc 
+omnios library/mpfr 
+omnios library/ncurses 
+omnios library/nghttp2 
+omnios library/nspr 
+omnios library/nspr/header-nspr 
+omnios library/pcre 
+omnios library/perl-5/xml-parser 
+omnios library/print/open-printing 
+omnios library/print/open-printing/ipp 
+omnios library/print/open-printing/lpd 
+omnios library/python-2/asn1crypto-27 
+omnios library/python-2/cffi-27 
+omnios library/python-2/cheroot-27 
+omnios library/python-2/cherrypy-27 
+omnios library/python-2/coverage-27 
+omnios library/python-2/cryptography-27 
+omnios library/python-2/enum-27 
+omnios library/python-2/functools32-27 
+omnios library/python-2/idna-27 
+omnios library/python-2/ipaddress-27 
+omnios library/python-2/jsonrpclib-27 
+omnios library/python-2/jsonschema-27 
+omnios library/python-2/lxml-27 
+omnios library/python-2/m2crypto-27 
+omnios library/python-2/mako-27 
+omnios library/python-2/numpy-27 
+omnios library/python-2/ply-27 
+omnios library/python-2/portend-27 
+omnios library/python-2/pybonjour-27 
+omnios library/python-2/pycurl-27 
+omnios library/python-2/pylint-27 
+omnios library/python-2/pyopenssl-27 
+omnios library/python-2/pyrex-27 
+omnios library/python-2/python-extra-27 
+omnios library/python-2/pytz-27 
+omnios library/python-2/setuptools-27 
+omnios library/python-2/simplejson-27 
+omnios library/python-2/six-27 
+omnios library/python-2/tempora-27 
+omnios library/python-2/typing-27 
+omnios library/readline 
+omnios library/security/openssl 
+omnios library/security/tcp-wrapper 
+omnios library/security/trousers 
+omnios library/unixodbc 
+omnios library/zlib 
+omnios locale/af 
+omnios locale/ar 
+omnios locale/ar-extra o 
+omnios locale/as 
+omnios locale/az 
+omnios locale/be 
+omnios locale/bg 
+omnios locale/bg-extra 
+omnios locale/bn 
+omnios locale/bo 
+omnios locale/bs 
+omnios locale/ca 
+omnios locale/ca-extra 
+omnios locale/cs 
+omnios locale/cs-extra 
+omnios locale/da 
+omnios locale/da-extra 
+omnios locale/de 
+omnios locale/de-extra 
+omnios locale/el 
+omnios locale/el-extra 
+omnios locale/en 
+omnios locale/en-extra 
+omnios locale/es 
+omnios locale/es-extra 
+omnios locale/et 
+omnios locale/fi 
+omnios locale/fi-extra 
+omnios locale/fil 
+omnios locale/fr 
+omnios locale/fr-extra 
+omnios locale/ga 
+omnios locale/gu 
+omnios locale/he 
+omnios locale/hi 
+omnios locale/hr 
+omnios locale/hr-extra 
+omnios locale/hu 
+omnios locale/hu-extra 
+omnios locale/hy 
+omnios locale/id 
+omnios locale/ii 
+omnios locale/is 
+omnios locale/is-extra 
+omnios locale/it 
+omnios locale/it-extra 
+omnios locale/ja 
+omnios locale/ka 
+omnios locale/kk 
+omnios locale/km 
+omnios locale/kn 
+omnios locale/ko 
+omnios locale/kok 
+omnios locale/lt 
+omnios locale/lt-extra 
+omnios locale/lv 
+omnios locale/lv-extra 
+omnios locale/mk 
+omnios locale/mk-extra 
+omnios locale/ml 
+omnios locale/mn 
+omnios locale/mr 
+omnios locale/ms 
+omnios locale/mt 
+omnios locale/nb 
+omnios locale/ne 
+omnios locale/nl 
+omnios locale/nl-extra 
+omnios locale/nn 
+omnios locale/or 
+omnios locale/pa 
+omnios locale/pl 
+omnios locale/pl-extra 
+omnios locale/pt 
+omnios locale/pt-extra 
+omnios locale/ro 
+omnios locale/ru 
+omnios locale/ru-extra 
+omnios locale/sa 
+omnios locale/si 
+omnios locale/sk 
+omnios locale/sl 
+omnios locale/sq 
+omnios locale/sq-extra 
+omnios locale/sr 
+omnios locale/sv 
+omnios locale/sv-extra 
+omnios locale/ta 
+omnios locale/te 
+omnios locale/th 
+omnios locale/th-extra 
+omnios locale/tr 
+omnios locale/tr-extra 
+omnios locale/ug 
+omnios locale/uk 
+omnios locale/ur 
+omnios locale/vi 
+omnios locale/zh_cn 
+omnios locale/zh_cn-extra 
+omnios locale/zh_hk 
+omnios locale/zh_mo 
+omnios locale/zh_sg 
+omnios locale/zh_tw 
+omnios media/cdrtools 
+omnios media/cdrw 
+omnios naming/ldap 
+omnios network/bridging 
+omnios network/dhcp/dhcpmgr o 
+omnios network/dns/bind 
+omnios network/dns/idnconv 
+omnios network/ftp 
+omnios network/ipd 
+omnios network/ipfilter 
+omnios network/ipfilter/header-ipfilter 
+omnios network/iscsi/initiator 
+omnios network/iscsi/iser 
+omnios network/iscsi/target 
+omnios network/netcat 
+omnios network/openssh 
+omnios network/openssh-server 
+omnios network/rsync 
+omnios network/service/isc-dhcp 
+omnios network/telnet 
+omnios network/test/iperf 
+omnios network/test/netperf 
+omnios package/pkg 
+omnios package/pkg/zones-proxy o 
+omnios package/svr4 
+omnios print/lp 
+omnios print/lp/compatibility/sunos4 
+omnios print/lp/filter/postscript-lp-filter 
+omnios print/lp/ipp/libipp 
+omnios print/lp/print-client-commands 
+omnios print/lp/print-manager/legacy 
+omnios release/name 
+omnios release/notices 
+omnios runtime/java 
+omnios runtime/perl 
+omnios runtime/perl-64 
+omnios runtime/perl/manual 
+omnios runtime/perl/module/sun-solaris 
+omnios runtime/python-27 
+omnios security/bart 
+omnios security/sudo 
+omnios service/fault-management 
+omnios service/fault-management/smtp-notify 
+omnios service/fault-management/snmp-notify 
+omnios service/file-system/nfs 
+omnios service/file-system/smb 
+omnios service/hal 
+omnios service/network/dhcp o 
+omnios service/network/dhcp/datastore/binfiles o 
+omnios service/network/dns/mdns 
+omnios service/network/ftp o 
+omnios service/network/legacy 
+omnios service/network/load-balancer/ilb 
+omnios service/network/network-clients 
+omnios service/network/network-servers 
+omnios service/network/nis 
+omnios service/network/ntp 
+omnios service/network/slp 
+omnios service/network/smtp/sendmail 
+omnios service/network/snmp/mibiisa o 
+omnios service/network/telnet 
+omnios service/network/tftp 
+omnios service/network/uucp 
+omnios service/network/wpa 
+omnios service/picl 
+omnios service/resource-cap 
+omnios service/resource-pools 
+omnios service/resource-pools/poold 
+omnios service/security/gss 
+omnios service/security/kerberos-5 
+omnios service/storage/avs/cache-management 
+omnios service/storage/fibre-channel/fc-fabric 
+omnios service/storage/isns 
+omnios service/storage/media-volume-manager 
+omnios service/storage/ndmp 
+omnios service/storage/removable-media 
+omnios service/storage/virus-scan 
+omnios shell/bash 
+omnios shell/pipe-viewer 
+omnios shell/tcsh 
+omnios shell/zsh 
+omnios source/demo/mdb-examples 
+omnios source/demo/system 
+omnios source/network/pppdump o 
+omnios source/security/tcp-wrapper o 
+omnios source/system/grub 
+omnios storage/avs 
+omnios storage/avs/point-in-time-copy 
+omnios storage/avs/remote-mirror 
+omnios storage/metassist o 
+omnios storage/mpathadm 
+omnios storage/stmf 
+omnios storage/storage-nas o 
+omnios storage/storage-server o 
+omnios storage/svm o 
+omnios system/accounting/legacy 
+omnios system/boot/grub 
+omnios system/boot/loader 
+omnios system/boot/network 
+omnios system/boot/real-mode 
+omnios system/boot/wanboot 
+omnios system/boot/wanboot/internal 
+omnios system/data/console/fonts 
+omnios system/data/hardware-registry 
+omnios system/data/keyboard/keytables 
+omnios system/data/terminfo 
+omnios system/data/zoneinfo 
+omnios system/dtrace/tests 
+omnios system/extended-system-utilities 
+omnios system/fault-management/eversholt-utilities 
+omnios system/ficl 
+omnios system/file-system/autofs 
+omnios system/file-system/nfs 
+omnios system/file-system/ntfsprogs o 
+omnios system/file-system/smb 
+omnios system/file-system/udfs 
+omnios system/file-system/zfs 
+omnios system/file-system/zfs/tests 
+omnios system/flash/fwflash 
+omnios system/fru-id 
+omnios system/fru-id/platform 
+omnios system/header 
+omnios system/header/header-agp 
+omnios system/header/header-audio 
+omnios system/header/header-firewire 
+omnios system/header/header-picl 
+omnios system/header/header-storage 
+omnios system/header/header-ugen 
+omnios system/header/header-usb 
+omnios system/install/kayak 
+omnios system/install/kayak-kernel 
+omnios system/io/tests 
+omnios system/ipc 
+omnios system/kernel 
+omnios system/kernel/cpu-counters 
+omnios system/kernel/dtrace/providers 
+omnios system/kernel/dtrace/providers/xdt 
+omnios system/kernel/dynamic-reconfiguration/i86pc 
+omnios system/kernel/platform 
+omnios system/kernel/power 
+omnios system/kernel/rsmops 
+omnios system/kernel/secure-rpc 
+omnios system/kernel/security/gss 
+omnios system/kernel/suspend-resume 
+omnios system/kernel/ultra-wideband o 
+omnios system/kvm 
+omnios system/library 
+omnios system/library/c++/sunpro 
+omnios system/library/c-runtime 
+omnios system/library/dbus 
+omnios system/library/g++-4-runtime r 
+omnios system/library/g++-5-runtime r 
+omnios system/library/g++-6-runtime r 
+omnios system/library/g++-runtime 
+omnios system/library/gcc-4-runtime r 
+omnios system/library/gcc-5-runtime r 
+omnios system/library/gcc-6-runtime r 
+omnios system/library/gcc-runtime 
+omnios system/library/iconv/unicode 
+omnios system/library/iconv/utf-8 
+omnios system/library/iconv/utf-8/manual 
+omnios system/library/iconv/xsh4/latin 
+omnios system/library/install/libinstzones 
+omnios system/library/libdbus 
+omnios system/library/libdbus-glib 
+omnios system/library/libdiskmgt 
+omnios system/library/libdiskmgt/header-libdiskmgt 
+omnios system/library/libfcoe 
+omnios system/library/liblayout 
+omnios system/library/math 
+omnios system/library/math/header-math r 
+omnios system/library/mozilla-nss 
+omnios system/library/mozilla-nss/header-nss 
+omnios system/library/mtsk 
+omnios system/library/pcap 
+omnios system/library/platform 
+omnios system/library/policykit 
+omnios system/library/processor 
+omnios system/library/security/crypto/pkcs11_kms o 
+omnios system/library/security/gss 
+omnios system/library/security/gss/diffie-hellman 
+omnios system/library/security/gss/spnego 
+omnios system/library/security/libsasl 
+omnios system/library/security/rpcsec 
+omnios system/library/storage/fibre-channel/hbaapi 
+omnios system/library/storage/fibre-channel/libsun_fc 
+omnios system/library/storage/ima 
+omnios system/library/storage/ima/header-ima 
+omnios system/library/storage/libmpapi 
+omnios system/library/storage/libmpscsi_vhci 
+omnios system/library/storage/scsi-plugin r 
+omnios system/library/storage/scsi-plugins 
+omnios system/library/svm-rcm o 
+omnios system/man 
+omnios system/management/ec2-api-tools 
+omnios system/management/ec2-credential 
+omnios system/management/intel-amt o 
+omnios system/management/ipmitool 
+omnios system/management/mdata-client 
+omnios system/management/pcitool 
+omnios system/management/snmp/net-snmp 
+omnios system/management/snmp/sea o 
+omnios system/management/snmp/sea/sea-config o 
+omnios system/management/wbem/data-management 
+omnios system/management/wbem/resource-management o 
+omnios system/manual o 
+omnios system/monitoring/arcstat 
+omnios system/network 
+omnios system/network/http-cache-accelerator 
+omnios system/network/ipqos 
+omnios system/network/ipqos/ipqos-config 
+omnios system/network/mailwrapper 
+omnios system/network/nis 
+omnios system/network/ppp 
+omnios system/network/ppp/pppdump 
+omnios system/network/ppp/tunnel 
+omnios system/network/routing 
+omnios system/network/routing/vrrp 
+omnios system/network/spdadm 
+omnios system/network/udapl 
+omnios system/network/udapl/udapl-tavor 
+omnios system/network/wificonfig 
+omnios system/pciutils 
+omnios system/pciutils/pci.ids 
+omnios system/pkgtree 
+omnios system/prerequisite/gnu 
+omnios system/remote-shared-memory 
+omnios system/scheduler/fss 
+omnios system/security/kerberos-5 
+omnios system/storage/fibre-channel/port-utility 
+omnios system/storage/luxadm 
+omnios system/storage/parted o 
+omnios system/storage/sasinfo 
+omnios system/test/fio 
+omnios system/test/libctest 
+omnios system/test/ostest 
+omnios system/test/testrunner 
+omnios system/test/utiltest 
+omnios system/test/zfstest 
+omnios system/tnf 
+omnios system/trusted 
+omnios system/trusted/global-zone 
+omnios system/virtualization/open-vm-tools 
+omnios system/xopen/xcu4 
+omnios system/xopen/xcu6 
+omnios system/xvm/ipagent 
+omnios system/zones 
+omnios system/zones/brand/ipkg 
+omnios system/zones/brand/lipkg 
+omnios system/zones/brand/lx 
+omnios system/zones/brand/s10 
+omnios system/zones/brand/sn1 
+omnios system/zones/internal 
+omnios terminal/screen 
+omnios terminal/tmux 
+omnios text/auto_ef 
+omnios text/doctools 
+omnios text/gawk 
+omnios text/gnu-diffutils 
+omnios text/gnu-gettext 
+omnios text/gnu-grep 
+omnios text/gnu-patch 
+omnios text/gnu-sed 
+omnios text/groff 
+omnios text/intltool 
+omnios text/less 
+omnios text/locale 
+omnios web/ca-bundle 
+omnios web/curl 
+omnios web/wget 

--- a/tools/test
+++ b/tools/test
@@ -188,45 +188,6 @@ check_packages_md()
 	done
 }
 
-check_baseline()
-{
-	echo "Checking doc/baseline..."
-	nawk < doc/baseline '
-		# Skip obsolete/renamed
-		NF == 3 {
-			sub(/-.*/, "", $NF)
-			print $2, $3
-		}
-	' | while read pkg ver; do
-		case $pkg in
-			system/zones/brand/*)		continue ;;
-			package/pkg)			continue ;;
-			system/library/mtsk)		continue ;;
-			library/security/openssl)	continue ;;
-			runtime/java)			continue ;;
-			shell/bash)			continue ;;
-		esac
-		if [ -n "${targets[$pkg]}" ]; then
-			pver="${targets[$pkg]}"
-			[ "$pver" = "$ver" ] && continue
-			# 16.02 -> 16.2 (e.g. p7zip)
-			[ "${pver//.0/.}" = "$ver" ] && continue
-			# x.0 -> x (e.g. gcc)
-			[ "$pver" = "${ver/.0/}" ] && continue
-			# b/p -> . (e.g. sudo)
-			[ "${pver/[-bp]/.}" = "$ver" ] && continue
-
-			# sqlite3 baseline=3.20.1, build=3200100
-			[ "${pver//0/}" = "${ver//[0\.]/}" ] && continue
-
-			# openjdk
-			jver="${pver/_/.}"
-			[ "${jver/-b0/.}" = "$ver" ] && continue
-			problem "$pkg - baseline=$ver, build=${targets[$pkg]}"
-		fi
-	done
-}
-
 check_constraints()
 {
 	comp="$1"
@@ -312,7 +273,6 @@ add_targets
 check_packages_md
 check_userland
 check_entire
-check_baseline
 
 exit $err
 


### PR DESCRIPTION
baseline is intended to prove that all packages have been built but it currently checks versions too.
This is unnecessary and adds overhead to every package update.

Will backport to r151024