### PR TITLE
mercurial: update to 4.5.2

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -27,16 +27,12 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.5
+VER=4.5.2
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - a free and open source, distributed version control system"
 DESC="$SUMMARY"
 
-DEPENDS_IPS="web/curl library/security/openssl"
-
-PYTHONPATH=/usr
-PYTHON=$PYTHONPATH/bin/python2.7
-PYTHONLIB=$PYTHONPATH/lib
+RUN_DEPENDS_IPS="web/curl library/security/openssl"
 
 python_build() {
     logmsg "Building using python setup.py"
@@ -44,22 +40,22 @@ python_build() {
     ISALIST=i386
     export ISALIST
     logmsg "--- setup.py (32) build"
-    logcmd $PYTHON ./setup.py build ||
-        logerr "--- build failed"
+    logcmd $PYTHON ./setup.py build \
+        || logerr "--- build failed"
     logmsg "--- setup.py (32) install"
     logcmd $PYTHON \
-        ./setup.py install --root=$DESTDIR ||
-        logerr "--- install failed"
+        ./setup.py install --root=$DESTDIR \
+        || logerr "--- install failed"
 
     ISALIST="amd64 i386"
     export ISALIST
     logmsg "--- setup.py (64) build"
-    logcmd $PYTHON ./setup.py build ||
-        logerr "--- build failed"
+    logcmd $PYTHON ./setup.py build \
+        || logerr "--- build failed"
     logmsg "--- setup.py (64) install"
     logcmd $PYTHON \
-        ./setup.py install --root=$DESTDIR ||
-        logerr "--- install failed"
+        ./setup.py install --root=$DESTDIR \
+        || logerr "--- install failed"
     popd > /dev/null
 
     python_vendor_relocate

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -26,7 +26,7 @@
 | developer/parser/bison		| 3.0.4			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.16.2		| https://www.kernel.org/pub/software/scm/git
-| developer/versioning/mercurial	| 4.5			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/mercurial	| 4.5.2			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.0.586		| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.29			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags


### PR DESCRIPTION
Confirmed that the new version is fine for building openjdk.