### PR TITLE
cffi: update to 1.11.4

### DIFF
--- a/build/python27/cffi/build.sh
+++ b/build/python27/cffi/build.sh
@@ -24,12 +24,11 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../../lib/functions.sh
 
 PKG=library/python-2/cffi-27
 PROG=cffi
-VER=1.11.3
+VER=1.11.4
 SUMMARY="cffi - Foreign Function Interface for Python calling C code"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -96,7 +96,7 @@
 | developer/swig			| 3.0.12		| http://www.swig.org/download.html
 | library/security/trousers		| 0.3.14		| https://sourceforge.net/projects/trousers/files/trousers
 | library/python-2/asn1crypto-27	| 0.24.0		| https://pypi.python.org/pypi/asn1crypto
-| library/python-2/cffi-27		| 1.11.3		| https://pypi.python.org/pypi/cffi
+| library/python-2/cffi-27		| 1.11.4		| https://pypi.python.org/pypi/cffi
 | library/python-2/cheroot-27		| 6.0.0			| https://pypi.python.org/pypi/cheroot
 | library/python-2/cherrypy-27		| 13.1.0		| https://pypi.python.org/pypi/cherrypy
 | library/python-2/coverage-27		| 4.4.2			| https://pypi.python.org/pypi/coverage


### PR DESCRIPTION
Built new module then rebuilt all python modules, installed them, and then ran the pkg test suite with no regressions.