### PR TITLE
p7zip: Fix for CVE-2017-17969

### DIFF
--- a/build/p7zip/patches/CVE-2017-17969.patch
+++ b/build/p7zip/patches/CVE-2017-17969.patch
@@ -1,0 +1,22 @@
+Subject: backport of the CVE-2017-17969 fix from 7zip 18.00-beta
+Forwarded: https://sourceforge.net/p/p7zip/bugs/204/
+Bug-Debian: http://bugs.debian.org/888297
+Author: Antoine Beaupré <anarcat@debian.org>
+Applied-Upstream: 18.00-beta
+Last-Update: 2018-01-26
+
+--- a/CPP/7zip/Compress/ShrinkDecoder.cpp
++++ b/CPP/7zip/Compress/ShrinkDecoder.cpp
+@@ -121,7 +121,12 @@
+     {
+       _stack[i++] = _suffixes[cur];
+       cur = _parents[cur];
++      if (cur >= kNumItems || i >= kNumItems)
++        break;
+     }
++
++    if (cur >= kNumItems || i >= kNumItems)
++      break;
+     
+     _stack[i++] = (Byte)cur;
+     lastChar2 = (Byte)cur;

--- a/build/p7zip/patches/series
+++ b/build/p7zip/patches/series
@@ -1,3 +1,4 @@
 makefile.patch
 bash.patch -p0
 CVE-2016-9296.patch -p1
+CVE-2017-17969.patch


### PR DESCRIPTION
See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17969