### PR TITLE
rsync: update dash-revision

### DIFF
--- a/build/rsync/build.sh
+++ b/build/rsync/build.sh
@@ -34,6 +34,10 @@ PKG=network/rsync
 SUMMARY="rsync - faster, flexible replacement for rcp"
 DESC="rsync - faster, flexible replacement for rcp"
 
+# Two new local patches since last release.
+# Remove when rsync version goes to >= 3.1.3
+DASHREV=2
+
 REMOVE_PREVIOUS=1
 BUILDARCH=32
 CONFIGURE_OPTS_32="$CONFIGURE_OPTS_32 --bindir=/usr/bin --with-included-popt"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -768,6 +768,8 @@ make_package() {
     if [ -n "$FLAVORSTR" ]; then
         DESCSTR="$DESCSTR ($FLAVOR)"
     fi
+    # Add the local dash-revision if specified.
+    [ -n "$DASHREV" ] && PVER=$DASHREV.$RELVER
     PKGSEND=/usr/bin/pkgsend
     PKGLINT=/usr/bin/pkglint
     PKGMOGRIFY=/usr/bin/pkgmogrify


### PR DESCRIPTION
Since we originally published rsync 3.1.2, we've updated it to fix CVEs but not increased the version number. That means that users need to rely on package timestamps to see which version they have. For example on r151024:

```
% pkg list -afv rsync
FMRI                                                                         IFO
pkg://omnios/network/rsync@3.1.2-0.151024:20171207T202651Z                   i--
pkg://omnios/network/rsync@3.1.2-0.151024:20171207T194017Z                   ---
pkg://omnios/network/rsync@3.1.2-0.151024:20171030T152409Z                   ---
```

As per IPS documentation:

> The third part of the version, which if present must follow a hyphen
> (-), is the branch version. The branch version is a versioning
> component that provides vendor-specific information. The branch version
> can be incremented when the packaging metadata is changed,
> independently of the component version. The branch version might
> contain a build number or other information.

and we currently set this to `0.r15102x` for all packages.

I'm introducing a new variable (`DASHREV`) to specify the dash-revision to be used and setting this initially to 2 for rsync. That will result in a version like:
```
pkg://omnios/network/rsync@3.1.2-2.151024:20180110T103622Z
```
We should begin to increment DASHREV for any packages where we backport specific patches - this will be mostly for LTS releases - resetting it to zero when the package version increases.

(Making this change for `rsync` should also make it easier for users upgrading from OmniTI OmniOS to the community edition).

Open to discussion about the variable name since it's a hyphen not a dash, but HYPHENREV seemed klunky...
  