### PR TITLE
Stick KVM revision for r151024

### DIFF
--- a/build/illumos-kvm/build.sh
+++ b/build/illumos-kvm/build.sh
@@ -39,7 +39,7 @@ DESC="$SUMMARY"
 
 # Unless building with HEAD from joyent/illumos-kvm[-cmd], specify the
 # revision to use.
-KVM_ROLLBACK=
+KVM_ROLLBACK=8c4fef5305b02720d9147e903cb28db5ed9e5958
 KVM_CMD_ROLLBACK=
 
 # These are the dependencies for both the module and the cmds


### PR DESCRIPTION
The repository recently received a fix to handle %cr3 changing between kernel and user-space.
We don't need this for r24 so stay with the revision we have already published.