### PR TITLE
dma added (as default MTA)

### DIFF
--- a/build/dma/build.sh
+++ b/build/dma/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+#
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=dma
+VER=0.11
+VERHUMAN=$VER
+PKG=service/network/smtp/dma
+SUMMARY="The DragonFly Mail Agent"
+DESC="$SUMMARY"
+
+BUILDARCH=32
+
+# adding ASLR flags to compiler and linker since
+# dma:             gets ASLR if linker flag is set
+# dma-mbox-create: gets ASLR if compiler flag is set
+export CFLAGS="-O -pipe -Wl,-z,aslr -DHAVE_STRLCPY -DHAVE_GETPROGNAME"
+export LDADD="-Wl,-z,aslr -lssl -lcrypto -lresolv -lsocket -lnsl"
+
+export PREFIX=/usr
+export SBIN=${PREFIX}/lib/smtp/dma
+export LIBEXEC=${PREFIX}/lib/smtp/dma
+
+# No configure
+configure32() {
+    export CC=gcc
+    export YACC=bison
+    export LEX=flex
+}
+
+make_install() {
+    logmsg "--- make install"
+    logcmd $MAKE DESTDIR=${DESTDIR} install install-spool-dirs install-etc || \
+        logerr "--- Make install failed"
+
+    logmsg "--- copying aliases template"
+    logcmd mkdir -p $DESTDIR/etc/dma || logerr "--- failed to create dir"
+    logcmd cp $SRCDIR/files/aliases $DESTDIR/etc/dma/aliases || \
+        logerr "--- failed to copy aliases"
+}
+
+init
+download_source $PROG "v$VER"
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/dma/files/aliases
+++ b/build/dma/files/aliases
@@ -1,0 +1,10 @@
+##
+# The aliases file is of the format
+# 	nam: dest1 dest2 ...
+# In this case, mails to nam will instead be delivered to dest1 and
+# dest2, which in turn could be entries in /etc/aliases.  The special
+# name ‘*’ can be used to create a catch-all alias, which gets used
+# if no other matching alias is found.  Use the catch-all alias only
+# if you don't want any local mail to be delivered.
+##
+

--- a/build/dma/local.mog
+++ b/build/dma/local.mog
@@ -1,0 +1,48 @@
+# CDDL HEADER START
+# 
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2017 OmniOS Community Edition.  All rights reserved.
+# Use is subject to license terms.
+user username=dma uid=26 group=mail gcos-field="DragonFly Mail Agent" \
+    home-dir=/ password=NP
+
+<transform dir path=var/mail$ -> drop>
+<transform file path=etc/dma/ -> set preserve renamenew>
+<transform file dir path=etc/dma -> set group mail>
+<transform file path=usr/lib/smtp/dma -> set group mail>
+<transform file path=usr/lib/smtp/dma/dma -> set mode 2755>
+<transform file path=usr/lib/smtp/dma/dma-mbox-create -> set mode 4754>
+<transform dir path=var/spool/dma -> set mode 0770>
+<transform dir path=var/spool/dma -> set group mail>
+
+# Mediated symlinks
+link path=usr/bin/mailq mediator=mta mediator-implementation=dma \
+    mediator-priority=vendor target=../lib/smtp/dma/dma
+link path=usr/lib/sendmail mediator=mta mediator-implementation=dma \
+    mediator-priority=vendor target=../lib/smtp/dma/dma
+link path=usr/sbin/sendmail mediator=mta mediator-implementation=dma \
+    mediator-priority=vendor target=../lib/smtp/dma/dma
+link path=usr/sbin/newaliases mediator=mta mediator-implementation=dma \
+    mediator-priority=vendor target=../lib/smtp/dma/dma
+link path=etc/aliases mediator=mta mediator-implementation=dma \
+    mediator-priority=vendor target=./dma/aliases
+
+license LICENSE license=BSD

--- a/build/dma/patches/dma-illumos-port.patch
+++ b/build/dma/patches/dma-illumos-port.patch
@@ -1,0 +1,381 @@
+commit a91f6a0d5499d46e0fe0facadd966a88ae3914b8
+Author: Dale Ghent <daleg@omniti.com>
+Date:   Fri Feb 5 17:18:53 2016 -0500
+
+    Port DMA to illumos
+
+diff -pruN '--exclude=*.orig' dma-0.11~/Makefile dma-0.11/Makefile
+--- dma-0.11~/Makefile	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/Makefile	2017-12-06 15:52:09.814914221 +0000
+@@ -50,8 +50,8 @@ clean:
+ install: all
+ 	${INSTALL} -d ${DESTDIR}${SBIN}
+ 	${INSTALL} -d ${DESTDIR}${MAN}/man8 ${DESTDIR}${LIBEXEC}
+-	${INSTALL} -m 2755 -o root -g mail dma ${DESTDIR}${SBIN}
+-	${INSTALL} -m 4754 -o root -g mail dma-mbox-create ${DESTDIR}${LIBEXEC}
++	${INSTALL} dma ${DESTDIR}${SBIN}
++	${INSTALL} dma-mbox-create ${DESTDIR}${LIBEXEC}
+ 	${INSTALL} -m 0644 dma.8 ${DESTDIR}${MAN}/man8/
+ 
+ sendmail-link:
+@@ -61,8 +61,8 @@ mailq-link:
+ 	cd ${DESTDIR}${SBIN} && ${LN} ${SYMLINK} dma mailq
+ 
+ install-spool-dirs:
+-	${INSTALL} -d -m 2775 -o root -g mail ${DESTDIR}${DMASPOOL}
+-	${INSTALL} -d -m 2775 -o root -g mail ${DESTDIR}${VARMAIL}
++	${INSTALL} -d -m 775 ${DESTDIR}${DMASPOOL}
++	${INSTALL} -d -m 775 ${DESTDIR}${VARMAIL}
+ 
+ permissions:
+ 	-${CHGRP} mail ${DESTDIR}${VARMAIL}/*
+@@ -74,14 +74,14 @@ install-etc:
+ 	@if [ -e ${DESTDIR}${CONFDIR}/dma.conf ]; then \
+ 		echo "Not overwriting ${DESTDIR}${CONFDIR}/dma.conf."; \
+ 	else \
+-		echo ${INSTALL} -m 644 -o root -g mail dma.conf ${DESTDIR}${CONFDIR}; \
+-		${INSTALL} -m 644 -o root -g mail dma.conf ${DESTDIR}${CONFDIR}; \
++		echo ${INSTALL} -m 644 dma.conf ${DESTDIR}${CONFDIR}; \
++		${INSTALL} -m 644 dma.conf ${DESTDIR}${CONFDIR}; \
+ 	fi
+ 	@if [ -e ${DESTDIR}${CONFDIR}/auth.conf ]; then \
+ 		echo "Not overwriting ${DESTDIR}${CONFDIR}/auth.conf."; \
+ 	else \
+-		echo ${INSTALL} -m 640 -o root -g mail auth.conf ${DESTDIR}${CONFDIR}; \
+-		${INSTALL} -m 640 -o root -g mail auth.conf ${DESTDIR}${CONFDIR}; \
++		echo ${INSTALL} -m 640 auth.conf ${DESTDIR}${CONFDIR}; \
++		${INSTALL} -m 640 auth.conf ${DESTDIR}${CONFDIR}; \
+ 	fi
+ 
+ aliases_parse.c: aliases_parse.y
+diff -pruN '--exclude=*.orig' dma-0.11~/crypto.c dma-0.11/crypto.c
+--- dma-0.11~/crypto.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/crypto.c	2017-12-06 15:52:09.815066006 +0000
+@@ -221,10 +221,10 @@ hmac_md5(unsigned char *text, int text_l
+          */
+ 
+         /* start out by storing key in pads */
+-        bzero( k_ipad, sizeof k_ipad);
+-        bzero( k_opad, sizeof k_opad);
+-        bcopy( key, k_ipad, key_len);
+-        bcopy( key, k_opad, key_len);
++        memset(k_ipad, 0, sizeof (k_ipad));
++        memset(k_opad, 0, sizeof (k_opad));
++        memmove(k_ipad, key, key_len);
++        memmove(k_opad, key, key_len);
+ 
+         /* XOR key with ipad and opad values */
+         for (i=0; i<64; i++) {
+diff -pruN '--exclude=*.orig' dma-0.11~/dma.8 dma-0.11/dma.8
+--- dma-0.11~/dma.8	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/dma.8	2017-12-06 15:52:09.815189707 +0000
+@@ -332,9 +332,7 @@ This value will be overridden when the
+ flag is used.
+ .El
+ .Sh SEE ALSO
+-.Xr mailaddr 7 ,
+ .Xr mailwrapper 8 ,
+-.Xr sendmail 8
+ .Rs
+ .%A "J. B. Postel"
+ .%T "Simple Mail Transfer Protocol"
+@@ -350,11 +348,6 @@ flag is used.
+ .%T "SMTP Service Extension for Secure SMTP over TLS"
+ .%O RFC 2487
+ .Re
+-.Sh HISTORY
+-The
+-.Nm
+-utility first appeared in
+-.Dx 1.11 .
+ .Sh AUTHORS
+ .An -nosplit
+ .Nm
+diff -pruN '--exclude=*.orig' dma-0.11~/dma.c dma-0.11/dma.c
+--- dma-0.11~/dma.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/dma.c	2017-12-06 15:52:09.815408429 +0000
+@@ -94,7 +94,7 @@ sighup_handler(int signo)
+ }
+ 
+ static char *
+-set_from(struct queue *queue, const char *osender)
++set_from(struct dma_queue *queue, const char *osender)
+ {
+ 	const char *addr;
+ 	char *sender;
+@@ -153,7 +153,7 @@ read_aliases(void)
+ }
+ 
+ static int
+-do_alias(struct queue *queue, const char *addr)
++do_alias(struct dma_queue *queue, const char *addr)
+ {
+ 	struct alias *al;
+         struct stritem *sit;
+@@ -173,7 +173,7 @@ do_alias(struct queue *queue, const char
+ }
+ 
+ int
+-add_recp(struct queue *queue, const char *str, int expand)
++add_recp(struct dma_queue *queue, const char *str, int expand)
+ {
+ 	struct qitem *it, *tit;
+ 	struct passwd *pw;
+@@ -240,7 +240,7 @@ out:
+ }
+ 
+ static struct qitem *
+-go_background(struct queue *queue)
++go_background(struct dma_queue *queue)
+ {
+ 	struct sigaction sa;
+ 	struct qitem *it;
+@@ -252,7 +252,7 @@ go_background(struct queue *queue)
+ 	}
+ 	daemonize = 0;
+ 
+-	bzero(&sa, sizeof(sa));
++	memset(&sa, 0, sizeof (sa));
+ 	sa.sa_handler = SIG_IGN;
+ 	sigaction(SIGCHLD, &sa, NULL);
+ 
+@@ -372,7 +372,7 @@ bounce:
+ }
+ 
+ void
+-run_queue(struct queue *queue)
++run_queue(struct dma_queue *queue)
+ {
+ 	struct qitem *it;
+ 
+@@ -385,7 +385,7 @@ run_queue(struct queue *queue)
+ }
+ 
+ static void
+-show_queue(struct queue *queue)
++show_queue(struct dma_queue *queue)
+ {
+ 	struct qitem *it;
+ 	int locked = 0;	/* XXX */
+@@ -421,7 +421,7 @@ main(int argc, char **argv)
+ {
+ 	struct sigaction act;
+ 	char *sender = NULL;
+-	struct queue queue;
++	struct dma_queue queue;
+ 	int i, ch;
+ 	int nodot = 0, showq = 0, queue_only = 0;
+ 	int recp_from_header = 0;
+@@ -454,7 +454,7 @@ main(int argc, char **argv)
+ 	atexit(deltmp);
+ 	init_random();
+ 
+-	bzero(&queue, sizeof(queue));
++	memset(&queue, 0, sizeof (queue));
+ 	LIST_INIT(&queue.queue);
+ 
+ 	if (strcmp(argv[0], "mailq") == 0) {
+diff -pruN '--exclude=*.orig' dma-0.11~/dma.h dma-0.11/dma.h
+--- dma-0.11~/dma.h	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/dma.h	2017-12-06 15:52:09.815542120 +0000
+@@ -81,7 +81,7 @@
+ #define SPOOL_FLUSHFILE	"flush"
+ 
+ #ifndef DMA_ROOT_USER
+-#define DMA_ROOT_USER	"mail"
++#define DMA_ROOT_USER	"dma"
+ #endif
+ #ifndef DMA_GROUP
+ #define DMA_GROUP	"mail"
+@@ -118,7 +118,7 @@ struct qitem {
+ };
+ LIST_HEAD(queueh, qitem);
+ 
+-struct queue {
++struct dma_queue {
+ 	struct queueh queue;
+ 	char *id;
+ 	FILE *mailf;
+@@ -205,16 +205,16 @@ int base64_decode(const char *, void *);
+ /* dma.c */
+ #define EXPAND_ADDR	1
+ #define EXPAND_WILDCARD	2
+-int add_recp(struct queue *, const char *, int);
+-void run_queue(struct queue *);
++int add_recp(struct dma_queue *, const char *, int);
++void run_queue(struct dma_queue *);
+ 
+ /* spool.c */
+-int newspoolf(struct queue *);
+-int linkspool(struct queue *);
+-int load_queue(struct queue *);
++int newspoolf(struct dma_queue *);
++int linkspool(struct dma_queue *);
++int load_queue(struct dma_queue *);
+ void delqueue(struct qitem *);
+ int acquirespool(struct qitem *);
+-void dropspool(struct queue *, struct qitem *);
++void dropspool(struct dma_queue *, struct qitem *);
+ int flushqueue_since(unsigned int);
+ int flushqueue_signal(void);
+ 
+@@ -223,7 +223,7 @@ int deliver_local(struct qitem *);
+ 
+ /* mail.c */
+ void bounce(struct qitem *, const char *);
+-int readmail(struct queue *, int, int);
++int readmail(struct dma_queue *, int, int);
+ 
+ /* util.c */
+ const char *hostname(void);
+diff -pruN '--exclude=*.orig' dma-0.11~/dns.c dma-0.11/dns.c
+--- dma-0.11~/dns.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/dns.c	2017-12-06 15:52:09.815653796 +0000
+@@ -43,6 +43,10 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
++#if defined(__sun)
++#include <sys/sysmacros.h>
++#endif
++
+ #include "dma.h"
+ 
+ static int
+@@ -109,7 +113,7 @@ add_host(int pref, const char *host, int
+ 		p->pref = pref;
+ 		p->ai = *res;
+ 		p->ai.ai_addr = NULL;
+-		bcopy(res->ai_addr, &p->sa, p->ai.ai_addrlen);
++		memmove(&p->sa, res->ai_addr, p->ai.ai_addrlen);
+ 
+ 		getnameinfo((struct sockaddr *)&p->sa, p->ai.ai_addrlen,
+ 			    p->addr, sizeof(p->addr),
+diff -pruN '--exclude=*.orig' dma-0.11~/local.c dma-0.11/local.c
+--- dma-0.11~/local.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/local.c	2017-12-06 15:52:09.815758331 +0000
+@@ -63,7 +63,7 @@ create_mbox(const char *name)
+ 	/*
+ 	 * We need to enable SIGCHLD temporarily so that waitpid works.
+ 	 */
+-	bzero(&sa, sizeof(sa));
++	memset(&sa, 0, sizeof (sa));
+ 	sa.sa_handler = SIG_DFL;
+ 	sigaction(SIGCHLD, &sa, &osa);
+ 
+diff -pruN '--exclude=*.orig' dma-0.11~/mail.c dma-0.11/mail.c
+--- dma-0.11~/mail.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/mail.c	2017-12-06 15:52:09.815911294 +0000
+@@ -44,7 +44,7 @@
+ void
+ bounce(struct qitem *it, const char *reason)
+ {
+-	struct queue bounceq;
++	struct dma_queue bounceq;
+ 	char line[1000];
+ 	size_t pos;
+ 	int error;
+@@ -55,7 +55,7 @@ bounce(struct qitem *it, const char *rea
+ 		exit(EX_SOFTWARE);
+ 	}
+ 
+-	bzero(&bounceq, sizeof(bounceq));
++	memset(&bounceq, 0, sizeof (bounceq));
+ 	LIST_INIT(&bounceq.queue);
+ 	bounceq.sender = "";
+ 	if (add_recp(&bounceq, it->sender, EXPAND_WILDCARD) != 0)
+@@ -160,7 +160,7 @@ struct parse_state {
+  * XXX local addresses will need treatment
+  */
+ static int
+-parse_addrs(struct parse_state *ps, char *s, struct queue *queue)
++parse_addrs(struct parse_state *ps, char *s, struct dma_queue *queue)
+ {
+ 	char *addr;
+ 
+@@ -171,7 +171,7 @@ again:
+ 
+ 	case START:
+ 		/* init our data */
+-		bzero(ps, sizeof(*ps));
++		memset(ps, 0, sizeof (*ps));
+ 
+ 		/* skip over header name */
+ 		while (*s != ':')
+@@ -342,7 +342,7 @@ newaddr:
+ }
+ 
+ int
+-readmail(struct queue *queue, int nodot, int recp_from_header)
++readmail(struct dma_queue *queue, int nodot, int recp_from_header)
+ {
+ 	struct parse_state parse_state;
+ 	char line[1000];	/* by RFC2822 */
+diff -pruN '--exclude=*.orig' dma-0.11~/spool.c dma-0.11/spool.c
+--- dma-0.11~/spool.c	2016-02-07 13:41:49.000000000 +0000
++++ dma-0.11/spool.c	2017-12-06 15:52:09.816064117 +0000
+@@ -69,7 +69,7 @@
+  */
+ 
+ int
+-newspoolf(struct queue *queue)
++newspoolf(struct dma_queue *queue)
+ {
+ 	char fn[PATH_MAX+1];
+ 	struct stat st;
+@@ -151,16 +151,16 @@ writequeuef(struct qitem *it)
+ }
+ 
+ static struct qitem *
+-readqueuef(struct queue *queue, char *queuefn)
++readqueuef(struct dma_queue *queue, char *queuefn)
+ {
+ 	char line[1000];
+-	struct queue itmqueue;
++	struct dma_queue itmqueue;
+ 	FILE *queuef = NULL;
+ 	char *s;
+ 	char *queueid = NULL, *sender = NULL, *addr = NULL;
+ 	struct qitem *it = NULL;
+ 
+-	bzero(&itmqueue, sizeof(itmqueue));
++	memset(&itmqueue, 0, sizeof (itmqueue));
+ 	LIST_INIT(&itmqueue.queue);
+ 
+ 	queuef = fopen(queuefn, "r");
+@@ -229,7 +229,7 @@ out:
+ }
+ 
+ int
+-linkspool(struct queue *queue)
++linkspool(struct dma_queue *queue)
+ {
+ 	struct stat st;
+ 	struct qitem *it;
+@@ -276,7 +276,7 @@ delfiles:
+ }
+ 
+ int
+-load_queue(struct queue *queue)
++load_queue(struct dma_queue *queue)
+ {
+ 	struct stat sb;
+ 	struct qitem *it;
+@@ -285,7 +285,7 @@ load_queue(struct queue *queue)
+ 	char *queuefn;
+ 	char *mailfn;
+ 
+-	bzero(queue, sizeof(*queue));
++	memset(queue, 0, sizeof (*queue));
+ 	LIST_INIT(&queue->queue);
+ 
+ 	spooldir = opendir(config.spooldir);
+@@ -382,7 +382,7 @@ fail:
+ }
+ 
+ void
+-dropspool(struct queue *queue, struct qitem *keep)
++dropspool(struct dma_queue *queue, struct qitem *keep)
+ {
+ 	struct qitem *it;
+ 

--- a/build/dma/patches/mxpref.patch
+++ b/build/dma/patches/mxpref.patch
@@ -1,0 +1,23 @@
+From bf003f40b4e251df73d4be0c3d8a282ce95f03e1 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <omnios@citrus-it.co.uk>
+Date: Wed, 6 Dec 2017 09:36:43 +0000
+Subject: [PATCH] Prefer IPv4 MX records over IPv6
+
+diff -pruN '--exclude=*.orig' dma-0.11~/build/dma/patches/mxpref.patch dma-0.11/build/dma/patches/mxpref.patch
+--- dma-0.11~/build/dma/patches/mxpref.patch	1970-01-01 01:00:00.000000000 +0000
++++ dma-0.11/build/dma/patches/mxpref.patch	2017-12-06 15:52:09.884416787 +0000
+@@ -0,0 +1,14 @@
++diff -ru dma-0.11~/dns.c dma-0.11/dns.c
++--- dma-0.11~/dns.c	2017-12-06 08:58:36.863762284 +0000
+++++ dma-0.11/dns.c	2017-12-06 09:31:35.778547802 +0000
++@@ -60,8 +60,8 @@
++ 	if (v != 0)
++ 		return (v);
++ 
++-	/* sort PF_INET6 before PF_INET */
++-	v = - (ha->ai.ai_family - hb->ai.ai_family);
+++	/* sort PF_INET before PF_INET6 */
+++	v = (ha->ai.ai_family - hb->ai.ai_family);
++ 	return (v);
++ }
++ 

--- a/build/dma/patches/series
+++ b/build/dma/patches/series
@@ -1,0 +1,2 @@
+dma-illumos-port.patch
+mxpref.patch

--- a/build/entire/entire.p5m
+++ b/build/entire/entire.p5m
@@ -274,7 +274,7 @@ depend fmri=service/file-system/smb@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/hal@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/network/network-clients@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/network/ntp@4.2.8,5.11-@PVER@ type=require
-depend fmri=service/network/smtp/sendmail@8.14.4,5.11-@PVER@ type=group
+depend fmri=service/network/smtp/dma@0.11,5.11-@PVER@ type=require
 depend fmri=service/picl@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/resource-pools@0.5.11,5.11-@PVER@ type=require
 depend fmri=service/storage/removable-media@0.5.11,5.11-@PVER@ type=require

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -102,6 +102,7 @@ runtime/perl				5.26
 runtime/python-27			2.7
 security/sudo				1.8
 service/network/ntp			4.2.8
+service/network/smtp/dma		0.11
 shell/bash				4.4
 shell/pipe-viewer			1.6
 shell/tcsh				6.20.0

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -22,6 +22,29 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
     * openssh daemon
     * TBC...
 
+* The default mail submission agent is now `Dragonfly Mail Agent (dma)` rather
+  than sendmail. In a default installation, `/usr/lib/sendmail` points to
+  `dma` and can deliver email messages to local users and Internet recipients.
+  Dragonfly supports TLS and SMTP authentication out of the box - see
+  `/etc/dma/dma.conf` and `man dma` for available options.
+  There are now three mediated MTA/MSA packages in OmniOS, `dma`, `sendmail`
+  and `mailwrapper`; only `dma` is installed by default. To switch between
+  them, install the appropriate package and then configure the `mta` mediator
+  implementation, for example:
+    ```
+	# pkg install service/network/smtp/sendmail
+
+	# pkg mediator -a mta
+	MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
+	mta      system            system     mailwrapper
+	mta      system            system     sendmail
+	mta      vendor            vendor     dma
+
+	# pkg set-mediator -I sendmail mta
+    ```
+  Mailwrapper is still available to support use of packages from non-IPS
+  repositories such as _pkgsrc_ via `/etc/mailer.conf`
+
 * `openssh` has been upgraded to 7.6p1. This version drops support for
   SSH protocol version 1, RSA keys under 1024 bits in length and a number
   of old ciphers and MACs. Refer to

--- a/doc/baseline
+++ b/doc/baseline
@@ -466,6 +466,7 @@ omnios service/network/network-servers
 omnios service/network/nis
 omnios service/network/ntp
 omnios service/network/slp
+omnios service/network/smtp/dma
 omnios service/network/smtp/sendmail
 omnios service/network/snmp/mibiisa o
 omnios service/network/telnet

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -62,6 +62,7 @@
 | runtime/python-27			| 2.7.14		| https://www.python.org/downloads/source/
 | security/sudo				| 1.8.21p2		| https://www.sudo.ws/
 | service/network/ntp			| 4.2.8p10		| http://www.ntp.org/downloads.html
+| service/network/smtp/dma		| 0.11			| https://github.com/corecode/dma/releases
 | shell/bash				| 4.4.12		| https://ftp.gnu.org/gnu/bash/
 | shell/bash-patchlvl			| 012			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml


### PR DESCRIPTION
This PR adds "The DragonFly Mail Agent (dma)". `dma` will be the default MTA for a fresh install from r26 on (see r151026 project page). Requirement for `mailwrapper` will be dropped as it is not necessary on an IPS mediated system  (Mailwrapper is still available to support use of packages from non-IPS repositories such as _pkgsrc_; see also: http://lists.omniti.com/pipermail/omnios-discuss/2015-March/004437.html)

> There are now three mediated MTA/MSA packages in OmniOS, `dma`, `sendmail` and `mailwrapper`; only `dma` is installed by default. To switch between them, install the appropriate package and then configure the `mta` mediator implementation.

Major parts for patches taken from @daleghent: https://github.com/corecode/dma/pull/39#issuecomment-189510297

@citrus-it did some testing:
- sending to local users and internet email addresses;
- sending using mailx (e.g. used by nightly.sh);
- FMA mail alerts;
- immediate TLS and STARTTLS;
- CRAM-MD5 AUTH & AUTH LOGIN over TLS.

