### PR TITLE
pycurl: Build with -std=c99

### DIFF
--- a/build/python27/pycurl/build.sh
+++ b/build/python27/pycurl/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,8 +18,7 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
@@ -34,6 +33,9 @@ VER=7.43.0
 SUMMARY="Python bindings for libcurl"
 DESC="PycURL provides a thin layer of Python bindings on top of libcurl."
 
+# Need to export this so it's picked up by setup.py
+export CFLAGS="-std=c99"
+
 . $SRCDIR/../common.sh
 
 init
@@ -43,3 +45,6 @@ prep_build
 python_build
 make_package local.mog ../final.mog
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker


### PR DESCRIPTION
This used to be inherited from the Python build but this was removed in #397 