### PR TITLE
Switch to building with gcc6

### DIFF
--- a/build/glib/build.sh
+++ b/build/glib/build.sh
@@ -49,6 +49,11 @@ CONFIGURE_OPTS="
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
+# With gcc 6, -Werror_format=2 produces errors like:
+#   error: format not a string literal, arguments not checked
+# Tell configure that this flag doesn't exist for the compiler.
+export cc_cv_CFLAGS__Werror_format_2=no
+
 init
 download_source $PROG $PROG $VER
 patch_source

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,5 +1,5 @@
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -17,11 +17,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
+# CDDL HEADER END }}}
 #
-#
-# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 #############################################################################
 # Configuration for the build system
@@ -57,7 +57,7 @@ PREFIX=/usr
 #    TMPDIR includes a username
 # DTMPDIR is used for constructing the DESTDIR path
 # Let the environment override TMPDIR.
-if [[ -z $TMPDIR ]]; then
+if [ -z "$TMPDIR" ]; then
 	TMPDIR=/tmp/build_$USER
 fi
 DTMPDIR=$TMPDIR
@@ -70,15 +70,6 @@ PATCHDIR=patches
 
 # Do we create isaexec stubs for scripts and other non-binaries (default yes)
 NOSCRIPTSTUB=
-
-#############################################################################
-# The version of certain software that's *installed* matters.  We don't yet
-# have a sophisticated build-certain-things-first bootstrap for omnios-build.
-# We must sometimes determine or even hardcode things about our build system.
-#############################################################################
-
-# libffi --> use pkg(5) to determine what we're running:
-FFIVERS=`pkg list -H libffi | awk '{print $(NF-1)}' | cut -d- -f1`
 
 #############################################################################
 # Perl stuff
@@ -106,16 +97,14 @@ export PERL_MM_USE_DEFAULT=true
 # Unset in a build script to skip tests
 PERL_MAKE_TEST=1
 
-
 #############################################################################
 # Python -- NOTE, these can be changed at runtime via set_python_version().
 #############################################################################
 : ${PYTHONVER:=2.7}
-: ${PYTHONPKGVER:=`echo $PYTHONVER | sed 's/\.//g'`}
+: ${PYTHONPKGVER:=${PYTHONVER//./}}
 PYTHONPATH=/usr
 PYTHON=$PYTHONPATH/bin/python$PYTHONVER
 PYTHONLIB=$PYTHONPATH/lib
-
 
 #############################################################################
 # Paths to common tools
@@ -138,9 +127,7 @@ PFEXEC=sudo
 # A build script may serialize make by setting NO_PARALLEL_MAKE
 LCPUS=`psrinfo | wc -l`
 MJOBS="$[ $LCPUS + ($LCPUS / 2) ]"
-if [ "$MJOBS" == "0" ]; then
-    MJOBS=2
-fi
+[ "$MJOBS" = "0" ] && MJOBS=2
 MAKE_JOBS="-j $MJOBS"
 NO_PARALLEL_MAKE=
 
@@ -164,23 +151,23 @@ CXX=g++
 
 # CFLAGS applies to both builds, 32/64 only gets applied to the respective
 # build
-CFLAGS=""
-CFLAGS32=""
+CFLAGS=
+CFLAGS32=
 CFLAGS64="-m64"
 
 # Linker flags
-LDFLAGS=""
-LDFLAGS32=""
+LDFLAGS=
+LDFLAGS32=
 LDFLAGS64="-m64"
 
 # C pre-processor flags
-CPPFLAGS=""
-CPPFLAGS32=""
-CPPFLAGS64=""
+CPPFLAGS=
+CPPFLAGS32=
+CPPFLAGS64=
 
 # C++ flags
-CXXFLAGS=""
-CXXFLAGS32=""
+CXXFLAGS=
+CXXFLAGS32=
 CXXFLAGS64="-m64"
 
 #############################################################################
@@ -220,7 +207,7 @@ reset_configure_opts
 
 # Configure options to apply to both builds - this is the one you usually want
 # to change for things like --enable-feature
-CONFIGURE_OPTS=""
+CONFIGURE_OPTS=
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
+# CDDL HEADER END }}}
 #
-#
-# Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Use is subject to license terms.
 # Copyright (c) 2014 by Delphix. All rights reserved.
+# Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Use is subject to license terms.
 #
 
 umask 022
@@ -244,8 +243,8 @@ url_encode() {
 #############################################################################
 # Set the LANG to C as the assembler will freak out on unicode in headers
 LANG=C
-GCCPATH=/opt/gcc-5
-GCC6PATH=/opt/gcc-6
+GCCVER=6
+GCCPATH=/opt/gcc-$GCCVER
 # Set the path - This can be overriden/extended in the build script
 PATH="$GCCPATH/bin:/usr/ccs/bin:/usr/bin:/usr/sbin:/usr/gnu/bin:/usr/sfw/bin"
 export LANG GCCPATH PATH
@@ -264,8 +263,8 @@ SRCDIR=$PWD/`dirname $0`
 . $MYDIR/config.sh
 [ -f $MYDIR/site.sh ] && . $MYDIR/site.sh
 
-# Platform information
-SUNOSVER=`uname -r` # e.g. 5.11
+# Platform information, e.g. 5.11
+SUNOSVER=`uname -r`
 
 [ -f "$LOGFILE" ] && mv $LOGFILE $LOGFILE.1
 process_opts $@
@@ -273,10 +272,7 @@ shift $((OPTIND - 1))
 
 BasicRequirements() {
     local needed=""
-    [ -x $GCCPATH/bin/gcc ] || needed+=" developer/gcc5"
-    # Require gcc6 too in order to build the gcc6 packages and to ensure a
-    # consistent set of package dependencies between builds.
-    [ -x $GCC6PATH/bin/gcc ] || needed+=" developer/gcc6"
+    [ -x $GCCPATH/bin/gcc ] || needed+=" developer/gcc$GCCVER"
     [ -x /usr/bin/ar ] || needed+=" developer/object-file"
     [ -x /usr/bin/ld ] || needed+=" developer/linker"
     [ -f /usr/lib/crt1.o ] || needed+=" developer/library/lint"
@@ -1550,4 +1546,4 @@ set_python_version() {
 }
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker


### PR DESCRIPTION
Build omnios user-land with gcc 6 instead of gcc 5.
The only package which required a minor change was `glib`.