### PR TITLE
ISC dhcp: update to 4.4.0

### DIFF
--- a/build/isc-dhcp/build.sh
+++ b/build/isc-dhcp/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
@@ -11,16 +11,15 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=dhcp
-VER=4.3.6
+VER=4.4.0
 VERHUMAN=$VER
 PKG=network/service/isc-dhcp
 SUMMARY="ISC DHCP"
@@ -28,22 +27,26 @@ DESC="$SUMMARY $VER"
 
 DEPENDS_IPS="system/library"
 
-# XXX 32-bit until Y2038 rears its ugly head.
-BUILDARCH=32
+BUILDARCH=64
 
 # Doesn't work with parallel gmake
 NO_PARALLEL_MAKE=1
 
-# Use old gcc4 standards level for this.
-export CFLAGS="$CFLAGS -std=gnu89"
+# This exposes msghdr.msg_control & msghdr.msg_controllen
+CFLAGS+=" -D_XPG4_2 -fstack-check"
 
-CONFIGURE_OPTS="--enable-use-sockets --enable-ipv4-pktinfo --prefix=$PREFIX --bindir=$PREFIX/bin --sbindir=$PREFIX/sbin"
+LDFLAGS="-zaslr"
+
+CONFIGURE_OPTS="
+    --prefix=$PREFIX
+    --bindir=$PREFIX/bin
+    --sbindir=$PREFIX/sbin
+    --enable-use-sockets
+    --enable-ipv4-pktinfo
+"
 
 pre_package() {
-    # Make directories and install extra files before package construction.
-    logcmd mkdir -p $DESTDIR/usr/share/isc-dhcp/examples \
-        || logerr "mkdir of $DESTDIR/usr/share/isc-dhcp/examples failed"
-    logcmd mkdir -p $DESTDIR/var/db || logerr "mkdir of $DESTDIR/var/db failed"
+    # Make empty lease files. They get preserve=true in local.mog.
     logcmd mkdir -p $DESTDIR/var/db || logerr "mkdir of $DESTDIR/var/db failed"
     logcmd touch $DESTDIR/var/db/dhcpd.leases
     logcmd touch $DESTDIR/var/db/dhcpd6.leases
@@ -56,10 +59,8 @@ prep_build
 build
 install_smf network isc-dhcp.xml dhcrelay
 pre_package
-VER=${VER//-P/.}
-VER=${VER//-W/.}
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/isc-dhcp/local.mog
+++ b/build/isc-dhcp/local.mog
@@ -11,33 +11,39 @@
 
 #
 # Copyright 2014 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
-<transform dir	path=etc$ -> edit path etc usr/share/isc-dhcp/examples>
-<transform file	path=etc/dhcpd.* -> edit path etc usr/share/isc-dhcp/examples>
-<transform file path=etc/dhclient.* -> drop>
-<transform dir	path=usr/include -> drop>
-<transform dir	path=usr/include/dhcpctl -> drop>
-<transform file	path=usr/include/dhcpctl/.* -> drop>
-<transform dir	path=usr/include/isc-dhcp -> drop>
-<transform file	path=usr/include/isc-dhcp/.* -> drop>
-<transform dir	path=usr/include/omapip -> drop>
-<transform file	path=usr/include/omapip/.* -> drop>
-<transform dir	path=usr/lib -> drop>
-<transform file	path=usr/lib/.* -> drop>
-<transform file	path=usr/sbin/dhclient -> drop>
-<transform file path=usr/share/man/man8/dhclient.8 -> drop>
-<transform dir	path=usr/share/man/man3 -> drop>
-<transform file	path=usr/share/man/man3/.* -> drop>
-<transform file	path=usr/share/man/man5/dhclient.* -> drop>
-<transform file	path=usr/share/man/man8/dhclient.* -> drop>
-<transform dir	path=var/db -> set group sys>
-<transform file	path=var/db/dhcp.leases -> set preserve true>
-<transform file	path=var/db/dhcp6.leases -> set preserve true>
+# Additional directories
+dir  path=usr/share/isc-dhcp owner=root group=bin mode=0755
+dir  path=usr/share/isc-dhcp/examples owner=root group=bin mode=0755
+dir  path=var/db owner=root group=sys mode=0755
 
-<transform file path=usr/sbin/dhcpd$ -> set restart_fmri svc:/network/service/dhcp:ipv4>
-<transform file path=usr/sbin/dhcpd$ -> add restart_fmri svc:/network/service/dhcp:ipv6>
-<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ -> set restart_fmri svc:/network/service/dhcrelay:ipv4>
-<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ -> add restart_fmri svc:/network/service/dhcrelay:ipv6>
+# Drop unwanted components
+<transform file dir path=usr/lib -> drop>
+<transform file dir path=usr/include -> drop>
+
+<transform file path=usr/sbin/dhclient -> drop>
+<transform file path=usr/share/man/man./dhclient -> drop>
+<transform file path=etc/dhclient -> drop>
+<transform file dir path=usr/share/man/man3 -> drop>
+
+# Move example dhcpd.conf file from /etc
+<transform file	dir path=etc -> edit path etc usr/share/isc-dhcp/examples>
+
+# Set permissions and preservation on lease files
+<transform dir	path=var/db -> set group sys>
+<transform file	path=var/db -> set preserve true>
+
+# Start services on package update
+<transform file path=usr/sbin/dhcpd$ -> \
+    set restart_fmri svc:/network/service/dhcp:ipv4>
+<transform file path=usr/sbin/dhcpd$ -> \
+    add restart_fmri svc:/network/service/dhcp:ipv6>
+
+<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ \
+    -> set restart_fmri svc:/network/service/dhcrelay:ipv4>
+<transform file path=(usr/sbin/dhcrelay|lib/svc/method/dhcrelay)$ \
+    -> add restart_fmri svc:/network/service/dhcrelay:ipv6>
 
 license LICENSE license=ISC

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -92,7 +92,7 @@ network/dns/idnconv			2.3
 network/openssh-server			7.6
 network/openssh				7.6
 network/rsync				3.1
-network/service/isc-dhcp		4.3
+network/service/isc-dhcp		4.4
 network/test/iperf			3
 network/test/netperf			2.7
 release/name				0.5.11

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -76,6 +76,7 @@ r151026 release repository: https://pkg.omniosce.org/r151026/core
     * Sendmail
     * Dragonfly Mail Agent
     * NTPsec
+    * DHCP daemon
 
 * `openssh` has been upgraded to 7.6p1. This version drops support for
   SSH protocol version 1, RSA keys under 1024 bits in length and a number

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -56,7 +56,7 @@
 | network/dns/bind			| 9.10.6-P1		| https://www.isc.org/downloads/
 | network/openssh			| 7.6p1			| https://mirrors.evowise.com/pub/OpenBSD/OpenSSH/portable/
 | network/rsync				| 3.1.3			| https://rsync.samba.org/
-| network/service/isc-dhcp		| 4.3.6			| https://www.isc.org/downloads/
+| network/service/isc-dhcp		| 4.4.0			| https://www.isc.org/downloads/
 | network/test/iperf			| 3.1.3			| https://iperf.fr/iperf-download.php#source
 | network/test/netperf			| 2.7.0			| https://github.com/HewlettPackard/netperf/releases
 | runtime/perl				| 5.26.1		| http://www.cpan.org/src/README.html


### PR DESCRIPTION
Upgraded, tidied up, moved to 64-bit with stack guard & ASLR; and fixed a couple of packaging errors:

Pkg contents diff:

```diff
-set name=pkg.descr value="ISC DHCP 4.3.6"
+set name=pkg.descr value="ISC DHCP 4.4.0"
-file path=usr/bin/omshell owner=root group=bin mode=0755 elfarch=i386 elfbits=32
+file path=usr/bin/omshell owner=root group=bin mode=0755 elfarch=i386 elfbits=64
-    elfbits=32 restart_fmri=svc:/network/service/dhcp:ipv4 \
+    elfbits=64 restart_fmri=svc:/network/service/dhcp:ipv4 \
-    elfbits=32 restart_fmri=svc:/network/service/dhcrelay:ipv4 \
+    elfbits=64 restart_fmri=svc:/network/service/dhcrelay:ipv4 \
-file path=var/db/dhcpd.leases owner=root group=bin mode=0644
-file path=var/db/dhcpd6.leases owner=root group=bin mode=0644
-license 08775d0598cbd2044ae98d5a0d3b2456757abca4 license=ISC
+dir  path=var/db owner=root group=sys mode=0755
+file path=var/db/dhcpd.leases owner=root group=bin mode=0644 preserve=true
+file path=var/db/dhcpd6.leases owner=root group=bin mode=0644 preserve=true
+license ab279e3b993117f81f008818ae93c6b97f213cfc license=ISC
```