### PR TITLE
Re-add NFS & SMB to entire

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -280,7 +280,7 @@ service/network/ntp				4.2.8	optional
 service/network/smtp/dma			0.11	require		F
 service/picl					0.5.11	require
 service/resource-pools				0.5.11	require
-service/storage/removable-media			0.5.11	require
+service/storage/removable-media			0.5.11	require		S
 shell/bash					4.4	require
 shell/pipe-viewer				1.6	require
 system/accounting/legacy			0.5.11	require

--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -272,6 +272,8 @@ runtime/perl/module/sun-solaris			0.5.11	require
 runtime/python-27				2.7	require
 security/sudo					1.8	require
 service/fault-management			0.5.11	require
+service/file-system/nfs				0.5.11	require
+service/file-system/smb				0.5.11	require
 service/hal					0.5.11	require
 service/network/network-clients			0.5.11	require
 service/network/ntp				4.2.8	optional


### PR DESCRIPTION
Testing has shown that these are too closely linked to libshare and ZFS to not have in a default installation.
Re-adding, but only the `service/...` FMRIs since these packages depend on the accompanying `system/...` ones.