### PR TITLE
Add NTPsec

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -100,6 +100,7 @@ runtime/perl				5.26
 runtime/python-27			2.7
 security/sudo				1.8
 service/network/ntp			4.2.8
+service/network/ntpsec			1
 service/network/smtp/dma		0.11
 shell/bash				4.4
 shell/pipe-viewer			1.6

--- a/build/ntpsec/build.sh
+++ b/build/ntpsec/build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=ntpsec
+VER=1.0.0
+VERHUMAN=$VER
+PKG=service/network/ntpsec
+SUMMARY="A secure, hardened and improved Network Time Protocol implementation"
+DESC="$SUMMARY"
+
+BUILDARCH=64
+XFORM_ARGS="-D PVER=$PYTHONVER"
+
+# Required to generate man pages
+BUILD_DEPENDS_IPS="ooce/text/asciidoc"
+export PATH=$PATH:/opt/ooce/bin
+
+# NTPsec uses the 'waf' build system
+
+make_clean() {
+    logcmd ./waf distclean
+}
+
+configure64() {
+    logmsg "--- configure"
+    BIN_ASCIIDOC=/opt/ooce/bin/asciidoc \
+        BIN_A2X=/opt/ooce/bin/a2x \
+        CC='gcc -m64' \
+        logcmd ./waf configure \
+        --prefix=/usr \
+        --sysconfdir=/etc/inet \
+        --refclock=all \
+        --define=CONFIG_FILE=/etc/inet/ntp.conf \
+        --python=/usr/bin/python$PYTHONVER \
+        --pythondir=/usr/lib/python$PYTHONVER/vendor-packages \
+        --pythonarchdir=/usr/lib/python$PYTHONVER/vendor-packages \
+        --nopyc \
+        --nopyo \
+        --nopycache \
+        || logerr "--- configure failed"
+}
+
+make_prog() {
+    logmsg "--- build"
+    logcmd ./waf build || logerr "--- build failed"
+}
+
+make_install() {
+    logmsg "--- install"
+    logcmd ./waf install \
+        --destdir=$DESTDIR \
+        || logerr "--- install failed"
+}
+
+install_ntpdate() {
+    logcmd cp $TMPDIR/$BUILDDIR/attic/ntpdate $DESTDIR/usr/bin/ntpdate
+    logcmd chmod 755 $DESTDIR/usr/bin/ntpdate
+}
+
+install_files() {
+    logmsg "--- install files"
+
+    logcmd mkdir -p $DESTDIR/etc/inet
+    logcmd cp $SRCDIR/files/ntp.conf $DESTDIR/etc/inet/ntp.conf
+
+    logcmd mkdir -p $DESTDIR/etc/security/auth_attr.d
+    logcmd mkdir -p $DESTDIR/etc/security/prof_attr.d
+    logcmd cp $SRCDIR/files/security/auth_attr \
+        $DESTDIR/etc/security/auth_attr.d/ntp
+    logcmd cp $SRCDIR/files/security/prof_attr \
+        $DESTDIR/etc/security/prof_attr.d/ntp
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+logcmd cp $TMPDIR/$BUILDDIR/build/main/test.log $SRCDIR/testsuite.log
+install_ntpdate
+install_files
+install_smf network ntpsec.xml ntpsec
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/ntpsec/files/ntp.conf
+++ b/build/ntpsec/files/ntp.conf
@@ -1,0 +1,66 @@
+## NTP daemon configuration file. See ntp.conf(4) for full documentation.
+
+## Always configure the drift file. It can take days for ntpd to completely
+## stabilise and without the drift file, it has to cold start following an
+## ntpd restart.
+driftfile /var/ntp/ntp.drift
+
+## Default to ignore all for safety -- no incoming packets are trusted.
+restrict default kod limited nomodify nopeer noquery
+restrict -6 default kod limited nomodify nopeer noquery
+
+## Permit localhost to connect to and manage ntpd
+restrict 127.0.0.1      # Allow localhost full access
+restrict -6 ::1         # Same, for IPv6
+
+## Permit ntp server to reply to our queries
+restrict source nomodify noquery notrap
+
+## OmniOS NTP vendor pool time servers
+## These are provided by the NTP Pool project for use by
+## OmniOS clients.
+pool 0.omnios.pool.ntp.org
+
+tos minclock 4 minsane 4
+
+## It is always wise to configure at least the loopstats and peerstats files.
+## Otherwise when ntpd does something you don't expect there is no way to
+## find out why.
+statsdir /var/ntp/ntpstats/
+filegen peerstats file peerstats type day enable
+filegen loopstats file loopstats type day enable
+
+## To track the events regarding the system clock, the protostats file can be useful
+## as well.
+#filegen protostats file protostats type day enable
+
+## To see the current state of the crypto authentication protocols, enable the
+## cryptostats file.
+#filegen cryptostats file cryptostats type day enable
+
+## The clockstats files are only useful if a hardware reference clock is
+## configured.
+#filegen clockstats file clockstats type day enable
+
+## The sysstats and rawstats output might be useful in debugging, but are
+## not important otherwise.
+#filegen sysstats file sysstats type day enable
+#filegen rawstats file rawstats type day enable
+
+## There are several types on authentication supported by NTP. The easiest
+## to use is a set of passwords, called "keys". They should be stored
+## the /etc/inet/ntp.keys file. Each key in the ntp.keys file can be
+## assigned to certain types of trust levels. See ntpd(1m) for more
+## information on setting up key.
+#keys /etc/inet/ntp.keys
+#trustedkey 1
+#requestkey 1
+#controlkey 1
+
+## To configure leap seconds processing, download the latest NIST leap seconds
+## file to /etc/inet, and then create a symbolic link to it from the ntp.leap
+## file. Without this file, NTP will still be able to accept leap announcements
+## from its upstream sources. If this file exists and is less than 6 months old
+## then the contents of this file will take precedence over the upstream servers.
+## The latest leap seconds file is always available at ftp://time.nist.gov/pub
+#leapfile /etc/inet/ntp.leap

--- a/build/ntpsec/files/ntpsec
+++ b/build/ntpsec/files/ntpsec
@@ -1,0 +1,102 @@
+#!/sbin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2016 Andrew Stormont <andyjstormont@gmail.com>
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+#
+
+# Standard prologue
+#
+. /lib/svc/share/smf_include.sh
+
+if [ -z $SMF_FMRI ]; then
+        echo "SMF framework variables are not initialised."
+        exit $SMF_EXIT_ERR
+fi
+
+#
+# Is NTP configured?
+#
+if [ ! -f /etc/inet/ntp.conf ]; then
+	echo "Error: Configuration file '/etc/inet/ntp.conf' not found." \
+	    "  See ntpd(1M)."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+# Disable globbing to prevent privilege escalations by users authorized
+# to set property values for the NTP service.
+set -f 
+
+#
+# Build the command line flags
+#
+shift $#
+
+# We allow a step larger than the panic value of 17 minutes only 
+# once when ntpd starts up. If always_all_large_step is true, 
+# then we allow this each time ntpd starts. Otherwise, we allow
+# it only the very first time ntpd starts after a boot. We 
+# check that by making ntpd write its pid to a file in /var/run.
+set -- -p /var/run/ntp.pid
+
+val=`svcprop -c -p config/always_allow_large_step $SMF_FMRI`
+if [ "$val" = "true" ] || [ ! -f /var/run/ntp.pid ]; then
+        set -- "$@" -g
+fi
+
+# Set up logging if requested.
+logfile=`svcprop -c -p config/logfile $SMF_FMRI`
+val=`svcprop -c -p config/verbose_logging $SMF_FMRI`
+[ "$val" = "true" ] && [ -n "$logfile" ]  && set -- "$@" -l $logfile
+
+# Register with mDNS.
+val=`svcprop -c -p config/mdnsregister $SMF_FMRI`
+mdns=`svcprop -c -p general/enabled svc:/network/dns/multicast:default`
+[ "$val" = "true" ] && [ "$mdns" = "true" ] && set -- "$@" -m
+
+# Slew option (old Sun slewalways)
+val=`svcprop -c -p config/slew_always $SMF_FMRI`
+[ "$val" = "true" ] && set -- "$@" --slew
+
+# Set up debugging.
+deb=`svcprop -c -p config/debuglevel $SMF_FMRI`
+
+# Start the daemon. If debugging is requested, put it in the background, 
+# since it won't do it on it's own.
+if [ "$deb" -gt 0 ]; then
+	/usr/sbin/ntpd "$@" --set-debug-level=$deb >/var/ntp/ntp.debug &
+else
+	/usr/sbin/ntpd "$@"
+fi
+
+# Now, wait for the first sync, if requested.
+val=`svcprop -c -p config/wait_for_sync $SMF_FMRI`
+tries=`svcprop -c -p config/wait_for_sync_tries $SMF_FMRI`
+sleep=`svcprop -c -p config/wait_for_sync_sleep $SMF_FMRI`
+if [ "$val" = "true" ]; then
+	/usr/bin/ntpwait --tries=$tries --sleep=$sleep ||
+	    exit $SMF_EXIT_ERR_CONFIG
+fi
+
+exit $SMF_EXIT_OK

--- a/build/ntpsec/files/ntpsec.xml
+++ b/build/ntpsec/files/ntpsec.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+ CDDL HEADER START
+
+ The contents of this file are subject to the terms of the
+ Common Development and Distribution License (the "License").
+ You may not use this file except in compliance with the License.
+
+ You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ or http://www.opensolaris.org/os/licensing.
+ See the License for the specific language governing permissions
+ and limitations under the License.
+
+ When distributing Covered Code, include this CDDL HEADER in each
+ file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ If applicable, add the following below this CDDL HEADER, with the
+ fields enclosed by brackets "[]" replaced with your own identifying
+ information: Portions Copyright [yyyy] [name of copyright owner]
+
+ CDDL HEADER END
+
+ Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ Copyright 2016 Andrew Stormont <andyjstormont@gmail.com>
+
+ NOTE:  This service manifest is not editable; its contents will
+ be overwritten by package or patch operations, including
+ operating system upgrade.  Make customizations in a different
+ file.
+-->
+
+<service_bundle type='manifest' name='SUNWntpr:ntp'>
+
+<service
+	name='network/ntp'
+	type='service'
+	version='1'>
+	<single_instance />
+	<dependency 
+		name='network'
+		grouping='require_any'
+		restart_on='error'
+		type='service'>
+		<service_fmri value='svc:/network/service' />
+	</dependency>
+
+	<dependency
+		name='filesystem'
+		grouping='require_all'
+		restart_on='error'
+		type='service'>
+		    <service_fmri value='svc:/system/filesystem/minimal' />
+	</dependency>
+
+	<dependency 
+		name='name-services'
+		grouping='optional_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/milestone/name-services' />
+	</dependency>
+
+	<dependency 
+		name='routing-setup'
+		grouping='optional_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/network/routing-setup' />
+	</dependency>
+
+	<dependency
+		name='config-file'
+		grouping='require_all'
+		restart_on='refresh'
+		type='path'>
+		<service_fmri value='file://localhost/etc/inet/ntp.conf' />
+	</dependency>
+
+	<exec_method
+	    type='method'
+    	    name='start'
+    	    exec='/lib/svc/method/ntpsec %m'
+    	    timeout_seconds='600'>
+		<method_context security_flags='aslr'>
+			<method_credential
+			    user='root'
+			    group='root'
+			    privileges='basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time'
+			/>
+		</method_context>
+	</exec_method>
+
+	<exec_method
+	    type='method'
+    	    name='restart'
+    	    exec='/lib/svc/method/ntpsec %m'
+    	    timeout_seconds='1800'>
+		<method_context security_flags='aslr'>
+			<method_credential
+			    user='root'
+			    group='root'
+			    privileges='basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time'
+			/>
+		</method_context>
+	</exec_method>
+
+	<exec_method
+    	    type='method'
+    	    name='stop'
+    	    exec=':kill'
+    	    timeout_seconds='60' />
+
+	<property_group name='general' type='framework'>
+		<!-- to start stop ntpd -->
+		<propval name='action_authorization' type='astring'
+		value='solaris.smf.manage.ntp' />
+		<propval name='value_authorization' type='astring'
+		value='solaris.smf.value.ntp' />
+	</property_group>
+
+	<instance name="default" enabled="false">
+		<property_group name='config' type='application' >
+			<!-- default property settings for ntpd(1M). -->
+		
+			<propval
+			    name='wait_for_sync'
+			    type='boolean'
+			    value='false' />
+		
+			<propval
+			    name='wait_for_sync_tries'
+			    type='integer'
+			    value='500' />
+
+			<propval
+			    name='wait_for_sync_sleep'
+			    type='integer'
+			    value='3' />
+
+			<propval
+			    name='verbose_logging'
+			    type='boolean'
+			    value='false' />
+	
+			<propval
+			    name='slew_always'
+			    type='boolean'
+			    value='false' />
+	
+			<propval
+			    name='always_allow_large_step'
+			    type='boolean'
+			    value='true' />
+	
+			<propval
+			    name='logfile'
+			    type='astring'
+			    value='/var/ntp/ntp.log' />
+		
+			<propval
+			    name='debuglevel'
+			    type='integer'
+			    value='0' />
+	
+			<propval
+			    name='mdnsregister'
+			    type='boolean'
+			    value='false' />
+	
+			<!-- to change properties -->
+			<propval
+			    name='value_authorization'
+			    type='astring'
+			    value='solaris.smf.value.ntp' />
+		
+		</property_group>
+	</instance>
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+			Network Time Protocol (NTP) Version 4
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title='ntpd' section='1M' />
+			<manpage title='ntp.conf' section='4' />
+			<manpage title='ntpq' section='1M' />
+		</documentation>
+	</template>
+</service>
+
+</service_bundle>

--- a/build/ntpsec/files/security/auth_attr
+++ b/build/ntpsec/files/security/auth_attr
@@ -1,0 +1,2 @@
+solaris.smf.manage.ntp:::Manage NTP service states::
+solaris.smf.value.ntp:::Change NTP value properties::

--- a/build/ntpsec/files/security/prof_attr
+++ b/build/ntpsec/files/security/prof_attr
@@ -1,0 +1,1 @@
+NTP Management:RO::Manage the NTP service:auths=solaris.smf.manage.ntp,solaris.smf.value.ntp

--- a/build/ntpsec/local.mog
+++ b/build/ntpsec/local.mog
@@ -1,0 +1,53 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license="Various"
+
+# Move shared objects to 64-bit directory
+dir group=bin mode=0755 owner=root \
+    path=usr/lib/python$(PVER)/vendor-packages/ntp
+<transform file path=.*/ntp/.*\.so$ -> edit path /ntp/ /ntp/64/ >
+
+# Preserve configuration file
+<transform file path=etc/inet/ntp.conf -> set preserve true >
+<transform file path=etc/inet/ntp.conf -> set overlay allow >
+
+# Skip dependency detection for python programs
+<transform file path=usr/bin -> set pkg.depend.bypass-generate .* >
+
+# Create directories
+dir group=sys mode=0755 owner=root path=var/ntp
+dir group=sys mode=0755 owner=root path=var/ntp/ntpstats
+
+# Skip system (SUNWcs) directories
+<transform dir path=etc -> drop>
+
+# Restart NTP on binary change
+<transform file path=usr/sbin/ntpd$ -> \
+    set restart_fmri svc:/nework/ntp:default>
+
+# Drop compiled python files.
+<transform file path=.*\.py[oc]$ -> drop>
+
+# Backwards compatibility links
+link path=usr/sbin/ntp-keygen target=../bin/ntpkeygen
+link path=usr/sbin/ntpdate target=../bin/ntpdate
+link path=usr/sbin/ntpq target=../bin/ntpq
+link path=usr/sbin/ntptime target=../bin/ntptime
+link path=usr/sbin/ntptrace target=../bin/ntptrace
+link path=usr/sbin/update-leap target=../bin/ntpleapfetch
+
+# Cannot be installed alongside the legacy NTP package
+depend fmri=pkg:///system/network/ntp type=exclude
+

--- a/build/ntpsec/patches/conf.patch
+++ b/build/ntpsec/patches/conf.patch
@@ -1,0 +1,96 @@
+
+Re-locate the default configuration file from /etc/ to /etc/inet/
+
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/docs/includes/ntp-conf-body.txt ntpsec-1.0.0/docs/includes/ntp-conf-body.txt
+--- ntpsec-1.0.0~/docs/includes/ntp-conf-body.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/docs/includes/ntp-conf-body.txt	2017-12-27 14:20:07.061288869 +0000
+@@ -4,7 +4,7 @@
+ 
+ [[synop]]
+ == SYNOPSIS ==
+-/etc/ntp.conf
++/etc/inet/ntp.conf
+ 
+ [[descr]]
+ == DESCRIPTION ==
+@@ -12,7 +12,7 @@
+ The `ntp.conf` configuration file is read at initial startup by the
+ {ntpdman} daemon in order to specify the synchronization
+ sources, modes and other related information. Usually, it is installed
+-in the `/etc` directory, but could be installed elsewhere (see the
++in the `/etc/inet` directory, but could be installed elsewhere (see the
+ daemon's `-c` command line option).
+ 
+ The file format is similar to other UNIX configuration files. Comments
+@@ -221,7 +221,7 @@ include::../includes/misc-options.txt[]
+ [[files]]
+ == FILES ==
+ 
+-`/etc/ntp.conf`::
++`/etc/inet/ntp.conf`::
+   the default name of the configuration file
+ _ntp.keys_::
+   private MD5 keys
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/docs/ntpsec.txt ntpsec-1.0.0/docs/ntpsec.txt
+--- ntpsec-1.0.0~/docs/ntpsec.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/docs/ntpsec.txt	2017-12-27 14:20:07.061587491 +0000
+@@ -195,8 +195,8 @@ codebase has been outright removed, with
+ * The ntpq utility resizes its display to take advantage of wide
+   terminal windows, allowing more space for long peer addresses.
+ 
+-* When running as root, the ntpq utility looks in /etc/ntp.conf and
+-  /usr/local/etc/ntp.keys to find credentials for control requests
++* When running as root, the ntpq utility looks in /etc/inet/ntp.conf and
++  /etc/inet/ntp.keys to find credentials for control requests
+   that require authentication. Thus it will often not be necessary to enter
+   them by hand. Note that your installation's locations for config and
+   key files may differ from these; in that case this convenience
+@@ -247,10 +247,10 @@ codebase has been outright removed, with
+   respect to the current working directory but with respect to the
+   directory name of the last pushed file in the stack.  This means
+   that you can run ntpd from any directory with "includefile foo"
+-  in /etc/ntp.conf finding /etc/foo rather than looking for foo in
++  in /etc/inet/ntp.conf finding /etc/inet/foo rather than looking for foo in
+   your current directory.
+ 
+-* If there is an /etc/ntp.d directory, its subfiles are scanned for
++* If there is an /etc/inet/ntp.d directory, its subfiles are scanned for
+   more configuration declarations. Only files with the extension
+   ".conf" are interpreted; others are ignored.  This feature is
+   intended to make assembling configuration easier for administration
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/include/ntp_config.h ntpsec-1.0.0/include/ntp_config.h
+--- ntpsec-1.0.0~/include/ntp_config.h	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/include/ntp_config.h	2017-12-27 14:20:07.061804919 +0000
+@@ -18,7 +18,7 @@
+  * Configuration file name
+  */
+ #ifndef CONFIG_FILE
+-#  define	CONFIG_FILE "/etc/ntp.conf"
++#  define	CONFIG_FILE "/etc/inet/ntp.conf"
+ #endif /* not CONFIG_FILE */
+ #define CONFIG_DIR	"ntp.d"
+ 
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/ntpclients/ntpleapfetch ntpsec-1.0.0/ntpclients/ntpleapfetch
+--- ntpsec-1.0.0~/ntpclients/ntpleapfetch	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpleapfetch	2017-12-27 14:20:07.062032656 +0000
+@@ -23,7 +23,7 @@ MAXTRIES=6
+ INTERVAL=10
+ 
+ # Where to find ntp config file
+-NTPCONF=/etc/ntp.conf
++NTPCONF=/etc/inet/ntp.conf
+ 
+ # How long before expiration to get updated file
+ PREFETCH="60 days"
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/pylib/packet.py ntpsec-1.0.0/pylib/packet.py
+--- ntpsec-1.0.0~/pylib/packet.py	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/pylib/packet.py	2017-12-27 14:20:07.062578539 +0000
+@@ -1674,7 +1674,7 @@ class Authenticator:
+                 return (keyid,) + self.passwords[keyid]
+             else:
+                 return (keyid, None, None)
+-        for line in open("/etc/ntp.conf"):
++        for line in open("/etc/inet/ntp.conf"):
+             if line.startswith("control"):
+                 keyid = int(line.split()[1])
+                 (keytype, passwd) = self.passwords[keyid]

--- a/build/ntpsec/patches/mansections.patch
+++ b/build/ntpsec/patches/mansections.patch
@@ -1,0 +1,209 @@
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/ntpd/ntp.conf-man.txt ntpsec-1.0.0/ntpd/ntp.conf-man.txt
+--- ntpsec-1.0.0~/ntpd/ntp.conf-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpd/ntp.conf-man.txt	2017-12-27 14:20:07.139145259 +0000
+@@ -1,4 +1,4 @@
+-= ntp.conf(5) =
++= ntp.conf(4) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/ntpd/ntp.keys-man.txt ntpsec-1.0.0/ntpd/ntp.keys-man.txt
+--- ntpsec-1.0.0~/ntpd/ntp.keys-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpd/ntp.keys-man.txt	2017-12-27 14:20:07.139345620 +0000
+@@ -1,4 +1,4 @@
+-= ntp.keys(5) =
++= ntp.keys(4) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/ntpd/ntpd-man.txt ntpsec-1.0.0/ntpd/ntpd-man.txt
+--- ntpsec-1.0.0~/ntpd/ntpd-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpd/ntpd-man.txt	2017-12-27 14:20:07.139507655 +0000
+@@ -1,4 +1,4 @@
+-= ntpd(8) =
++= ntpd(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/ntpd/wscript ntpsec-1.0.0/ntpd/wscript
+--- ntpsec-1.0.0~/ntpd/wscript	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpd/wscript	2017-12-27 14:20:07.140142787 +0000
+@@ -133,6 +133,6 @@ def build(ctx):
+             "CRYPTO DNS_SD DNS_SD_INCLUDES %s SOCKET NSL SCF" % use_refclock,
+     )
+ 
+-    ctx.manpage(8, "ntpd-man.txt")
+-    ctx.manpage(5, "ntp.conf-man.txt")
+-    ctx.manpage(5, "ntp.keys-man.txt")
++    ctx.manpage("1m", "ntpd-man.txt")
++    ctx.manpage(4, "ntp.conf-man.txt")
++    ctx.manpage(4, "ntp.keys-man.txt")
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/wscript ntpsec-1.0.0/wscript
+--- ntpsec-1.0.0~/wscript	2017-12-27 14:20:06.985213252 +0000
++++ ntpsec-1.0.0/wscript	2017-12-27 14:20:07.139949432 +0000
+@@ -1101,17 +1101,17 @@ def build(ctx):
+     if ctx.cmd == 'clean':
+         afterparty(ctx)
+ 
+-    ctx.manpage(1, "ntpclients/ntploggps-man.txt")
+-    ctx.manpage(1, "ntpclients/ntpdig-man.txt")
+-    ctx.manpage(1, "ntpclients/ntpmon-man.txt")
+-    ctx.manpage(1, "ntpclients/ntpq-man.txt")
+-    ctx.manpage(1, "ntpclients/ntpsweep-man.txt")
+-    ctx.manpage(1, "ntpclients/ntptrace-man.txt")
+-    ctx.manpage(1, "ntpclients/ntpviz-man.txt")
+-    ctx.manpage(1, "ntpclients/ntplogtemp-man.txt")
+-    ctx.manpage(8, "ntpclients/ntpkeygen-man.txt")
+-    ctx.manpage(8, "ntpclients/ntpleapfetch-man.txt")
+-    ctx.manpage(8, "ntpclients/ntpwait-man.txt")
++    ctx.manpage("1m", "ntpclients/ntploggps-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpdig-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpmon-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpq-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpsweep-man.txt")
++    ctx.manpage("1m", "ntpclients/ntptrace-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpviz-man.txt")
++    ctx.manpage("1m", "ntpclients/ntplogtemp-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpkeygen-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpleapfetch-man.txt")
++    ctx.manpage("1m", "ntpclients/ntpwait-man.txt")
+ 
+     # Skip running unit tests on a cross compile build
+     if not ctx.env.ENABLE_CROSS:
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpdig-man.txt ntpsec-1.0.0/ntpclients/ntpdig-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpdig-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpdig-man.txt	2017-12-27 14:27:41.641524630 +0000
+@@ -1,4 +1,4 @@
+-= ntpdig(1) =
++= ntpdig(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpkeygen-man.txt ntpsec-1.0.0/ntpclients/ntpkeygen-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpkeygen-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpkeygen-man.txt	2017-12-27 14:27:46.010859598 +0000
+@@ -1,4 +1,4 @@
+-= ntpkeygen(8) =
++= ntpkeygen(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpleapfetch-man.txt ntpsec-1.0.0/ntpclients/ntpleapfetch-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpleapfetch-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpleapfetch-man.txt	2017-12-27 14:27:50.226539706 +0000
+@@ -1,4 +1,4 @@
+-= ntpleapfetch(8) =
++= ntpleapfetch(1m) =
+ :doctype: manpage
+ 
+ == NAME == 
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntploggps-man.txt ntpsec-1.0.0/ntpclients/ntploggps-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntploggps-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntploggps-man.txt	2017-12-27 14:27:53.252447459 +0000
+@@ -1,4 +1,4 @@
+-= ntploggps(1) =
++= ntploggps(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntplogtemp-man.txt ntpsec-1.0.0/ntpclients/ntplogtemp-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntplogtemp-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntplogtemp-man.txt	2017-12-27 14:28:03.358470877 +0000
+@@ -1,4 +1,4 @@
+-= ntplogtemp-(1) =
++= ntplogtemp(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpmon-man.txt ntpsec-1.0.0/ntpclients/ntpmon-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpmon-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpmon-man.txt	2017-12-27 14:28:06.311128860 +0000
+@@ -1,4 +1,4 @@
+-= ntpmon(1) =
++= ntpmon(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpq-man.txt ntpsec-1.0.0/ntpclients/ntpq-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpq-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpq-man.txt	2017-12-27 14:28:09.543157150 +0000
+@@ -1,4 +1,4 @@
+-= ntpq(1) =
++= ntpq(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpsweep-man.txt ntpsec-1.0.0/ntpclients/ntpsweep-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpsweep-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpsweep-man.txt	2017-12-27 14:28:11.534964730 +0000
+@@ -1,4 +1,4 @@
+-= ntpsweep(1) =
++= ntpsweep(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntptrace-man.txt ntpsec-1.0.0/ntpclients/ntptrace-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntptrace-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntptrace-man.txt	2017-12-27 14:28:13.998988222 +0000
+@@ -1,4 +1,4 @@
+-= ntptrace(1) =
++= ntptrace(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpviz-man.txt ntpsec-1.0.0/ntpclients/ntpviz-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpviz-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpviz-man.txt	2017-12-27 14:28:17.747062892 +0000
+@@ -1,4 +1,4 @@
+-= ntpviz(1) =
++= ntpviz(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpclients/ntpwait-man.txt ntpsec-1.0.0/ntpclients/ntpwait-man.txt
+--- ntpsec-1.0.0.dist/ntpclients/ntpwait-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpclients/ntpwait-man.txt	2017-12-27 14:28:21.587598592 +0000
+@@ -1,4 +1,4 @@
+-= ntpwait(8) =
++= ntpwait(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpfrob/ntpfrob-man.txt ntpsec-1.0.0/ntpfrob/ntpfrob-man.txt
+--- ntpsec-1.0.0.dist/ntpfrob/ntpfrob-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpfrob/ntpfrob-man.txt	2017-12-27 14:45:18.129171208 +0000
+@@ -1,4 +1,4 @@
+-= ntpfrob(8) =
++= ntpfrob(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntpfrob/wscript ntpsec-1.0.0/ntpfrob/wscript
+--- ntpsec-1.0.0.dist/ntpfrob/wscript	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntpfrob/wscript	2017-12-27 14:45:27.158683437 +0000
+@@ -13,4 +13,4 @@
+         use="M RT",
+     )
+ 
+-    ctx.manpage(8, "ntpfrob-man.txt")
++    ctx.manpage("1m", "ntpfrob-man.txt")
+diff -ru ntpsec-1.0.0.dist/ntptime/ntptime-man.txt ntpsec-1.0.0/ntptime/ntptime-man.txt
+--- ntpsec-1.0.0.dist/ntptime/ntptime-man.txt	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntptime/ntptime-man.txt	2017-12-27 14:45:44.477443985 +0000
+@@ -1,4 +1,4 @@
+-= ntptime(8) =
++= ntptime(1m) =
+ :doctype: manpage
+ 
+ == NAME ==
+diff -ru ntpsec-1.0.0.dist/ntptime/wscript ntpsec-1.0.0/ntptime/wscript
+--- ntpsec-1.0.0.dist/ntptime/wscript	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/ntptime/wscript	2017-12-27 14:45:41.435004843 +0000
+@@ -14,6 +14,6 @@
+             install_path='${BINDIR}',
+         )
+ 
+-    ctx.manpage(8, "ntptime-man.txt")
++    ctx.manpage("1m", "ntptime-man.txt")
+ 
+ # end

--- a/build/ntpsec/patches/pie.patch
+++ b/build/ntpsec/patches/pie.patch
@@ -1,0 +1,16 @@
+
+Support for position independent executable is detected but then GCC fails
+to link the NTP daemon. Disable the PIE test for now.
+
+diff -pruN '--exclude=*.orig' ntpsec-1.0.0~/wscript ntpsec-1.0.0/wscript
+--- ntpsec-1.0.0~/wscript	2017-10-10 03:54:39.000000000 +0000
++++ ntpsec-1.0.0/wscript	2017-12-27 14:20:06.985213252 +0000
+@@ -329,7 +329,7 @@ def configure(ctx):
+     cc_test_flags = [
+         ('f_stack_protector_all', '-fstack-protector-all'),
+         ('PIC', '-fPIC'),
+-        ('PIE', '-pie -fPIE'),
++        #('PIE', '-pie -fPIE'),
+         # this quiets most of macOS warnings on -fpie
+         ('unused', '-Qunused-arguments'),
+         # This is a useless warning on any architecture with a barrel

--- a/build/ntpsec/patches/series
+++ b/build/ntpsec/patches/series
@@ -1,0 +1,3 @@
+pie.patch
+conf.patch
+mansections.patch

--- a/build/ntpsec/testsuite.log
+++ b/build/ntpsec/testsuite.log
@@ -1,0 +1,285 @@
+BINARY      : /data/omnios-build/omniosorg/bloody/_build/ntpsec-1.0.0/build/main/tests/test_libparse
+RETURN VALUE: 0
+
+*** stdout ***
+Unity test run 1 of 1
+TEST(binio, get_lsb_int160) PASS
+TEST(binio, get_lsb_int161) PASS
+TEST(binio, get_lsb_int162) PASS
+TEST(binio, get_lsb_int163) PASS
+TEST(binio, get_lsb_int164) PASS
+TEST(binio, get_lsb_int320) PASS
+TEST(binio, get_lsb_int321) PASS
+TEST(binio, get_lsb_int322) PASS
+TEST(binio, get_lsb_int323) PASS
+TEST(binio, get_lsb_int324) PASS
+TEST(binio, put_lsb_uint160) PASS
+TEST(binio, put_lsb_uint161) PASS
+TEST(binio, put_lsb_uint162) PASS
+TEST(binio, put_lsb_uint163) PASS
+TEST(binio, put_lsb_uint164) PASS
+TEST(binio, get_lsb_uint160) PASS
+TEST(binio, get_lsb_uint161) PASS
+TEST(binio, get_lsb_uint162) PASS
+TEST(binio, get_lsb_uint163) PASS
+TEST(binio, get_lsb_uint164) PASS
+TEST(binio, get_lsb_uint320) PASS
+TEST(binio, get_lsb_uint321) PASS
+TEST(binio, get_lsb_uint322) PASS
+TEST(binio, get_lsb_uint323) PASS
+TEST(binio, get_lsb_uint324) PASS
+TEST(binio, get_msb_short0) PASS
+TEST(binio, get_msb_short1) PASS
+TEST(binio, get_msb_short2) PASS
+TEST(binio, get_msb_short3) PASS
+TEST(binio, get_msb_short4) PASS
+TEST(binio, getmsb_short0) PASS
+TEST(binio, getmsb_short1) PASS
+TEST(binio, getmsb_short2) PASS
+TEST(binio, getmsb_short3) PASS
+TEST(binio, getmsb_short4) PASS
+TEST(binio, get_msb_ushort0) PASS
+TEST(binio, get_msb_ushort1) PASS
+TEST(binio, get_msb_ushort2) PASS
+TEST(binio, get_msb_ushort3) PASS
+TEST(binio, get_msb_ushort4) PASS
+TEST(gpstolfp, check) PASS
+TEST(ieee754io, test_zero32) PASS
+TEST(ieee754io, test_one32) PASS
+TEST(ieee754io, test_negone32) PASS
+TEST(ieee754io, test_small32) PASS
+TEST(ieee754io, test_nan32) PASS
+TEST(ieee754io, test_max32) PASS
+TEST(ieee754io, test_order32) PASS
+TEST(ieee754io, test_zero64) PASS
+TEST(ieee754io, test_one64) PASS
+TEST(ieee754io, test_negone64) PASS
+TEST(ieee754io, test_small64) PASS
+TEST(ieee754io, test_nan64) PASS
+TEST(ieee754io, test_max64) PASS
+TEST(ieee754io, test_order64) PASS
+
+-----------------------
+55 Tests 0 Failures 0 Ignored 
+OK
+
+*** stderr ***
+
+
+
+BINARY      : /data/omnios-build/omniosorg/bloody/_build/ntpsec-1.0.0/build/main/tests/test_ntpd
+RETURN VALUE: 0
+
+*** stdout ***
+Unity test run 1 of 1
+TEST(leapsec, ValidateGood) PASS
+TEST(leapsec, ValidateNoHash) PASS
+TEST(leapsec, ValidateBad) PASS
+TEST(leapsec, ValidateMalformed) PASS
+TEST(leapsec, ValidateMalformedShort) PASS
+TEST(leapsec, ValidateNoLeadZero) PASS
+TEST(leapsec, tableSelect) PASS
+TEST(leapsec, loadFileExpire) PASS
+TEST(leapsec, loadFileTTL) PASS
+TEST(leapsec, lsQueryPristineState)leap table (0 entries) expires at 1970-01-01:
+ PASS
+TEST(leapsec, ls2009faraway) PASS
+TEST(leapsec, ls2009weekaway) PASS
+TEST(leapsec, ls2009houraway) PASS
+TEST(leapsec, ls2009secaway) PASS
+TEST(leapsec, ls2009onspot) PASS
+TEST(leapsec, ls2009nodata) PASS
+TEST(leapsec, ls2009limdata)leap table (10 entries) expires at 2014-06-01:
+1991-01-01 [-] (1990-12-04) - 26
+1992-07-01 [-] (1992-06-03) - 27
+1993-07-01 [-] (1993-06-03) - 28
+1994-07-01 [-] (1994-06-03) - 29
+1996-01-01 [-] (1995-12-04) - 30
+1997-07-01 [-] (1997-06-03) - 31
+1999-01-01 [-] (1998-12-04) - 32
+2006-01-01 [-] (2005-12-04) - 33
+2009-01-01 [-] (2008-12-04) - 34
+2012-07-01 [-] (2012-06-03) - 35
+ PASS
+TEST(leapsec, addDynamic)leap table (10 entries) expires at 1993-07-01:
+1990-01-01 [-] (1989-12-04) - 25
+1991-01-01 [-] (1990-12-04) - 26
+1992-07-01 [-] (1992-06-03) - 27
+1993-07-01 [-] (1993-06-03) - 28
+1996-01-11 [*] (1995-12-11) - 29
+1997-07-10 [*] (1997-06-10) - 30
+1999-01-11 [*] (1998-12-11) - 31
+2006-01-11 [*] (2005-12-11) - 32
+2009-01-11 [*] (2008-12-11) - 33
+2012-07-10 [*] (2012-06-10) - 34
+ PASS
+TEST(leapsec, addFixed) PASS
+TEST(leapsec, ls2009seqInsElectric) PASS
+TEST(leapsec, ls2009seqInsDumb) PASS
+TEST(leapsec, ls2009seqDelElectric) PASS
+TEST(leapsec, ls2009seqDelDumb) PASS
+TEST(leapsec, ls2012seqInsElectric) PASS
+TEST(leapsec, ls2012seqInsDumb) PASS
+TEST(leapsec, lsEmptyTableDumb) PASS
+TEST(leapsec, lsEmptyTableElectric) PASS
+TEST(hackrestrict, RestrictionsAreEmptyAfterInit) PASS
+TEST(hackrestrict, ReturnsCorrectDefaultRestrictions) PASS
+TEST(hackrestrict, HackingDefaultRestriction) PASS
+TEST(hackrestrict, CantRemoveDefaultEntry) PASS
+TEST(hackrestrict, AddingNewRestriction) PASS
+TEST(hackrestrict, TheMostFittingRestrictionIsMatched) PASS
+TEST(hackrestrict, DeletedRestrictionIsNotMatched) PASS
+TEST(hackrestrict, RestrictUnflagWorks) PASS
+
+-----------------------
+35 Tests 0 Failures 0 Ignored 
+OK
+
+*** stderr ***
+
+
+
+BINARY      : /data/omnios-build/omniosorg/bloody/_build/ntpsec-1.0.0/build/main/tests/test_libntp
+RETURN VALUE: 0
+
+*** stdout ***
+Unity test run 1 of 1
+TEST(authkeys, AddTrustedKeys) PASS
+TEST(authkeys, AddUntrustedKey) PASS
+TEST(authkeys, HaveKeyCorrect) PASS
+TEST(authkeys, HaveKeyIncorrect) PASS
+TEST(calendar, is_leapyear) PASS
+TEST(calendar, julian0) PASS
+TEST(calendar, days_per_year) PASS
+TEST(calendar, parse_to_unixtime) PASS
+TEST(calendar, DaySplitMerge) PASS
+TEST(calendar, SplitYearDays1) PASS
+TEST(calendar, SplitYearDays2) PASS
+TEST(calendar, RataDie1) PASS
+TEST(calendar, LeapYears1) PASS
+TEST(calendar, LeapYears2) PASS
+TEST(calendar, RoundTripDate) PASS
+TEST(clocktime, CurrentYear) PASS
+TEST(clocktime, CurrentYearExplicit) PASS
+TEST(clocktime, CurrentYearFuzz) PASS
+TEST(clocktime, TimeZoneOffset) PASS
+TEST(clocktime, WrongYearStart) PASS
+TEST(clocktime, PreviousYear) PASS
+TEST(clocktime, NextYear) PASS
+TEST(clocktime, NoReasonableConversion) PASS
+TEST(clocktime, AlwaysInLimit) PASS
+TEST(decodenetnum, Services) PASS
+TEST(decodenetnum, IPv4AddressOnly) PASS
+TEST(decodenetnum, IPv4AddressWithPort) PASS
+TEST(decodenetnum, IPv4AddressWithPort2) PASS
+TEST(decodenetnum, IPv6AddressOnly) PASS
+TEST(decodenetnum, IPv6AddressWithPort) PASS
+TEST(decodenetnum, IllegalAddress) PASS
+TEST(decodenetnum, IllegalCharInPort) PASS
+TEST(hextolfp, PositiveInteger) PASS
+TEST(hextolfp, NegativeInteger) PASS
+TEST(hextolfp, PositiveFraction) PASS
+TEST(hextolfp, NegativeFraction) PASS
+TEST(hextolfp, IllegalNumberOfInteger) PASS
+TEST(hextolfp, IllegalChar) PASS
+TEST(humandate, RegularTime) PASS
+TEST(humandate, CurrentTime) PASS
+TEST(lfpfunc, Extraction) PASS
+TEST(lfpfunc, Negation) PASS
+TEST(lfpfunc, Absolute) PASS
+TEST(lfpfunc, FDF_RoundTrip) PASS
+TEST(lfpfunc, SignedRelOps) PASS
+TEST(lfpfunc, UnsignedRelOps) PASS
+TEST(lfptostr, PositiveInteger) PASS
+TEST(lfptostr, NegativeInteger) PASS
+TEST(lfptostr, PositiveIntegerWithFraction) PASS
+TEST(lfptostr, NegativeIntegerWithFraction) PASS
+TEST(lfptostr, RoundingDownToInteger) PASS
+TEST(lfptostr, RoundingMiddleToInteger) PASS
+TEST(lfptostr, RoundingUpToInteger) PASS
+TEST(lfptostr, SingleDecimal) PASS
+TEST(lfptostr, MillisecondsRoundingUp) PASS
+TEST(lfptostr, MillisecondsRoundingDown) PASS
+TEST(lfptostr, UnsignedInteger) PASS
+TEST(macencrypt, Encrypt) PASS
+TEST(macencrypt, DecryptValid) PASS
+TEST(macencrypt, DecryptInvalid) PASS
+TEST(macencrypt, IPv4AddressToRefId) PASS
+TEST(macencrypt, IPv6AddressToRefId) PASS
+TEST(msyslog, msnprintf) PASS
+TEST(msyslog, msnprintfLiteralPercentm) PASS
+TEST(msyslog, msnprintfBackslashLiteralPercentm) PASS
+TEST(msyslog, msnprintfBackslashPercent) PASS
+TEST(msyslog, msnprintfHangingPercent) PASS
+TEST(msyslog, format_errmsgHangingPercent) PASS
+TEST(msyslog, msnprintfNullTarget) PASS
+TEST(msyslog, msnprintfTruncate) PASS
+TEST(netof6, IPv6Address) PASS
+TEST(numtoa, Address) PASS
+TEST(numtoa, Netmask) PASS
+TEST(prettydate, ConstantDate) PASS
+TEST(recvbuff, Initialization) PASS
+TEST(recvbuff, GetAndFree) PASS
+TEST(recvbuff, GetAndFill) PASS
+TEST(refidsmear, Main) PASS
+TEST(socktoa, IPv4AddressWithPort) PASS
+TEST(socktoa, IPv6AddressWithPort) PASS
+TEST(socktoa, ScopedIPv6AddressWithPort) PASS
+TEST(socktoa, HashEqual) PASS
+TEST(socktoa, HashNotEqual) PASS
+TEST(socktoa, IgnoreIPv6Fields) PASS
+TEST(statestr, PeerRestart) PASS
+TEST(statestr, SysUnspecified) PASS
+TEST(statestr, ClockCodeExists) PASS
+TEST(statestr, ClockCodeUnknown) PASS
+TEST(strtolfp, PositiveInteger) PASS
+TEST(strtolfp, NegativeInteger) PASS
+TEST(strtolfp, PositiveFraction) PASS
+TEST(strtolfp, NegativeFraction) PASS
+TEST(strtolfp, PositiveMsFraction) PASS
+TEST(strtolfp, NegativeMsFraction) PASS
+TEST(strtolfp, InvalidChars) PASS
+TEST(timespecops, Helpers1) PASS
+TEST(timespecops, Normalise) PASS
+TEST(timespecops, SignNoFrac) PASS
+TEST(timespecops, SignWithFrac) PASS
+TEST(timespecops, CmpFracEQ) PASS
+TEST(timespecops, CmpFracGT) PASS
+TEST(timespecops, CmpFracLT) PASS
+TEST(timespecops, AddFullNorm) PASS
+TEST(timespecops, AddFullOflow1) PASS
+TEST(timespecops, AddNsecNorm) PASS
+TEST(timespecops, AddNsecOflow1) PASS
+TEST(timespecops, SubFullNorm) PASS
+TEST(timespecops, SubFullOflow) PASS
+TEST(timespecops, SubNsecNorm) PASS
+TEST(timespecops, SubNsecOflow) PASS
+TEST(timespecops, test_Neg) PASS
+TEST(timespecops, test_AbsNoFrac) PASS
+TEST(timespecops, test_AbsWithFrac) PASS
+TEST(timespecops, test_ToLFPbittest) PASS
+TEST(timespecops, test_ToLFPrelPos) PASS
+TEST(timespecops, test_ToLFPrelNeg) PASS
+TEST(timespecops, test_ToLFPabs) PASS
+TEST(timespecops, test_FromLFPbittest) PASS
+TEST(timespecops, test_FromLFPrelPos) PASS
+TEST(timespecops, test_FromLFPrelNeg) PASS
+TEST(timespecops, test_LFProundtrip) PASS
+TEST(timespecops, test_ToString) PASS
+TEST(vi64ops, SetVUI64s_pos) PASS
+TEST(vi64ops, SetVUI64s_neg) PASS
+TEST(vi64ops, SetVUI64u) PASS
+TEST(vi64ops, NegVUI64) PASS
+TEST(ymd2yd, NonLeapYearFebruary) PASS
+TEST(ymd2yd, NonLeapYearJune) PASS
+TEST(ymd2yd, LeapYearFebruary) PASS
+TEST(ymd2yd, LeapYearDecember) PASS
+
+-----------------------
+130 Tests 0 Failures 0 Ignored 
+OK
+
+*** stderr ***
+
+
+

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -45,10 +45,23 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
   Mailwrapper is still available to support use of packages from non-IPS
   repositories such as _pkgsrc_ via `/etc/mailer.conf`
 
-* Experimental support for `sparse` zones. These are linked-ipkg zones that
-  share the `/usr`, `/sbin` and `/lib` directories with the global zone.
-  They are tiny (under 4MiB of installed files) and perfect for isolating
-  VM instances for extra security or to apply more granular resource controls.
+* A new `service/network/ntpsec` package is available as an alternative to
+  `service/network/ntp`. NTPsec is a secure, hardened and improved
+  implementation of the Network Time Protocol derived from NTP Classic.
+  NTPsec also runs with stack protection and ASLR out of the box on OmniOS.
+  To switch just record any changes you have made to `/etc/inet/ntp.conf` and
+  the service manifest properties (`svcprop -p config ntp`) and then
+  `pkg uninstall service/network/ntp && pkg install service/network/ntpsec`.
+  Restore any customisations and then start the network/ntp service.
+
+* Experimental support for `sparse` and `vm` branded zones. These are
+  linked-ipkg zones that share most of the `/usr`, `/sbin` and `/lib`
+  directories with the global zone. They are tiny (under 4MiB of installed
+  files) and perfect for isolating small services or VM instances for extra
+  security or to apply more granular resource controls. The only current
+  difference between `sparse` and `vm` zones is the services which are enabled
+  by default. `vm` zones have no services running and are designed specifically
+  for isolating VM instances; they may become more specialised in the future.
 
 * A number of system components now enable Address Space Layout Randomisation
   (ASLR) by default:
@@ -57,6 +70,7 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
     * rpcbind
     * Sendmail
     * Dragonfly Mail Agent
+    * NTPsec
 
 * `openssh` has been upgraded to 7.6p1. This version drops support for
   SSH protocol version 1, RSA keys under 1024 bits in length and a number

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -62,6 +62,7 @@
 | runtime/python-27			| 2.7.14		| https://www.python.org/downloads/source/
 | security/sudo				| 1.8.21p2		| https://www.sudo.ws/
 | service/network/ntp			| 4.2.8p10		| http://www.ntp.org/downloads.html
+| service/network/ntpsec		| 1.0.0			| https://github.com/ntpsec/ntpsec/releases
 | service/network/smtp/dma		| 0.11			| https://github.com/corecode/dma/releases
 | shell/bash				| 4.4.12		| https://ftp.gnu.org/gnu/bash/
 | shell/bash-patchlvl			| 012			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches


### PR DESCRIPTION
Provide NTPsec (https://www.ntpsec.org/) as a more modern, lightweight and secure alternative to  NTP Classic. The existing NTP package is not yet being deprecated (but might be in the future).