### PR TITLE
Ship /usr/bin/guname too

### DIFF
--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -31,7 +31,7 @@ PROG=coreutils          # App name
 VER=8.29                # App version
 PKG=file/gnu-coreutils  # Package name (without prefix)
 SUMMARY="coreutils - GNU core utilities"
-DESC="GNU core utilities ($VER)"
+DESC="GNU core utilities"
 
 BUILD_DEPENDS_IPS="compress/xz library/gmp"
 

--- a/build/coreutils/local.mog
+++ b/build/coreutils/local.mog
@@ -55,3 +55,7 @@ hardlink path=usr/bin/users		target=../gnu/bin/users
 hardlink path=usr/bin/vdir		target=../gnu/bin/vdir
 hardlink path=usr/bin/whoami		target=../gnu/bin/whoami
 
+hardlink path=usr/bin/guname		target=../gnu/bin/uname
+hardlink path=usr/share/man/man1/guname.1 \
+    target=../../../gnu/share/man/man1/uname.1
+


### PR DESCRIPTION
We should provide `guname` along with other g-prefixed utilities.
looks like we forgot to do this when re-adding GNU uname to coreutils.