### PR TITLE
Make storage/removable-media optional

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -280,7 +280,7 @@ service/network/ntp				4.2.8	optional
 service/network/smtp/dma			0.11	require		F
 service/picl					0.5.11	require
 service/resource-pools				0.5.11	require
-service/storage/removable-media			0.5.11	require		S
+service/storage/removable-media			0.5.11	optional	SZ
 shell/bash					4.4	require
 shell/pipe-viewer				1.6	require
 system/accounting/legacy			0.5.11	require


### PR DESCRIPTION
The `service/storage/removable-media` package delivers the `network/rpc/smserver` service.
As long as this service is installed, `inetd` cannot be disabled without causing the server to fail to enter multi-user.
Making this optional so that it is present in release/install media but can be removed if unwanted.