### PR TITLE
Ship compiled python modules with packages

### DIFF
--- a/build/ntpsec/build.sh
+++ b/build/ntpsec/build.sh
@@ -103,6 +103,7 @@ cat $TMPDIR/$BUILDDIR/build/main/test.log | perl -e '
 install_ntpdate
 install_files
 install_smf network ntpsec.xml ntpsec
+python_compile
 make_package
 clean_up
 

--- a/build/ntpsec/local.mog
+++ b/build/ntpsec/local.mog
@@ -37,9 +37,6 @@ dir group=sys mode=0755 owner=root path=var/ntp/ntpstats
 <transform file path=usr/sbin/ntpd$ -> \
     set restart_fmri svc:/nework/ntp:default>
 
-# Drop compiled python files.
-<transform file path=.*\.py[oc]$ -> drop>
-
 # Backwards compatibility links
 link path=usr/sbin/ntp-keygen target=../bin/ntpkeygen
 link path=usr/sbin/ntpdate target=../bin/ntpdate

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1317,6 +1317,11 @@ python_vendor_relocate() {
         logerr "python: cannot move from site-packages to vendor-packages"
 }
 
+python_compile() {
+    logmsg "Compiling python modules"
+    logcmd $PYTHON -m compileall $DESTDIR
+}
+
 python_build() {
     [ -z "$PYTHON" ] && logerr "PYTHON not set"
     [ -z "$PYTHONPATH" ] && logerr "PYTHONPATH not set"
@@ -1348,6 +1353,8 @@ python_build() {
     popd > /dev/null
 
     python_vendor_relocate
+
+    python_compile
 }
 
 #############################################################################

--- a/lib/global-transforms.mog
+++ b/lib/global-transforms.mog
@@ -23,7 +23,7 @@
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 # Copyright (c) 2014 by Delphix. All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 # Make all directories usable
 <transform dir -> default mode 0755>
@@ -106,8 +106,8 @@
 # Drop everything under /var/run since it's tmpfs
 <transform file dir link hardlink path=var/run/ -> drop>
 
-# Drop compiled python files
-<transform file path=.*\.py[co]$ -> drop>
+# Drop compiled optimised python files
+<transform file path=.*\.pyo$ -> drop>
 
 # SMF manifests should be imported upon pkg install
 <transform file path=(var|lib)/svc/manifest/.*\.xml -> \


### PR DESCRIPTION
When we inherited OmniOS, most python packages shipped a few compiled python files (.pyc or .pyo extension) but this was inconsistent and could even change between package builds. 

We changed this so that no compiled files are shipped at all but that presents a problem as they are generally installed in system directories to which normal users have no write permission. This means that the bytecode compiled modules are not produced until a root user uses them; until that point no speed benefit is realised (for pkg, root will always sooner-or-later use the modules so it's less of a problem there, however...)

So, changing tack again, let's pre-compile everything during package build and include the bytecode versions too. I'm not generating the optimised (.pyo) versions since they are not generally used and the optimisations are very limited anyway in python 2.7
