### PR TITLE
bind: deliver python modules under vendor-packages/

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=bind
@@ -32,9 +31,9 @@ VER=9.10.6
 VERHUMAN=$VER
 PKG=network/dns/bind
 SUMMARY="BIND DNS tools"
-DESC="$SUMMARY ($VER)"
+DESC="$SUMMARY"
 
-DEPENDS_IPS="library/libxml2 library/security/openssl library/zlib
+RUN_DEPENDS_IPS="library/libxml2 library/security/openssl library/zlib
              system/library system/library/gcc-runtime system/library/math"
 
 BUILDARCH=32
@@ -57,11 +56,18 @@ CONFIGURE_OPTS="
     --disable-static
 "
 
+python_cleanup() {
+    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
+        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages \
+        || logerr "Cannot move from site-packages to vendor-packages"
+}
+
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+python_cleanup
 run_testsuite test-force
 make_isa_stub
 VER=${VER//-P/.}
@@ -70,4 +76,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/bind/local.mog
+++ b/build/bind/local.mog
@@ -22,17 +22,13 @@
 
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Use is subject to license terms.
-#
-
-#
 # Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
 <transform dir  path=etc -> drop>
 <transform file path=etc/bind.keys -> drop>
-<transform dir  path=usr/include -> drop>
-<transform file path=usr/include/.* -> drop>
+<transform file dir path=usr/include -> drop>
 <transform file path=usr/sbin/arpaname -> drop>
 <transform file path=usr/sbin/ddns-confgen -> drop>
 <transform file path=usr/sbin/dnssec-.* -> drop>
@@ -42,8 +38,7 @@
 <transform hardlink path=usr/sbin/bind9-config -> drop>
 <transform file path=usr/sbin/isc-hmac-fixup -> drop>
 <transform hardlink path=usr/sbin/lwresd -> drop>
-<transform file path=usr/sbin/named.* -> drop>
-<transform link path=usr/sbin/named.* -> drop>
+<transform file link path=usr/sbin/named.* -> drop>
 <transform file path=usr/sbin/nsec3hash -> drop>
 <transform file path=usr/sbin/pkcs11.* -> drop>
 <transform file path=usr/sbin/rndc -> drop>
@@ -54,9 +49,5 @@
 <transform file path=usr/share/man/man1/named-rrchecker.1 -> drop>
 <transform hardlink path=usr/share/man/man1/bind9-config.sh.1 -> drop>
 <transform hardlink path=usr/share/man/man1/bind9-config.1 -> drop>
-<transform dir  path=usr/share/man/man[358] -> drop>
-<transform file path=usr/share/man/man[358]/.* -> drop>
-<transform link path=usr/share/man/man[358]/.* -> drop>
-<transform hardlink path=usr/share/man/man[358]/.* -> drop>
-<transform dir  path=var -> drop>
+<transform file dir link hardlink path=usr/share/man/man[358] -> drop>
 license COPYRIGHT license=ISC


### PR DESCRIPTION
as our other packages do. They're currently under site-packages/ which is wrong.