### PR TITLE
dhcp: update to 4.3.6-P1 (r151024)

### DIFF
--- a/build/isc-dhcp/build.sh
+++ b/build/isc-dhcp/build.sh
@@ -20,7 +20,7 @@
 . ../../lib/functions.sh
 
 PROG=dhcp
-VER=4.3.6
+VER=4.3.6-P1
 VERHUMAN=$VER
 PKG=network/service/isc-dhcp
 SUMMARY="ISC DHCP"


### PR DESCRIPTION
CVE fix but only in the client part.
Bloody already has version 4.4.1