### PR TITLE
setuptools: update to 38.4.0

### DIFF
--- a/build/python27/setuptools/build.sh
+++ b/build/python27/setuptools/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/setuptools-27
 PROG=setuptools
-VER=38.2.4
+VER=38.4.0
 SUMMARY="setuptools - Easily download, build, install, upgrade, and uninstall Python packages"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -116,7 +116,7 @@
 | library/python-2/pycurl-27		| 7.43.0.1		| https://pypi.python.org/pypi/pycurl
 | library/python-2/pyopenssl-27		| 17.5.0		| https://pypi.python.org/pypi/pyOpenSSL
 | library/python-2/pytz-27		| 2017.3		| https://pypi.python.org/pypi/pytz
-| library/python-2/setuptools-27	| 38.2.4		| https://pypi.python.org/pypi/setuptools
+| library/python-2/setuptools-27	| 38.4.0		| https://pypi.python.org/pypi/setuptools
 | library/python-2/simplejson-27	| 3.13.2		| https://pypi.python.org/pypi/simplejson
 | library/python-2/six-27		| 1.11.0		| https://pypi.python.org/pypi/six
 | library/python-2/tempora-27		| 1.10			| https://pypi.python.org/pypi/tempora


### PR DESCRIPTION
pkg test suite run, no regressions.
rebuilt all python modules successfully with new setuptools.