### PR TITLE
Add S & Z flags for entire.

### DIFF
--- a/build/entire/build-entire.sh
+++ b/build/entire/build-entire.sh
@@ -30,6 +30,8 @@ set name=pkg.fmri value=pkg://@PKGPUBLISHER@/entire@11,5.11-@PVER@
 set name=pkg.depend.install-hold value=core-os
 set name=pkg.summary value="Minimal set of core system packages"
 set name=pkg.description value="Minimal set of core system packages"
+set name=variant.opensolaris.zone value=global value=nonglobal
+set name=variant.opensolaris.imagetype value=full value=partial
 EOM
 }
 
@@ -45,8 +47,13 @@ add_constraints()
         (
             echo "depend\\c"
             if [[ "$flags" = *F* ]]; then
-                # Add facet
                 echo " facet.entire.$pkg=true\\c"
+            fi
+            if [[ "$flags" = *Z* ]]; then
+                echo " variant.opensolaris.zone=global\\c"
+            fi
+            if [[ "$flags" = *S* ]]; then
+                echo " variant.opensolaris.imagetype=full\\c"
             fi
             echo " fmri=pkg://@PKGPUBLISHER@/$pkg@$ver,5.11-@PVER@ type=$typ"
         ) >> $cmf

--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -6,6 +6,8 @@
 # where flags can include:
 #
 #	F	- Add a facet to allow this line to be selectively disabled.
+#	S	- Do not include this package in entire for sparse zones.
+#	Z	- Do not include this package in entire for non-global zones.
 #
 incorporation/jeos/illumos-gate			11	incorporate
 incorporation/jeos/illumos-gate			11	require
@@ -27,107 +29,107 @@ diagnostic/cpu-counters				0.5.11	require
 diagnostic/diskinfo				0.5.11	require
 diagnostic/latencytop				0.5.11	require
 diagnostic/powertop				0.5.11	require
-driver/audio					0.5.11	require
-driver/crypto/dca				0.5.11	require
-driver/crypto/tpm				0.5.11	require
-driver/firewire					0.5.11	require
-driver/graphics/agpgart				0.5.11	require
-driver/graphics/atiatom				0.5.11	require
-driver/graphics/drm				0.5.11	require
-driver/i86pc/fipe				0.5.11	require
-driver/i86pc/ioat				0.5.11	require
-driver/i86pc/platform				0.5.11	require
-driver/misc/virtio				0.5.11	require
-driver/network/afe				0.5.11	require
-driver/network/amd8111s				0.5.11	require
-driver/network/atge				0.5.11	require
-driver/network/bfe				0.5.11	require
-driver/network/bge				0.5.11	require
-driver/network/bnx				0.5.11	require
-driver/network/bnxe				0.5.11	require
-driver/network/bpf				0.5.11	require
-driver/network/chxge				0.5.11	require
-driver/network/dmfe				0.5.11	require
-driver/network/e1000g				0.5.11	require
-driver/network/elxl				0.5.11	require
-driver/network/emlxs				0.5.11	require
-driver/network/eoib				0.5.11	require
-driver/network/fcip				0.5.11	require
-driver/network/fcp				0.5.11	require
-driver/network/fcsm				0.5.11	require
-driver/network/fp				0.5.11	require
-driver/network/hermon				0.5.11	require
-driver/network/hme				0.5.11	require
-driver/network/hxge				0.5.11	require
-driver/network/i40e				0.5.11	require
-driver/network/ib				0.5.11	require
-driver/network/ibdma				0.5.11	require
-driver/network/ibp				0.5.11	require
-driver/network/igb				0.5.11	require
-driver/network/iprb				0.5.11	require
-driver/network/ixgb				0.5.11	require
-driver/network/ixgbe				0.5.11	require
-driver/network/mxfe				0.5.11	require
-driver/network/myri10ge				0.5.11	require
-driver/network/nge				0.5.11	require
-driver/network/ntxn				0.5.11	require
-driver/network/nxge				0.5.11	require
-driver/network/ofk				0.5.11	require
-driver/network/pcn				0.5.11	require
-driver/network/platform				0.5.11	require
-driver/network/qlc				0.5.11	require
-driver/network/rds				0.5.11	require
-driver/network/rdsv3				0.5.11	require
-driver/network/rge				0.5.11	require
-driver/network/rpcib				0.5.11	require
-driver/network/rtls				0.5.11	require
-driver/network/sdp				0.5.11	require
-driver/network/sdpib				0.5.11	require
-driver/network/sfe				0.5.11	require
-driver/network/sfxge				0.5.11	require
-driver/network/tavor				0.5.11	require
-driver/network/usbecm				0.5.11	require
-driver/network/vioif				0.5.11	require
-driver/network/vmxnet3s				0.5.11	require
-driver/network/vr				0.5.11	require
-driver/network/xge				0.5.11	require
-driver/network/yge				0.5.11	require
-driver/pcmcia					0.5.11	require
-driver/serial/usbftdi				0.5.11	require
-driver/serial/usbsacm				0.5.11	require
-driver/serial/usbser				0.5.11	require
-driver/serial/usbser_edge			0.5.11	require
-driver/serial/usbsksp				0.5.11	require
-driver/serial/usbsksp/usbs49_fw			0.5.11	require
-driver/serial/usbsprl				0.5.11	require
-driver/storage/aac				0.5.11	require
-driver/storage/adpu320				0.5.11	require
-driver/storage/ahci				0.5.11	require
-driver/storage/amr				0.5.11	require
-driver/storage/arcmsr				0.5.11	require
-driver/storage/ata				0.5.11	require
-driver/storage/bcm_sata				0.5.11	require
-driver/storage/blkdev				0.5.11	require
-driver/storage/cpqary3				0.5.11	require
-driver/storage/glm				0.5.11	require
-driver/storage/lsimega				0.5.11	require
-driver/storage/marvell88sx			0.5.11	require
-driver/storage/mega_sas				0.5.11	require
-driver/storage/mpt_sas				0.5.11	require
-driver/storage/mr_sas				0.5.11	require
-driver/storage/nv_sata				0.5.11	require
-driver/storage/nvme				0.5.11	require
-driver/storage/pmcs				0.5.11	require
-driver/storage/sbp2				0.5.11	require
-driver/storage/scsa1394				0.5.11	require
-driver/storage/sdcard				0.5.11	require
-driver/storage/ses				0.5.11	require
-driver/storage/si3124				0.5.11	require
-driver/storage/smp				0.5.11	require
-driver/storage/vioblk				0.5.11	require
-driver/usb					0.5.11	require
-driver/usb/ugen					0.5.11	require
-driver/xvm/pv					0.5.11	require
+driver/audio					0.5.11	require		S
+driver/crypto/dca				0.5.11	require		S
+driver/crypto/tpm				0.5.11	require		S
+driver/firewire					0.5.11	require		S
+driver/graphics/agpgart				0.5.11	require		S
+driver/graphics/atiatom				0.5.11	require		S
+driver/graphics/drm				0.5.11	require		S
+driver/i86pc/fipe				0.5.11	require		S
+driver/i86pc/ioat				0.5.11	require		S
+driver/i86pc/platform				0.5.11	require		S
+driver/misc/virtio				0.5.11	require		S
+driver/network/afe				0.5.11	require		S
+driver/network/amd8111s				0.5.11	require		S
+driver/network/atge				0.5.11	require		S
+driver/network/bfe				0.5.11	require		S
+driver/network/bge				0.5.11	require		S
+driver/network/bnx				0.5.11	require		S
+driver/network/bnxe				0.5.11	require		S
+driver/network/bpf				0.5.11	require		S
+driver/network/chxge				0.5.11	require		S
+driver/network/dmfe				0.5.11	require		S
+driver/network/e1000g				0.5.11	require		S
+driver/network/elxl				0.5.11	require		S
+driver/network/emlxs				0.5.11	require		S
+driver/network/eoib				0.5.11	require		S
+driver/network/fcip				0.5.11	require		S
+driver/network/fcp				0.5.11	require		S
+driver/network/fcsm				0.5.11	require		S
+driver/network/fp				0.5.11	require		S
+driver/network/hermon				0.5.11	require		S
+driver/network/hme				0.5.11	require		S
+driver/network/hxge				0.5.11	require		S
+driver/network/i40e				0.5.11	require		S
+driver/network/ib				0.5.11	require		S
+driver/network/ibdma				0.5.11	require		S
+driver/network/ibp				0.5.11	require		S
+driver/network/igb				0.5.11	require		S
+driver/network/iprb				0.5.11	require		S
+driver/network/ixgb				0.5.11	require		S
+driver/network/ixgbe				0.5.11	require		S
+driver/network/mxfe				0.5.11	require		S
+driver/network/myri10ge				0.5.11	require		S
+driver/network/nge				0.5.11	require		S
+driver/network/ntxn				0.5.11	require		S
+driver/network/nxge				0.5.11	require		S
+driver/network/ofk				0.5.11	require		S
+driver/network/pcn				0.5.11	require		S
+driver/network/platform				0.5.11	require		S
+driver/network/qlc				0.5.11	require		S
+driver/network/rds				0.5.11	require		S
+driver/network/rdsv3				0.5.11	require		S
+driver/network/rge				0.5.11	require		S
+driver/network/rpcib				0.5.11	require		S
+driver/network/rtls				0.5.11	require		S
+driver/network/sdp				0.5.11	require		S
+driver/network/sdpib				0.5.11	require		S
+driver/network/sfe				0.5.11	require		S
+driver/network/sfxge				0.5.11	require		S
+driver/network/tavor				0.5.11	require		S
+driver/network/usbecm				0.5.11	require		S
+driver/network/vioif				0.5.11	require		S
+driver/network/vmxnet3s				0.5.11	require		S
+driver/network/vr				0.5.11	require		S
+driver/network/xge				0.5.11	require		S
+driver/network/yge				0.5.11	require		S
+driver/pcmcia					0.5.11	require		S
+driver/serial/usbftdi				0.5.11	require		S
+driver/serial/usbsacm				0.5.11	require		S
+driver/serial/usbser				0.5.11	require		S
+driver/serial/usbser_edge			0.5.11	require		S
+driver/serial/usbsksp				0.5.11	require		S
+driver/serial/usbsksp/usbs49_fw			0.5.11	require		S
+driver/serial/usbsprl				0.5.11	require		S
+driver/storage/aac				0.5.11	require		S
+driver/storage/adpu320				0.5.11	require		S
+driver/storage/ahci				0.5.11	require		S
+driver/storage/amr				0.5.11	require		S
+driver/storage/arcmsr				0.5.11	require		S
+driver/storage/ata				0.5.11	require		S
+driver/storage/bcm_sata				0.5.11	require		S
+driver/storage/blkdev				0.5.11	require		S
+driver/storage/cpqary3				0.5.11	require		S
+driver/storage/glm				0.5.11	require		S
+driver/storage/lsimega				0.5.11	require		S
+driver/storage/marvell88sx			0.5.11	require		S
+driver/storage/mega_sas				0.5.11	require		S
+driver/storage/mpt_sas				0.5.11	require		S
+driver/storage/mr_sas				0.5.11	require		S
+driver/storage/nv_sata				0.5.11	require		S
+driver/storage/nvme				0.5.11	require		S
+driver/storage/pmcs				0.5.11	require		S
+driver/storage/sbp2				0.5.11	require		S
+driver/storage/scsa1394				0.5.11	require		S
+driver/storage/sdcard				0.5.11	require		S
+driver/storage/ses				0.5.11	require		S
+driver/storage/si3124				0.5.11	require		S
+driver/storage/smp				0.5.11	require		S
+driver/storage/vioblk				0.5.11	require		S
+driver/usb					0.5.11	require		S
+driver/usb/ugen					0.5.11	require		S
+driver/xvm/pv					0.5.11	require		S
 editor/vim					8.0	require
 file/gnu-coreutils				8	require
 file/gnu-findutils				4.6	require
@@ -153,107 +155,107 @@ library/security/openssl			1.0.2	require
 library/security/tcp-wrapper			7.6	require
 library/security/trousers			0.3	require
 library/zlib					1.2.11	require
-locale/af					0.5.11	require
-locale/ar					0.5.11	require
-locale/as					0.5.11	require
-locale/az					0.5.11	require
-locale/be					0.5.11	require
-locale/bg					0.5.11	require
-locale/bg-extra					0.5.11	require
-locale/bn					0.5.11	require
-locale/bo					0.5.11	require
-locale/bs					0.5.11	require
-locale/ca					0.5.11	require
-locale/ca-extra					0.5.11	require
-locale/cs					0.5.11	require
-locale/cs-extra					0.5.11	require
-locale/da					0.5.11	require
-locale/da-extra					0.5.11	require
-locale/de					0.5.11	require
-locale/de-extra					0.5.11	require
-locale/el					0.5.11	require
-locale/el-extra					0.5.11	require
-locale/en					0.5.11	require
-locale/en-extra					0.5.11	require
-locale/es					0.5.11	require
-locale/es-extra					0.5.11	require
-locale/et					0.5.11	require
-locale/fi					0.5.11	require
-locale/fi-extra					0.5.11	require
-locale/fil					0.5.11	require
-locale/fr					0.5.11	require
-locale/fr-extra					0.5.11	require
-locale/ga					0.5.11	require
-locale/gu					0.5.11	require
-locale/he					0.5.11	require
-locale/hi					0.5.11	require
-locale/hr					0.5.11	require
-locale/hr-extra					0.5.11	require
-locale/hu					0.5.11	require
-locale/hu-extra					0.5.11	require
-locale/hy					0.5.11	require
-locale/id					0.5.11	require
-locale/ii					0.5.11	require
-locale/is					0.5.11	require
-locale/is-extra					0.5.11	require
-locale/it					0.5.11	require
-locale/it-extra					0.5.11	require
-locale/ja					0.5.11	require
-locale/ka					0.5.11	require
-locale/kk					0.5.11	require
-locale/km					0.5.11	require
-locale/kn					0.5.11	require
-locale/ko					0.5.11	require
-locale/kok					0.5.11	require
-locale/lt					0.5.11	require
-locale/lt-extra					0.5.11	require
-locale/lv					0.5.11	require
-locale/lv-extra					0.5.11	require
-locale/mk					0.5.11	require
-locale/mk-extra					0.5.11	require
-locale/ml					0.5.11	require
-locale/mn					0.5.11	require
-locale/mr					0.5.11	require
-locale/ms					0.5.11	require
-locale/mt					0.5.11	require
-locale/nb					0.5.11	require
-locale/ne					0.5.11	require
-locale/nl					0.5.11	require
-locale/nl-extra					0.5.11	require
-locale/nn					0.5.11	require
-locale/or					0.5.11	require
-locale/pa					0.5.11	require
-locale/pl					0.5.11	require
-locale/pl-extra					0.5.11	require
-locale/pt					0.5.11	require
-locale/pt-extra					0.5.11	require
-locale/ro					0.5.11	require
-locale/ru					0.5.11	require
-locale/ru-extra					0.5.11	require
-locale/sa					0.5.11	require
-locale/si					0.5.11	require
-locale/sk					0.5.11	require
-locale/sl					0.5.11	require
-locale/sq					0.5.11	require
-locale/sq-extra					0.5.11	require
-locale/sr					0.5.11	require
-locale/sv					0.5.11	require
-locale/sv-extra					0.5.11	require
-locale/ta					0.5.11	require
-locale/te					0.5.11	require
-locale/th					0.5.11	require
-locale/th-extra					0.5.11	require
-locale/tr					0.5.11	require
-locale/tr-extra					0.5.11	require
-locale/ug					0.5.11	require
-locale/uk					0.5.11	require
-locale/ur					0.5.11	require
-locale/vi					0.5.11	require
-locale/zh_cn					0.5.11	require
-locale/zh_hk					0.5.11	require
-locale/zh_mo					0.5.11	require
-locale/zh_sg					0.5.11	require
-locale/zh_tw					0.5.11	require
+locale/af					0.5.11	require		S
+locale/ar					0.5.11	require		S
+locale/as					0.5.11	require		S
+locale/az					0.5.11	require		S
+locale/be					0.5.11	require		S
+locale/bg					0.5.11	require		S
+locale/bg-extra					0.5.11	require		S
+locale/bn					0.5.11	require		S
+locale/bo					0.5.11	require		S
+locale/bs					0.5.11	require		S
+locale/ca					0.5.11	require		S
+locale/ca-extra					0.5.11	require		S
+locale/cs					0.5.11	require		S
+locale/cs-extra					0.5.11	require		S
+locale/da					0.5.11	require		S
+locale/da-extra					0.5.11	require		S
+locale/de					0.5.11	require		S
+locale/de-extra					0.5.11	require		S
+locale/el					0.5.11	require		S
+locale/el-extra					0.5.11	require		S
+locale/en					0.5.11	require		S
+locale/en-extra					0.5.11	require		S
+locale/es					0.5.11	require		S
+locale/es-extra					0.5.11	require		S
+locale/et					0.5.11	require		S
+locale/fi					0.5.11	require		S
+locale/fi-extra					0.5.11	require		S
+locale/fil					0.5.11	require		S
+locale/fr					0.5.11	require		S
+locale/fr-extra					0.5.11	require		S
+locale/ga					0.5.11	require		S
+locale/gu					0.5.11	require		S
+locale/he					0.5.11	require		S
+locale/hi					0.5.11	require		S
+locale/hr					0.5.11	require		S
+locale/hr-extra					0.5.11	require		S
+locale/hu					0.5.11	require		S
+locale/hu-extra					0.5.11	require		S
+locale/hy					0.5.11	require		S
+locale/id					0.5.11	require		S
+locale/ii					0.5.11	require		S
+locale/is					0.5.11	require		S
+locale/is-extra					0.5.11	require		S
+locale/it					0.5.11	require		S
+locale/it-extra					0.5.11	require		S
+locale/ja					0.5.11	require		S
+locale/ka					0.5.11	require		S
+locale/kk					0.5.11	require		S
+locale/km					0.5.11	require		S
+locale/kn					0.5.11	require		S
+locale/ko					0.5.11	require		S
+locale/kok					0.5.11	require		S
+locale/lt					0.5.11	require		S
+locale/lt-extra					0.5.11	require		S
+locale/lv					0.5.11	require		S
+locale/lv-extra					0.5.11	require		S
+locale/mk					0.5.11	require		S
+locale/mk-extra					0.5.11	require		S
+locale/ml					0.5.11	require		S
+locale/mn					0.5.11	require		S
+locale/mr					0.5.11	require		S
+locale/ms					0.5.11	require		S
+locale/mt					0.5.11	require		S
+locale/nb					0.5.11	require		S
+locale/ne					0.5.11	require		S
+locale/nl					0.5.11	require		S
+locale/nl-extra					0.5.11	require		S
+locale/nn					0.5.11	require		S
+locale/or					0.5.11	require		S
+locale/pa					0.5.11	require		S
+locale/pl					0.5.11	require		S
+locale/pl-extra					0.5.11	require		S
+locale/pt					0.5.11	require		S
+locale/pt-extra					0.5.11	require		S
+locale/ro					0.5.11	require		S
+locale/ru					0.5.11	require		S
+locale/ru-extra					0.5.11	require		S
+locale/sa					0.5.11	require		S
+locale/si					0.5.11	require		S
+locale/sk					0.5.11	require		S
+locale/sl					0.5.11	require		S
+locale/sq					0.5.11	require		S
+locale/sq-extra					0.5.11	require		S
+locale/sr					0.5.11	require		S
+locale/sv					0.5.11	require		S
+locale/sv-extra					0.5.11	require		S
+locale/ta					0.5.11	require		S
+locale/te					0.5.11	require		S
+locale/th					0.5.11	require		S
+locale/th-extra					0.5.11	require		S
+locale/tr					0.5.11	require		S
+locale/tr-extra					0.5.11	require		S
+locale/ug					0.5.11	require		S
+locale/uk					0.5.11	require		S
+locale/ur					0.5.11	require		S
+locale/vi					0.5.11	require		S
+locale/zh_cn					0.5.11	require		S
+locale/zh_hk					0.5.11	require		S
+locale/zh_mo					0.5.11	require		S
+locale/zh_sg					0.5.11	require		S
+locale/zh_tw					0.5.11	require		S
 naming/ldap					0.5.11	require
 network/bridging				0.5.11	require
 network/dns/bind				9.10	require
@@ -280,8 +282,8 @@ service/storage/removable-media			0.5.11	require
 shell/bash					4.4	require
 shell/pipe-viewer				1.6	require
 system/accounting/legacy			0.5.11	require
-system/boot/grub				0.97	require		F
-system/boot/loader				1.1	require
+system/boot/grub				0.97	require		FS
+system/boot/loader				1.1	require		S
 system/boot/real-mode				0.5.11	require
 system/boot/wanboot				0.5.11	require
 system/boot/wanboot/internal			0.5.11	require
@@ -293,7 +295,7 @@ system/extended-system-utilities		0.5.11	require
 system/file-system/autofs			0.5.11	require
 system/file-system/udfs				0.5.11	require
 system/file-system/zfs				0.5.11	require
-system/flash/fwflash				0.5.11	require
+system/flash/fwflash				0.5.11	require		S
 system/fru-id					0.5.11	require
 system/fru-id/platform				0.5.11	require
 system/ipc					0.5.11	require


### PR DESCRIPTION
Flag some packages as not required in a sparse zone.
This reduces the list of packages in the sparse zone index and those which have to be evaluated down from 390 to 188.
Since /usr contains all files from the GZ, the fact that the driver and locale packages are not specifically installed does not affect the availability of man pages and locale files.