### PR TITLE
ntp: Remove duplicate man pages & HTML docs

### DIFF
--- a/build/ntp/build.sh
+++ b/build/ntp/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=ntp
@@ -57,10 +55,7 @@ CONFIGURE_OPTS_32="--prefix=/usr
 "
 
 overlay_root() {
-    logcmd rm -f $DESTDIR/usr/sbin/tickadj
-    logcmd ln -s ntpdc $DESTDIR/usr/sbin/xntpdc
     (cd $SRCDIR/root && tar cf - .) | (cd $DESTDIR && tar xf -)
-    logcmd mkdir -p $DESTDIR/var/ntp/ntpstats
 }
 
 init
@@ -77,4 +72,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/ntp/local.mog
+++ b/build/ntp/local.mog
@@ -21,6 +21,7 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 <transform dir  path=var/.* -> set group sys>
@@ -32,5 +33,17 @@
 <transform file path=etc/security/.*/ntp$ -> set mode 0444>
 <transform file path=usr/sbin/.* -> set mode 0555>
 <transform file path=usr/lib/inet/.* -> set mode 0555>
-<transform file path=(usr/lib/inet/ntpd|lib/svc/method/ntp)$ -> set restart_fmri svc:/network/ntp:default>
+<transform file path=(usr/lib/inet/ntpd|lib/svc/method/ntp)$ \
+    -> set restart_fmri svc:/network/ntp:default>
 license COPYRIGHT license="UD Open Source"
+
+<transform file path=usr/sbin/tickadj -> drop>
+link path=usr/sbin/xntpdc target=ntpdc
+dir group=sys mode=0755 owner=root path=var/ntp
+dir group=sys mode=0755 owner=root path=var/ntp/ntpstats
+
+# Drop duplicate man pages & documentation
+<transform dir path=usr/share/man/man[158]$ -> drop>
+<transform file path=usr/share/man/man[158]/ -> drop>
+<transform file dir link path=usr/share/doc -> drop>
+


### PR DESCRIPTION
NTP currently delivers man pages to multiple places, e.g.

```
% pkg contents ntp | grep ntpd.1m
usr/share/man/man1/ntpd.1m
usr/share/man/man1m/ntpd.1m
```

This drops the copies from the non-OmniOS-standard directories.
Also removing HTML documentation
