### PR TITLE
libxml: update to 2.9.7

### DIFF
--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,79 +18,46 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions
 . ../../lib/functions.sh
 
-PROG=libxml2        # App name
-VER=2.9.6           # App version
-PKG=library/libxml2 # Package name (without prefix)
+PROG=libxml2
+VER=2.9.7
+PKG=library/libxml2
 SUMMARY="$PROG - XML C parser and toolkit"
 DESC="$SUMMARY"
 
-DEPENDS_IPS="compress/xz system/library/gcc-runtime library/zlib"
-BUILD_DEPENDS_IPS="$DEPENDS_IPS developer/sunstudio12.1"
-# Keep python tied to the version we're supporting, to aid future changes.
-CONFIGURE_OPTS="--with-python=/usr/bin/python2.7"
+RUN_DEPENDS_IPS="compress/xz library/zlib"
+# For lint library creation
+BUILD_DEPENDS_IPS="developer/sunstudio12.1"
 
-fix_python_install() {
-    logcmd mkdir -p $DESTDIR/usr/lib/python2.7/vendor-packages
-    logcmd mv $DESTDIR/usr/lib/python2.7/site-packages/* $DESTDIR/usr/lib/python2.7/vendor-packages/ || logerr "failed relocating python install"
-    logcmd rm -f $DESTDIR/usr/lib/python2.7/vendor-packages/64/drv_libxml2.py
-    logcmd rm -rf $DESTDIR/usr/lib/python2.7/site-packages || logerr "failed removing bad python install"
-    logcmd rm -rf $DESTDIR/usr/include/amd64 || logerr "failed removing bad includes install"
-}
+XFORM_ARGS="-D VER=$VER"
 
-make_prog64() {
-    logcmd perl -pi -e 's#(\$CC.*\$compiler_flags)#$1 -nostdlib#g;' libtool ||
-        logerr "libtool patch failed"
-    logcmd gmake || logerr "Make failed"
-}
-
-make_prog32() {
-    logcmd perl -pi -e 's#(\$CC.*\$compiler_flags)#$1 -nostdlib#g;' libtool ||
-        logerr "libtool patch failed"
-    logcmd gmake || logerr "Make failed"
+python_cleanup() {
+    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
+        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages \
+        || logerr "Cannot move from site-packages to vendor-packages"
 }
 
 make_install64() {
     logmsg "--- make install"
-    logcmd perl -pi -e 's#(\/site-packages)#$1\/64#g;' python/.libs/libxml2mod.la ||
-        logerr "libtool libxml2mod.la patch failed"
-    logcmd perl -pi -e 's#(\/site-packages)#$1\/64#g;' python/libxml2mod.la ||
-        logerr "libtool libxml2mod.la patch failed"
 
-    logcmd perl -pi -e 's#(\/site-packages)#$1\/64#g;' python/.libs/libxml2mod.lai ||
-        logerr "libtool libxml2mod.la patch failed"
+    # Install 64-bit python modules into 64/
+    for f in libxml2mod.la .libs/libxml2mod.la .libs/libxml2mod.lai; do
+        logcmd perl -pi -e 's#(\/site-packages)#$1\/64#g;' python/$f \
+            || logerr "libtool libxml2mod.la patch failed"
+    done
 
     logcmd $MAKE DESTDIR=${DESTDIR} \
         PYTHON_SITE_PACKAGES=/usr/lib/python2.7/site-packages/64 \
-        install || \
-        logerr "--- Make install failed"
-}
-
-# Relocate the libs to /lib, to match upstream
-move_libs() {
-    logcmd mkdir -p $DESTDIR/lib/amd64
-    logcmd mv $DESTDIR/usr/lib/lib* $DESTDIR/lib || \
-        logerr "failed to move libs (32-bit)"
-    logcmd mv $DESTDIR/usr/lib/amd64/lib* $DESTDIR/lib/amd64 || \
-        logerr "failed to move libs (64-bit)"
-    pushd $DESTDIR/usr/lib >/dev/null
-    logcmd ln -s ../../lib/libxml2.so.$VER libxml2.so
-    logcmd ln -s ../../lib/libxml2.so.$VER libxml2.so.2
-    logcmd ln -s ../../lib/libxml2.so.$VER libxml2.so.$VER
-    popd >/dev/null
-    pushd $DESTDIR/usr/lib/amd64 >/dev/null
-    logcmd ln -s ../../../lib/64/libxml2.so.$VER libxml2.so
-    logcmd ln -s ../../../lib/64/libxml2.so.$VER libxml2.so.2
-    logcmd ln -s ../../../lib/64/libxml2.so.$VER libxml2.so.$VER
-    popd>/dev/null
+        install \
+        || logerr "--- Make install failed"
 }
 
 init
@@ -98,10 +65,12 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+python_cleanup
 run_testsuite check
 make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
-fix_python_install
 make_isa_stub
-move_libs
-make_package
+make_package local.mog final.mog
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/libxml2/final.mog
+++ b/build/libxml2/final.mog
@@ -1,0 +1,9 @@
+
+link path=usr/lib/amd64/libxml2.so target=../../../lib/64/libxml2.so.$(VER)
+link path=usr/lib/amd64/libxml2.so.2 target=../../../lib/64/libxml2.so.$(VER)
+link path=usr/lib/amd64/libxml2.so.$(VER) \
+    target=../../../lib/64/libxml2.so.$(VER)
+link path=usr/lib/libxml2.so target=../../lib/libxml2.so.$(VER)
+link path=usr/lib/libxml2.so.2 target=../../lib/libxml2.so.$(VER)
+link path=usr/lib/libxml2.so.$(VER) target=../../lib/libxml2.so.$(VER)
+

--- a/build/libxml2/local.mog
+++ b/build/libxml2/local.mog
@@ -1,1 +1,11 @@
 license COPYING license=MIT
+
+<transform file dir path=usr/share/doc -> drop>
+
+# Reason unknown, inherited from OmniTI
+<transform file path=usr/lib/python2.7/vendor-packages/64/drv_libxml2.py \
+    -> drop>
+
+# Move libs to /lib, to match upstream
+<transform file link path=usr/lib(/amd64)?/lib.* -> edit path usr/lib lib>
+

--- a/build/libxml2/testsuite.log
+++ b/build/libxml2/testsuite.log
@@ -15,30 +15,30 @@ Making all in tests
   CC       testrecurse.o
   CCLD     testrecurse
   CC       testapi.o
-testapi.c:18112:25: warning: 'gen_xmlSchematronPtr' defined but not used [-Wunused-function]
- static xmlSchematronPtr gen_xmlSchematronPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-                         ^
-testapi.c:18115:13: warning: 'des_xmlSchematronPtr' defined but not used [-Wunused-function]
- static void des_xmlSchematronPtr(int no ATTRIBUTE_UNUSED, xmlSchematronPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-             ^
-testapi.c:18132:35: warning: 'gen_xmlSchematronParserCtxtPtr' defined but not used [-Wunused-function]
- static xmlSchematronParserCtxtPtr gen_xmlSchematronParserCtxtPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-                                   ^
-testapi.c:18135:13: warning: 'des_xmlSchematronParserCtxtPtr' defined but not used [-Wunused-function]
- static void des_xmlSchematronParserCtxtPtr(int no ATTRIBUTE_UNUSED, xmlSchematronParserCtxtPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-             ^
-testapi.c:18630:18: warning: 'gen_const_xmlBufPtr' defined but not used [-Wunused-function]
- static xmlBufPtr gen_const_xmlBufPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-                  ^
-testapi.c:18633:13: warning: 'des_const_xmlBufPtr' defined but not used [-Wunused-function]
- static void des_const_xmlBufPtr(int no ATTRIBUTE_UNUSED, const xmlBufPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-             ^
-testapi.c:34629:27: warning: 'gen_xmlSAXHandlerPtr_ptr' defined but not used [-Wunused-function]
- static xmlSAXHandlerPtr * gen_xmlSAXHandlerPtr_ptr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-                           ^
 testapi.c:34632:13: warning: 'des_xmlSAXHandlerPtr_ptr' defined but not used [-Wunused-function]
  static void des_xmlSAXHandlerPtr_ptr(int no ATTRIBUTE_UNUSED, xmlSAXHandlerPtr * val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
-             ^
+             ^~~~~~~~~~~~~~~~~~~~~~~~
+testapi.c:34629:27: warning: 'gen_xmlSAXHandlerPtr_ptr' defined but not used [-Wunused-function]
+ static xmlSAXHandlerPtr * gen_xmlSAXHandlerPtr_ptr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+                           ^~~~~~~~~~~~~~~~~~~~~~~~
+testapi.c:18633:13: warning: 'des_const_xmlBufPtr' defined but not used [-Wunused-function]
+ static void des_const_xmlBufPtr(int no ATTRIBUTE_UNUSED, const xmlBufPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+             ^~~~~~~~~~~~~~~~~~~
+testapi.c:18630:18: warning: 'gen_const_xmlBufPtr' defined but not used [-Wunused-function]
+ static xmlBufPtr gen_const_xmlBufPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+                  ^~~~~~~~~~~~~~~~~~~
+testapi.c:18135:13: warning: 'des_xmlSchematronParserCtxtPtr' defined but not used [-Wunused-function]
+ static void des_xmlSchematronParserCtxtPtr(int no ATTRIBUTE_UNUSED, xmlSchematronParserCtxtPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+testapi.c:18132:35: warning: 'gen_xmlSchematronParserCtxtPtr' defined but not used [-Wunused-function]
+ static xmlSchematronParserCtxtPtr gen_xmlSchematronParserCtxtPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+testapi.c:18115:13: warning: 'des_xmlSchematronPtr' defined but not used [-Wunused-function]
+ static void des_xmlSchematronPtr(int no ATTRIBUTE_UNUSED, xmlSchematronPtr val ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+             ^~~~~~~~~~~~~~~~~~~~
+testapi.c:18112:25: warning: 'gen_xmlSchematronPtr' defined but not used [-Wunused-function]
+ static xmlSchematronPtr gen_xmlSchematronPtr(int no ATTRIBUTE_UNUSED, int nr ATTRIBUTE_UNUSED) {
+                         ^~~~~~~~~~~~~~~~~~~~
   CCLD     testapi
   CC       testchar.o
   CCLD     testchar
@@ -89,7 +89,7 @@ testapi.c:34632:13: warning: 'des_xmlSAXHandlerPtr_ptr' defined but not used [-W
 ## C14N exclusive without comments regression tests
 ## C14N 1.1 without comments regression tests
 ## Catalog and Threads regression tests
-Total 3146 tests, no errors
+Total 3147 tests, no errors
 .........
 ## Parsing recursive test cases
 ## Parsing non-recursive test cases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -38,7 +38,7 @@
 | library/idnkit			| 2.3			| https://jprs.co.jp/idn/index-e.html
 | library/libidn			| 1.33			| http://git.savannah.gnu.org/cgit/libidn.git/refs/tags
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
-| library/libxml2			| 2.9.6			| http://xmlsoft.org/news.html
+| library/libxml2			| 2.9.7			| https://github.com/GNOME/libxml2/releases http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.0.20171104		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.27.0		| https://github.com/nghttp2/nghttp2/releases


### PR DESCRIPTION
Also:
* drop examples from package
* remove stray `.la` files which were included in previous package versions by mistake
* clean-up the build script in favour of mog actions
* change package source link.