### PR TITLE
bash: update to 4.4.18

### DIFF
--- a/build/bash/build.sh
+++ b/build/bash/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,23 +18,20 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 # Copyright (c) 2013 by Delphix. All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
-
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=bash       # App name
-VER=4.4         # App version
-PATCHLEVEL=12   # Patch level
+PROG=bash
+VER=4.4
+PATCHLEVEL=18
 VERHUMAN="$VER.$PATCHLEVEL"
-PKG=shell/bash  # Package name (without prefix)
+PKG=shell/bash
 SUMMARY="GNU Bourne-Again shell (bash)"
 DESC="$SUMMARY"
 
@@ -113,4 +110,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/bash/patches/bash-4.4-patches/bash44-013
+++ b/build/bash/patches/bash-4.4-patches/bash44-013
@@ -1,0 +1,43 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-013
+
+Bug-Reported-by:	Siteshwar Vashisht <svashisht@redhat.com>
+Bug-Reference-ID:	<1508861265.9523642.1484659442561.JavaMail.zimbra@redhat.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2017-01/msg00026.html
+
+Bug-Description:
+
+If a here-document contains a command substitution, the command substitution
+can get access to the file descriptor used to write the here-document.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4-patched/redir.c	2016-06-02 20:22:24.000000000 -0400
+--- redir.c	2017-01-17 13:23:40.000000000 -0500
+***************
+*** 470,473 ****
+--- 467,472 ----
+      }
+  
++   SET_CLOSE_ON_EXEC (fd);
++ 
+    errno = r = 0;		/* XXX */
+    /* write_here_document returns 0 on success, errno on failure. */
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 12
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 13
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/bash-4.4-patches/bash44-014
+++ b/build/bash/patches/bash-4.4-patches/bash44-014
@@ -1,0 +1,104 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-014
+
+Bug-Reported-by:	Oyvind Hvidsten <oyvind.hvidsten@dhampir.no>	
+Bug-Reference-ID:	<c01b7049-925c-9409-d978-e59bf42591f4@dhampir.no>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2017-12/msg00023.html
+
+Bug-Description:
+
+Under some circumstances, functions that return via the `return' builtin do
+not clean up memory they allocated to keep track of FIFOs.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20171205/execute_cmd.c	2017-12-08 07:38:28.000000000 -0500
+--- execute_cmd.c	2018-01-26 15:23:38.000000000 -0500
+***************
+*** 727,730 ****
+--- 727,732 ----
+        ofifo = num_fifos ();
+        ofifo_list = copy_fifo_list ((int *)&osize);
++       begin_unwind_frame ("internal_fifos");
++       add_unwind_protect (xfree, ofifo_list);
+        saved_fifo = 1;
+      }
+***************
+*** 742,746 ****
+  #if defined (PROCESS_SUBSTITUTION)
+        if (saved_fifo)
+! 	free ((void *)ofifo_list);
+  #endif
+        return (last_command_exit_value = EXECUTION_FAILURE);
+--- 744,751 ----
+  #if defined (PROCESS_SUBSTITUTION)
+        if (saved_fifo)
+!         {
+! 	  free ((void *)ofifo_list);
+! 	  discard_unwind_frame ("internal_fifos");
+!         }
+  #endif
+        return (last_command_exit_value = EXECUTION_FAILURE);
+***************
+*** 1061,1064 ****
+--- 1066,1070 ----
+  	close_new_fifos ((char *)ofifo_list, osize);
+        free ((void *)ofifo_list);
++       discard_unwind_frame ("internal_fifos");
+      }
+  #endif
+***************
+*** 4978,4984 ****
+  #endif
+  
+! #if defined (PROCESS_SUBSTITUTION)  
+    ofifo = num_fifos ();
+    ofifo_list = copy_fifo_list (&osize);
+  #endif
+  
+--- 4984,4995 ----
+  #endif
+  
+! #if defined (PROCESS_SUBSTITUTION)
+!   begin_unwind_frame ("saved_fifos");
+!   /* If we return, we longjmp and don't get a chance to restore the old
+!      fifo list, so we add an unwind protect to free it */
+    ofifo = num_fifos ();
+    ofifo_list = copy_fifo_list (&osize);
++   if (ofifo_list)
++     add_unwind_protect (xfree, ofifo_list);
+  #endif
+  
+***************
+*** 5064,5068 ****
+    if (nfifo > ofifo)
+      close_new_fifos (ofifo_list, osize);
+!   free (ofifo_list);
+  #endif
+  
+--- 5075,5081 ----
+    if (nfifo > ofifo)
+      close_new_fifos (ofifo_list, osize);
+!   if (ofifo_list)
+!     free (ofifo_list);
+!   discard_unwind_frame ("saved_fifos");
+  #endif
+  
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 13
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 14
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/bash-4.4-patches/bash44-015
+++ b/build/bash/patches/bash-4.4-patches/bash44-015
@@ -1,0 +1,43 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-015
+
+Bug-Reported-by:	David Simmons <bug-bash@tmp.davidsimmons.com>
+Bug-Reference-ID:	<bc6f0839-fa50-fe8f-65f5-5aa6feb11ec5@davidsimmons.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2017-02/msg00033.html
+
+Bug-Description:
+
+Process substitution can leak internal quoting to the parser in the invoked
+subshell.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20170210/subst.c	2017-01-19 11:08:50.000000000 -0500
+--- subst.c	2017-02-20 10:12:49.000000000 -0500
+***************
+*** 5907,5910 ****
+--- 5907,5912 ----
+    expanding_redir = 0;
+  
++   remove_quoted_escapes (string);
++ 
+    subshell_level++;
+    result = parse_and_execute (string, "process substitution", (SEVAL_NONINT|SEVAL_NOHIST));
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 14
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 15
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/bash-4.4-patches/bash44-016
+++ b/build/bash/patches/bash-4.4-patches/bash44-016
@@ -1,0 +1,78 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-016
+
+Bug-Reported-by:	Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Bug-Reference-ID:	<CAJq09z7G1-QnLyiUQA0DS=V3da_rtHF8VdYbbdzPe_W3kydpRg@mail.gmail.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2016-09/msg00092.html
+
+Bug-Description:
+
+Bash can perform trap processing while reading command substitution output
+instead of waiting until the command completes.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-4.4/lib/sh/zread.c	2014-12-22 10:48:04.000000000 -0500
+--- lib/sh/zread.c	2016-09-29 15:21:36.000000000 -0400
+***************
+*** 38,42 ****
+--- 38,45 ----
+  #endif
+  
++ extern int executing_builtin;
++ 
+  extern void check_signals_and_traps (void);
++ extern void check_signals (void);
+  extern int signal_is_trapped (int);
+  
+***************
+*** 51,69 ****
+    ssize_t r;
+  
+- #if 0
+- #if defined (HAVE_SIGINTERRUPT)
+-   if (signal_is_trapped (SIGCHLD))
+-     siginterrupt (SIGCHLD, 1);
+- #endif
+- #endif
+- 
+    while ((r = read (fd, buf, len)) < 0 && errno == EINTR)
+!     check_signals_and_traps ();	/* XXX - should it be check_signals()? */
+! 
+! #if 0 
+! #if defined (HAVE_SIGINTERRUPT)
+!   siginterrupt (SIGCHLD, 0);
+! #endif
+! #endif
+  
+    return r;
+--- 54,64 ----
+    ssize_t r;
+  
+    while ((r = read (fd, buf, len)) < 0 && errno == EINTR)
+!     /* XXX - bash-5.0 */
+!     /* We check executing_builtin and run traps here for backwards compatibility */
+!     if (executing_builtin)
+!       check_signals_and_traps ();	/* XXX - should it be check_signals()? */
+!     else
+!       check_signals ();
+  
+    return r;
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 15
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 16
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/bash-4.4-patches/bash44-017
+++ b/build/bash/patches/bash-4.4-patches/bash44-017
@@ -1,0 +1,45 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-017
+
+Bug-Reported-by:	ZhangXiao <xiao.zhang@windriver.com>
+Bug-Reference-ID:	<58AD3EAC.4020608@windriver.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2017-02/msg00061.html
+
+Bug-Description:
+
+There is a memory leak when `read -e' is used to read a line using readline.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20170217/builtins/read.def	2017-01-02 16:53:02.000000000 -0500
+--- builtins/read.def	2017-02-22 09:43:14.000000000 -0500
+***************
+*** 691,694 ****
+--- 691,699 ----
+    CHECK_ALRM;
+  
++ #if defined (READLINE)
++   if (edit)
++     free (rlbuf);
++ #endif
++ 
+    if (retval < 0)
+      {
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 16
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 17
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/bash-4.4-patches/bash44-018
+++ b/build/bash/patches/bash-4.4-patches/bash44-018
@@ -1,0 +1,48 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.4
+Patch-ID:	bash44-018
+
+Bug-Reported-by:	Siteshwar Vashisht <svashisht@redhat.com>
+Bug-Reference-ID:	<1341922391.30876471.1501250355579.JavaMail.zimbra@redhat.com>
+Bug-Reference-URL:	https://bugzilla.redhat.com/show_bug.cgi?id=1466737
+
+Bug-Description:
+
+Under certain circumstances (e.g., reading from /dev/zero), read(2) will not
+return -1 even when interrupted by a signal. The read builtin needs to check
+for signals in this case.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20170622/builtins/read.def	2017-06-17 18:45:20.000000000 -0400
+--- builtins/read.def	2017-06-30 11:09:26.000000000 -0400
+***************
+*** 611,615 ****
+  
+        CHECK_ALRM;
+! 
+  #if defined (READLINE)
+  	}
+--- 611,615 ----
+  
+        CHECK_ALRM;
+!       QUIT;		/* in case we didn't call check_signals() */
+  #if defined (READLINE)
+  	}
+*** ../bash-4.4/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 17
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 18
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/build/bash/patches/series
+++ b/build/bash/patches/series
@@ -10,4 +10,10 @@ bash-4.4-patches/bash44-009 -p0
 bash-4.4-patches/bash44-010 -p0
 bash-4.4-patches/bash44-011 -p0
 bash-4.4-patches/bash44-012 -p0
+bash-4.4-patches/bash44-013 -p0
+bash-4.4-patches/bash44-014 -p0
+bash-4.4-patches/bash44-015 -p0
+bash-4.4-patches/bash44-016 -p0
+bash-4.4-patches/bash44-017 -p0
+bash-4.4-patches/bash44-018 -p0
 memalloc.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -66,7 +66,7 @@
 | service/network/ntpsec		| 1.0.0			| https://github.com/ntpsec/ntpsec/releases
 | service/network/smtp/dma		| 0.11			| https://github.com/corecode/dma/releases
 | shell/bash				| 4.4.12		| https://ftp.gnu.org/gnu/bash/
-| shell/bash-patchlvl			| 012			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches
+| shell/bash-patchlvl			| 018			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.00		| https://github.com/tcsh-org/tcsh/releases
 | shell/zsh				| 5.4.2			| https://sourceforge.net/projects/zsh/files/zsh


### PR DESCRIPTION
```
hadfl@bloody-build:~$ bash --version
GNU bash, version 4.4.18(1)-release (i386-pc-solaris2.11)
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```