### PR TITLE
hg: update to 4.4.2

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -28,7 +28,7 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.4.1
+VER=4.4.2
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -24,7 +24,7 @@
 | developer/parser/bison		| 3.0.4			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.15.1		| https://www.kernel.org/pub/software/scm/git
-| developer/versioning/mercurial	| 4.4.1			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/mercurial	| 4.4.2			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.0.586		| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.28			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags


### PR DESCRIPTION
```
hadfl@mars:~$ hg version
Mercurial Distributed SCM (version 4.4.2)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2017 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```