### PR TITLE
curl: update to 7.57.0

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,18 +18,18 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions
 . ../../lib/functions.sh
 
-PROG=curl       # App name
-VER=7.56.1      # App version
-PKG=web/curl    # Package name (without prefix)
+PROG=curl
+VER=7.57.0
+PKG=web/curl
 SUMMARY="$PROG - command line tool for transferring data with URL syntax"
 DESC="$SUMMARY"
 
@@ -38,6 +38,15 @@ DEPENDS_IPS="web/ca-bundle library/libidn"
 CONFIGURE_OPTS="--enable-thread --with-ca-bundle=/etc/ssl/cacert.pem"
 # curl actually has arch-dependent headers. Boo.
 CONFIGURE_OPTS_64="$CONFIGURE_OPTS_64 --includedir=$PREFIX/include/amd64"
+
+# Build backwards so that the 32-bit version is available for the test-suite.
+# Otherwise there are test failures because some tests preload a library
+# to override the hostname. If the library is 64-bit then the test aborts
+# when runtests.pl calls a 32-bit shell to spawn a sub-process.
+build() {
+    [[ $BUILDARCH =~ ^(64|both)$ ]] && build64
+    [[ $BUILDARCH =~ ^(32|both)$ ]] && build32
+}
 
 LIBTOOL_NOSTDLIB=libtool
 TESTSUITE_FILTER="^TEST[A-Z]"
@@ -51,3 +60,6 @@ run_testsuite
 make_isa_stub
 make_package
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/curl/patches/series
+++ b/build/curl/patches/series
@@ -1,0 +1,1 @@
+tests.patch

--- a/build/curl/patches/tests.patch
+++ b/build/curl/patches/tests.patch
@@ -1,0 +1,43 @@
+
+Curl's tests run from perl which invokes curl commands via system().
+Perls's system() uses /bin/sh which on OmniOS is a link to the 32-bit
+version of ksh93
+ksh ends up removing the empty parameter to --[no]proxy without this patch.
+
+Only in curl-7.57.0.patch/tests/data: Makefile
+diff -ru curl-7.57.0/tests/data/test1004 curl-7.57.0.patch/tests/data/test1004
+--- curl-7.57.0/tests/data/test1004	2017-11-09 22:40:31.000000000 +0000
++++ curl-7.57.0.patch/tests/data/test1004	2017-11-29 15:07:54.375245273 +0000
+@@ -36,7 +36,7 @@
+ HTTP GET with empty proxy
+  </name>
+  <command>
+-http://%HOSTIP:%HTTPPORT/1004 --proxy ""
++http://%HOSTIP:%HTTPPORT/1004 --proxy "''"
+ </command>
+ </client>
+ 
+diff -ru curl-7.57.0/tests/data/test1254 curl-7.57.0.patch/tests/data/test1254
+--- curl-7.57.0/tests/data/test1254	2017-11-09 22:40:36.000000000 +0000
++++ curl-7.57.0.patch/tests/data/test1254	2017-11-29 15:07:34.738745881 +0000
+@@ -33,7 +33,7 @@
+ NO_PROXY=example.com
+ </setenv>
+ <command>
+-http://somewhere.example.com/1254 --proxy http://%HOSTIP:%HTTPPORT --noproxy ""
++http://somewhere.example.com/1254 --proxy http://%HOSTIP:%HTTPPORT --noproxy "''"
+ </command>
+ </client>
+ 
+diff -ru curl-7.57.0/tests/data/test1257 curl-7.57.0.patch/tests/data/test1257
+--- curl-7.57.0/tests/data/test1257	2017-11-09 22:40:36.000000000 +0000
++++ curl-7.57.0.patch/tests/data/test1257	2017-11-29 15:06:40.559644485 +0000
+@@ -34,7 +34,7 @@
+ NO_PROXY=example.com
+ </setenv>
+ <command>
+-http://somewhere.example.com/1257 --noproxy ""
++http://somewhere.example.com/1257 --noproxy "''"
+ </command>
+ </client>
+ 

--- a/build/curl/testsuite.log
+++ b/build/curl/testsuite.log
@@ -1,3 +1,3 @@
-TESTDONE: 864 tests out of 867 reported OK: 99%
-TESTFAIL: These test cases failed: 1004 1254 1257 
-TESTDONE: 1138 tests were considered during 308 seconds.
+TESTDONE: 906 tests out of 907 reported OK: 99%
+TESTFAIL: These test cases failed: 1004 
+TESTDONE: 1164 tests were considered during 308 seconds.

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -82,7 +82,7 @@
 | text/gnu-sed				| 4.4			| http://git.savannah.gnu.org/cgit/sed.git/refs/tags
 | text/groff				| 1.22.3		| https://ftp.gnu.org/gnu/groff/
 | text/less				| 487			| https://ftp.gnu.org/gnu/less/
-| web/curl				| 7.56.1		| https://curl.haxx.se/download.html
+| web/curl				| 7.57.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.19.2		| https://git.savannah.gnu.org/cgit/wget.git/refs/tags
 | library/glib2				| 2.54.2		| https://download.gnome.org/sources/glib/cache.json | 2.55.0 is an unstable/dev version.
 | developer/gnu-binutils		| 2.25			| https://ftp.gnu.org/gnu/binutils | On hold pending illumos fix https://www.illumos.org/issues/6653


### PR DESCRIPTION
and fix two failing test cases.
(test 1004 still fails due to OmniOS having a different system shell than expected by the test-suite).

Converts a lot of other tests from SKIP to OK too.

Already backported as #410  & #411 