### PR TITLE
Patch intltool to properly escape braces

### DIFF
--- a/build/intltool/build.sh
+++ b/build/intltool/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/bash
 #
+# {{{
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
@@ -8,8 +9,10 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
+# }}}
 #
 # Copyright 2014 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions
@@ -22,7 +25,7 @@ PKG=text/intltool
 SUMMARY="Extracts translatable strings from specific source file types."
 DESC="$SUMMARY $VER"
 
-DEPENDS_IPS="system/library SUNWcs"
+RUN_DEPENDS_IPS="system/library"
 
 BUILDARCH=32
 
@@ -38,4 +41,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/intltool/patches/braces.patch
+++ b/build/intltool/patches/braces.patch
@@ -1,0 +1,49 @@
+Fix unescaped braces that are treated as problems with newer perl versions.
+Patch taken from:
+
+https://code.launchpad.net/~dobey/intltool/regex-fix
+
+diff -pruN '--exclude=*.orig' intltool-0.51.0~/intltool-update.in intltool-0.51.0/intltool-update.in
+--- intltool-0.51.0~/intltool-update.in	2015-03-09 01:39:54.000000000 +0000
++++ intltool-0.51.0/intltool-update.in	2017-11-10 09:47:19.979256659 +0000
+@@ -1062,7 +1062,7 @@ sub SubstituteVariable
+ 	}
+     }
+ 
+-    if ($str =~ /^(.*)\${?([A-Z_]+)}?(.*)$/)
++    if ($str =~ /^(.*)\$\{?([A-Z_]+)}?(.*)$/)
+     {
+ 	my $rest = $3;
+ 	my $untouched = $1;
+@@ -1190,10 +1190,10 @@ sub FindPackageName
+ 	$name    =~ s/\(+$//g;
+ 	$version =~ s/\(+$//g;
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
+     }
+ 
+     if ($conf_source =~ /^AC_INIT\(([^,\)]+),([^,\)]+)[,]?([^,\)]+)?/m)
+@@ -1219,11 +1219,11 @@ sub FindPackageName
+ 	$version =~ s/\(+$//g;
+         $bugurl  =~ s/\(+$//g if (defined $bugurl);
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
+-        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\${?\w+}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
++        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\$\{?\w+}?/);
+     }
+ 
+     # \s makes this not work, why?

--- a/build/intltool/patches/series
+++ b/build/intltool/patches/series
@@ -1,0 +1,1 @@
+braces.patch


### PR DESCRIPTION
The recent perl upgrade has exposed missing escapes for left curly braces in `intltool`.
This is already fixed in an upstream branch at https://code.launchpad.net/intltool so the patch is taken from there.