### PR TITLE
Trousers daemon needs /var/tpm

### DIFF
--- a/build/trousers/local.mog
+++ b/build/trousers/local.mog
@@ -2,3 +2,9 @@ license LICENSE license=BSD
 
 <transform file path=etc/tcsd -> edit path etc etc/security>
 
+dir path=var/tpm mode=0755 owner=root group=sys
+dir path=var/tpm/pkcs11 mode=0755 owner=root group=sys
+
+<transform dir path=var -> drop>
+
+


### PR DESCRIPTION
Without, it fails to start:

```
# /usr/sbin/amd64/tcsd -f
TCSD ERROR: mkdir(/var/tpm/system) failed: No such file or directory. If you'd like to use /var/tpm/system to store your system persistent data, please create it. Otherwise, change the location in your tcsd config file.
zsh: exit 4     /usr/sbin/amd64/tcsd -f
```
