### PR TITLE
Centralise Python site-packages->vendor->packages code

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 . ../../lib/functions.sh
@@ -56,18 +56,12 @@ CONFIGURE_OPTS="
     --disable-static
 "
 
-python_cleanup() {
-    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
-        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages \
-        || logerr "Cannot move from site-packages to vendor-packages"
-}
-
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-python_cleanup
+python_vendor_relocate
 run_testsuite test-force
 make_isa_stub
 VER=${VER//-P/.}

--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -21,10 +21,9 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=libxml2
@@ -38,12 +37,6 @@ RUN_DEPENDS_IPS="compress/xz library/zlib"
 BUILD_DEPENDS_IPS="developer/sunstudio12.1"
 
 XFORM_ARGS="-D VER=$VER"
-
-python_cleanup() {
-    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
-        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages \
-        || logerr "Cannot move from site-packages to vendor-packages"
-}
 
 make_install64() {
     logmsg "--- make install"
@@ -65,7 +58,7 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-python_cleanup
+python_vendor_relocate
 run_testsuite check
 make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
 make_isa_stub

--- a/build/libxslt/build.sh
+++ b/build/libxslt/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 . ../../lib/functions.sh
@@ -91,19 +91,13 @@ tests() {
 	    || logerr "xslt-config --cflags not working"
 }
 
-python_cleanup() {
-    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
-        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages \
-        || logerr "Cannot move from site-packages to vendor-packages"
-}
-
 init
 download_source $PROG $PROG $VER
 patch_source
 backup_man
 prep_build
 build
-python_cleanup
+python_vendor_relocate
 make_isa_stub
 tests
 make_package

--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -20,11 +20,10 @@
 #
 # CDDL HEADER END }}}
 #
-#
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=mercurial
@@ -63,8 +62,7 @@ python_build() {
         logerr "--- install failed"
     popd > /dev/null
 
-    mv $DESTDIR/usr/lib/python2.7/site-packages $DESTDIR/usr/lib/python2.7/vendor-packages ||
-        logerr "Cannot move from site-packages to vendor-packages"
+    python_vendor_relocate
 }
 
 init

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -22,7 +22,7 @@
 #
 # Copyright (c) 2014 by Delphix. All rights reserved.
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 
@@ -1283,6 +1283,12 @@ pre_python_64() {
     logmsg "prepping 64bit python build"
 }
 
+python_vendor_relocate() {
+    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
+        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages ||
+        logerr "python: cannot move from site-packages to vendor-packages"
+}
+
 python_build() {
     [ -z "$PYTHON" ] && logerr "PYTHON not set"
     [ -z "$PYTHONPATH" ] && logerr "PYTHONPATH not set"
@@ -1313,9 +1319,7 @@ python_build() {
         logerr "--- install failed"
     popd > /dev/null
 
-    mv $DESTDIR/usr/lib/python$PYTHONVER/site-packages \
-        $DESTDIR/usr/lib/python$PYTHONVER/vendor-packages ||
-        logerr "Cannot move from site-packages to vendor-packages"
+    python_vendor_relocate
 }
 
 #############################################################################


### PR DESCRIPTION
The python module build code in `lib/functions.sh` already automatically deals with moving python files from `site-packages/` to `vendor-packages/` but other packages that deliver python components have this code in their build script. I've split out the code in functions.sh into a new function and then updated those packages that had their own copy to use the central one.