### PR TITLE
 pycurl: update to 7.43.0.1 

### DIFF
--- a/build/python27/cheroot/build.sh
+++ b/build/python27/cheroot/build.sh
@@ -32,11 +32,11 @@ VER=6.0.0
 SUMMARY="cheroot - Highly-optimized, pure-python HTTP server"
 DESC="$SUMMARY"
 
+. $SRCDIR/../common.sh
+
 RUN_DEPENDS_IPS+="
     library/python-2/more-itertools-27
 "
-
-. $SRCDIR/../common.sh
 
 init
 download_source $PROG $PROG $VER

--- a/build/python27/pycurl/build.sh
+++ b/build/python27/pycurl/build.sh
@@ -29,12 +29,9 @@
 
 PKG=library/python-2/pycurl-27
 PROG=pycurl
-VER=7.43.0
+VER=7.43.0.1
 SUMMARY="Python bindings for libcurl"
 DESC="PycURL provides a thin layer of Python bindings on top of libcurl."
-
-# Need to export this so it's picked up by setup.py
-export CFLAGS="-std=c99"
 
 . $SRCDIR/../common.sh
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -112,7 +112,7 @@
 | library/python-2/ply-27		| 3.10			| https://pypi.python.org/pypi/ply
 | library/python-2/portend-27		| 2.2			| https://pypi.python.org/pypi/portend
 | library/python-2/pybonjour-27		| 1.1.1			| https://pypi.python.org/pypi/pybonjour
-| library/python-2/pycurl-27		| 7.43.0		| https://pypi.python.org/pypi/pycurl
+| library/python-2/pycurl-27		| 7.43.0.1		| https://pypi.python.org/pypi/pycurl
 | library/python-2/pylint-27		| 1.7.4			| https://pypi.python.org/pypi/pylint
 | library/python-2/pyopenssl-27		| 17.5.0		| https://pypi.python.org/pypi/pyOpenSSL
 | library/python-2/pytz-27		| 2017.3		| https://pypi.python.org/pypi/pytz


### PR DESCRIPTION
pkg test suite results match baseline.

also fixed additional manual dependency for cheroot