### PR TITLE
Rebuild package repository prior to evaluating baseline

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -318,6 +318,7 @@ baseline() {
 
     # PUBLISHER NAME                 O VERSION
     # omnios    developer/macro/gnu-m4 1.4.18-0.151023:20171022T080105Z
+    pkgrepo -s $PKGSRVR rebuild
     pkgrepo -s $PKGSRVR list | nawk '
         $1 == "PUBLISHER" { next }
         $2 in seen { next }


### PR DESCRIPTION
Otherwise some packages published at the tail end of the build might not show up.