### PR TITLE
Drop all dtrace objects from client package

### DIFF
--- a/build/openssh/client.mog
+++ b/build/openssh/client.mog
@@ -3,8 +3,7 @@
 <transform file dir path=lib/svc/manifest/network -> drop>
 <transform file dir path=lib/svc/method -> drop>
 <transform file path=usr/libexec/sftp-server -> drop>
-<transform dir path=usr/lib/dtrace -> drop>
-<transform file path=usr/lib/dtrace/sftp.d -> drop>
+<transform file dir path=usr/lib/dtrace -> drop>
 <transform dir path=usr/sbin -> drop>
 <transform file path=usr/sbin/sshd -> drop>
 <transform file path=usr/share/man/man4/moduli.4 -> drop>


### PR DESCRIPTION
With the switch to 64-bit openssh, the dtrace helper has moved to `/usr/lib/dtrace/64/` and isn't being dropped by the current lines in `client.mog`.
Fixing that and generalising the rule.