### PR TITLE
Prevent GCC from bundling own copy of userland include files.

### DIFF
--- a/build/bash/patches/memalloc.patch
+++ b/build/bash/patches/memalloc.patch
@@ -1,0 +1,20 @@
+'sun' is considered a forbidden identifier by GCC and therefore it creates
+a "fixed" version of bash/include/memalloc.h in its library directory.
+
+This prevents the compiler from seeing any updated version of that file.
+
+To resolve that, the fix that GCC would use is applied directly to the
+include file so that it doesn't see a need to fix it.
+
+diff -ru bash-4.4~/include/memalloc.h bash-4.4/include/memalloc.h
+--- bash-4.4~/include/memalloc.h	2008-08-12 14:01:05.000000000 +0000
++++ bash-4.4/include/memalloc.h	2018-01-22 20:34:48.611886722 +0000
+@@ -22,7 +22,7 @@
+ #if !defined (_MEMALLOC_H_)
+ #  define _MEMALLOC_H_
+ 
+-#if defined (sparc) && defined (sun) && !defined (HAVE_ALLOCA_H)
++#if defined (sparc) && defined (__sun__) && !defined (HAVE_ALLOCA_H)
+ #  define HAVE_ALLOCA_H
+ #endif
+ 

--- a/build/bash/patches/series
+++ b/build/bash/patches/series
@@ -10,3 +10,4 @@ bash-4.4-patches/bash44-009 -p0
 bash-4.4-patches/bash44-010 -p0
 bash-4.4-patches/bash44-011 -p0
 bash-4.4-patches/bash44-012 -p0
+memalloc.patch

--- a/build/openssl/patches-1.0/opensslconf.patch
+++ b/build/openssl/patches-1.0/opensslconf.patch
@@ -1,0 +1,21 @@
+
+'sun' is considered a forbidden identifier by GCC and therefore it creates
+a "fixed" version of openssl/opensslconf.h in its library directory.
+
+This breaks the openssl mediation in OmniOS and also prevents the
+compiler from seeing any updated version of that file.
+
+To resolve that, the fix that GCC would use is applied directly to the
+include file so that it doesn't see a need to fix it.
+
+--- openssl-1.0.2n/crypto/opensslconf.h.in~	2018-01-22 20:06:01.457357627 +0000
++++ openssl-1.0.2n/crypto/opensslconf.h.in	2018-01-22 20:06:51.976227643 +0000
+@@ -120,7 +120,7 @@
+    optimization options.  Older Sparc's work better with only UNROLL, but
+    there's no way to tell at compile time what it is you're running on */
+  
+-#if defined( __sun ) || defined ( sun )		/* Newer Sparc's */
++#if defined( __sun ) || defined ( __sun__ )		/* Newer Sparc's */
+ #  define DES_PTR
+ #  define DES_RISC1
+ #  define DES_UNROLL

--- a/build/openssl/patches-1.0/series
+++ b/build/openssl/patches-1.0/series
@@ -1,2 +1,3 @@
 pkcs11.patch -p1
 unused-dep.patch -p0
+opensslconf.patch


### PR DESCRIPTION
By default, GCC considers certain identifiers in include files to be "forbidden" and will then include private modified copies of these files in its own library to override the copies in system include directories.
For userland software this is generally undesirable since GCC will continue using its private copy even when the corresponding package is updated.
In particular for openssl, this breaks the version mediation in OmniOS since gcc will continue using the openssl 1.0 header even when openssl 1.1 is selected.