### PR TITLE
Remove packages from entire and make others optional

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -1,3 +1,12 @@
+#
+# The format of this file is tab-separated fields as follows:
+#
+#	<pkg>	<minimum version>	<dependency type>	<flags>
+#
+# where flags can include:
+#
+#	F	- Add a facet to allow this line to be selectively disabled.
+#
 incorporation/jeos/illumos-gate			11	incorporate
 incorporation/jeos/illumos-gate			11	require
 incorporation/jeos/omnios-userland		11	incorporate
@@ -118,7 +127,6 @@ driver/storage/smp				0.5.11	require
 driver/storage/vioblk				0.5.11	require
 driver/usb					0.5.11	require
 driver/usb/ugen					0.5.11	require
-driver/virtualization/kvm			1.0.3	require
 driver/xvm/pv					0.5.11	require
 editor/vim					8.0	require
 file/gnu-coreutils				8	require
@@ -249,13 +257,10 @@ locale/zh_tw					0.5.11	require
 naming/ldap					0.5.11	require
 network/bridging				0.5.11	require
 network/dns/bind				9.10	require
-network/ftp					0.5.11	require
+network/ftp					0.5.11	optional
 network/ipfilter				0.5.11	require
-network/iscsi/initiator				0.5.11	require
-network/iscsi/iser				0.5.11	require
-network/openssh					7.6	require
-network/openssh-server				7.6	require
-network/telnet					0.5.11	require
+network/openssh-server				7.6	optional
+network/telnet					0.5.11	optional
 package/pkg					0.5.11	require
 release/name					0.5.11	require
 release/notices					0.5.11	require
@@ -265,21 +270,17 @@ runtime/perl/module/sun-solaris			0.5.11	require
 runtime/python-27				2.7	require
 security/sudo					1.8	require
 service/fault-management			0.5.11	require
-service/file-system/nfs				0.5.11	require
-service/file-system/smb				0.5.11	require
 service/hal					0.5.11	require
 service/network/network-clients			0.5.11	require
-service/network/ntp				4.2.8	require
-service/network/smtp/dma			0.11	require
+service/network/ntp				4.2.8	optional
+service/network/smtp/dma			0.11	require		F
 service/picl					0.5.11	require
 service/resource-pools				0.5.11	require
 service/storage/removable-media			0.5.11	require
 shell/bash					4.4	require
 shell/pipe-viewer				1.6	require
-shell/tcsh					6.20.0	require
-shell/zsh					5.4	require
 system/accounting/legacy			0.5.11	require
-system/boot/grub				0.97	require
+system/boot/grub				0.97	require		F
 system/boot/loader				1.1	require
 system/boot/real-mode				0.5.11	require
 system/boot/wanboot				0.5.11	require
@@ -290,8 +291,6 @@ system/data/terminfo				0.5.11	require
 system/data/zoneinfo				2017.2	require
 system/extended-system-utilities		0.5.11	require
 system/file-system/autofs			0.5.11	require
-system/file-system/nfs				0.5.11	require
-system/file-system/smb				0.5.11	require
 system/file-system/udfs				0.5.11	require
 system/file-system/zfs				0.5.11	require
 system/flash/fwflash				0.5.11	require
@@ -307,7 +306,6 @@ system/kernel/power				0.5.11	require
 system/kernel/secure-rpc			0.5.11	require
 system/kernel/security/gss			0.5.11	require
 system/kernel/suspend-resume			0.5.11	require
-system/kvm					1.0.3	require
 system/library					0.5.11	require
 system/library/c++/sunpro			0.5.11	require
 system/library/g++-runtime			7	require
@@ -334,7 +332,6 @@ system/network/nis				0.5.11	require
 system/network/routing				0.5.11	require
 system/network/udapl				0.5.11	require
 system/network/udapl/udapl-tavor		0.5.11	require
-system/prerequisite/gnu				0.5.11	require
 system/scheduler/fss				0.5.11	require
 system/storage/fibre-channel/port-utility	0.5.11	require
 system/storage/luxadm				0.5.11	require
@@ -342,8 +339,7 @@ system/xopen/xcu4				0.5.11	require
 system/zones					0.5.11	require
 system/zones/brand/ipkg				0.5.11	require
 system/zones/brand/lipkg			0.5.11	require
-system/zones/brand/lx				0.5.11	require
-terminal/screen					4.6	require
+terminal/screen					4.6	optional
 text/doctools					0.5.11	require
 text/gawk					4.2	require
 text/gnu-diffutils				3.6	require
@@ -355,5 +351,5 @@ text/groff					1.22	require
 text/less					487	require
 text/locale					0.5.11	require
 web/ca-bundle					5.11	require
-web/curl					7	require
-web/wget					1.19	require
+web/curl					7	optional
+web/wget					1.19	optional


### PR DESCRIPTION
This is part of the entire clean-up task.

### Remove several packages from `entire` altogether, making them optional features.

The rationale for this is to force fewer reboots for OmniOS updates. For example, if a server does not use lx-branded zones, then it should not have to reboot just because `system/zones/brand/lx` has been updated. The features which fall into this category are:

* lx-branded zones
* KVM
* NFS
* iSCSI
* SMB/CIFS

### Make several packages optional in `entire`

These packages will be still be installed for a default OmniOS installation including into a non-global zone (see PRs https://github.com/omniosorg/kayak/pull/33 & https://github.com/omniosorg/pkg5/pull/17 for this mechanism) but can subsequently be removed if desired.

* telnet client
* FTP client
* OpenSSH server
* OpenSSH client
* NTP
* Screen
* Curl
* Wget

### Remove packages from `entire`

Some packages are being removed from entire completely because they don't belong there. They won't be present in a default installation but can be added afterwards:

* tcsh
* zsh

### Provide facets for some packages

Some packages are gaining facets to allow selective removal even though they are required packages. This facilitates future testing or edge-cases. There's a new flags field in `entire.pkg` to specify this on a per-package basis.

* Grub
* dma
