### PR TITLE
Set SHELL variable so subshells are always started under a known interpreter

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -40,6 +40,9 @@ PKGSRVR=file://$ROOTDIR/tmp.repo/
 # set locale to C
 export LC_ALL=C
 
+# Use bash for subshells and commands launched by python setuptools
+export SHELL=/usr/bin/bash
+
 # Which server to fetch files from.
 # If $MIRROR begins with a '/', it is treated as a local directory.
 MIRROR=https://mirrors.omniosce.org


### PR DESCRIPTION
In particular this came to light when building `numpy` as this assumes a bourne compatible shell when it launches sub-commands.
Let's have a consistent environment.