### PR TITLE
cpuid: update to 1.6.1

### DIFF
--- a/build/cpuid/build.sh
+++ b/build/cpuid/build.sh
@@ -15,11 +15,10 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=cpuid
-VER=1.5.0
+VER=1.6.1
 VERHUMAN=$VER
 PKG=system/cpuid
 SUMMARY="A simple CPUID decoder/dumper for x86/x86_64"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -69,7 +69,7 @@
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.00		| https://github.com/tcsh-org/tcsh/releases
 | shell/zsh				| 5.4.2			| https://sourceforge.net/projects/zsh/files/zsh
-| system/cpuid				| 1.5.0			| https://github.com/tycho/cpuid/releases
+| system/cpuid				| 1.6.1			| https://github.com/tycho/cpuid/releases
 | system/library/dbus			| 1.12.2		| https://dbus.freedesktop.org/releases/dbus
 | system/library/libdbus-glib		| 0.108			| https://dbus.freedesktop.org/releases/dbus-glib/
 | system/library/pcap			| 1.8.1			| http://www.tcpdump.org/#latest-releases


### PR DESCRIPTION
This new version includes detection of the new CPU instructions added via microcode in response to the recent Spectre attach, and also provides more details on things like TLB architecture.

I'm going to backport this to r22&r24 too.

```
reaper# ucodeadm -v | head -2
CPU     Microcode Version
0       0x2d
reaper# cpuid | egrep 'IBRS|STI'

reaper# ucodeadm -u intel-ucode-201808.txt
reaper# ucodeadm -v | head -2
CPU     Microcode Version
0       0x3b
reaper# cpuid | egrep 'IBRS|STI'
  Speculation Control (IBRS and IBPB)
  Single Thread Indirect Branch Predictors (STIBP)
```