### PR TITLE
Add sparse zones package

### DIFF
--- a/build/pkg/build.sh
+++ b/build/pkg/build.sh
@@ -27,11 +27,17 @@
 # Load support functions
 . ../../lib/functions.sh
 
-# The following lines let buildctl spot the packages that are actually built
-# by the makefiles in pkg
+# The following lines starting with PKG= let buildctl spot the packages that
+# are actually built by the makefiles in the pkg source. Also build a package
+# list to use later when showing package differences.
 PKG=package/pkg
+PKGLIST=$PKG
 PKG=system/zones/brand/ipkg
+PKGLIST+=" $PKG"
 PKG=system/zones/brand/lipkg
+PKGLIST+=" $PKG"
+PKG=system/zones/brand/sparse
+PKGLIST+=" $PKG"
 SUMMARY="This isn't used, see the makefiles for pkg"
 DESC="This isn't used, see the makefiles for pkg"
 
@@ -120,6 +126,12 @@ init
 clone_source
 build
 package
+
+for pkg in $PKGLIST; do
+    fmri="`pkg list -nvHg $PKGSRVR $pkg | awk '{print $1}'`"
+    logmsg "-- For package $fmri"
+    diff_package $fmri
+done
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -17,11 +17,6 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
 
 ### System Features
 
-* A number of system components now enable Address Space Layout Randomisation
-  (ASLR) by default:
-    * openssh daemon
-    * TBC...
-
 * The default mail submission agent is now `Dragonfly Mail Agent (dma)` rather
   than sendmail. In a default installation, `/usr/lib/sendmail` points to
   `dma` and can deliver email messages to local users and Internet recipients.
@@ -49,6 +44,14 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
 
   Mailwrapper is still available to support use of packages from non-IPS
   repositories such as _pkgsrc_ via `/etc/mailer.conf`
+
+* A number of system components now enable Address Space Layout Randomisation
+  (ASLR) by default:
+    * OpenSSH daemon
+    * pfexecd
+    * rpcbind
+    * Sendmail
+    * Dragonfly Mail Agent
 
 * `openssh` has been upgraded to 7.6p1. This version drops support for
   SSH protocol version 1, RSA keys under 1024 bits in length and a number
@@ -107,8 +110,8 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
 
 ### Deprecated features
 
-* The python `m2crypto` and `typing` modules have been removed as they are no
-  longer required by core OmniOS packages.
+* The python `m2crypto`, `typing`, `lxml` and `pyrex` modules
+  have been removed as they are no longer required by core OmniOS packages.
 
 ### Package changes ([+] Added, [-] Removed, [\*] Changed)
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -45,6 +45,11 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
   Mailwrapper is still available to support use of packages from non-IPS
   repositories such as _pkgsrc_ via `/etc/mailer.conf`
 
+* Experimental support for `sparse` zones. These are linked-ipkg zones that
+  share the `/usr`, `/sbin` and `/lib` directories with the global zone.
+  They are tiny (under 4MiB of installed files) and perfect for isolating
+  VM instances for extra security or to apply more granular resource controls.
+
 * A number of system components now enable Address Space Layout Randomisation
   (ASLR) by default:
     * OpenSSH daemon

--- a/doc/baseline
+++ b/doc/baseline
@@ -661,6 +661,7 @@ omnios system/zones/brand/lipkg
 omnios system/zones/brand/lx
 omnios system/zones/brand/s10
 omnios system/zones/brand/sn1
+omnios system/zones/brand/sparse
 omnios system/zones/internal
 omnios terminal/screen
 omnios terminal/tmux


### PR DESCRIPTION
Add package contents comparison to `pkg` and co.
Catch up with some missed release-notes changes.

See also https://github.com/omniosorg/pkg5/pull/18