### PR TITLE
Fix ListenAddress compatibility patch

### DIFF
--- a/build/openssh/patches/0020-Compatibility-fix-for-ListenAddress.patch
+++ b/build/openssh/patches/0020-Compatibility-fix-for-ListenAddress.patch
@@ -12,7 +12,7 @@ diff -pruN '--exclude=*.orig' openssh-7.6p1~/servconf.c openssh-7.6p1/servconf.c
  process_queued_listen_addrs(ServerOptions *options)
  {
  	u_int i;
-+	int v4port = 0;
++	int v4port = -1;
  
  	if (options->num_ports == 0)
  		options->ports[options->num_ports++] = SSH_DEFAULT_PORT;


### PR DESCRIPTION
If the only `ListenAddress` directive in `sshd_config` is:
    `ListenAddress ::`
then sshd currently only listens on IPv6 whereas it would previously have also listened on IPv4 to retain compatibility with the behaviour of SunSSH.

Long-term we want to drop these compatibility patches entirely but not just yet.

This broke with https://github.com/omniosorg/omnios-build/commit/297a224be5d82809bc7f9e6d9704f56f421b29a8#diff-9d3895d93635e842185781b5fc0eb22fL8


