### PR TITLE
xz needs to run full autoreconf

### DIFF
--- a/build/xz/build.sh
+++ b/build/xz/build.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/bash
 
-# Load support functions
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 . ../../lib/functions.sh
 
 PROG=xz
@@ -12,40 +25,30 @@ DESC="$SUMMARY"
 
 BUILD_DEPENDS_IPS="autoconf"
 
-save_function configure32 configure32_orig
-save_function configure64 configure64_orig
-
+save_function configure32 _configure32
 configure32() {
-    configure32_orig
-    pushd $TMPDIR/$BUILDDIR > /dev/null
-    pushd src/liblzma > /dev/null
-    logcmd gmake foo 2>&1 /dev/null
-    popd > /dev/null
-    logcmd perl -pi -e 's#^^(archive_cmds=.*)"$#$1 -nostdlib -lc"#g;' libtool || \
-        logerr "patching libtool failed"
-    popd > /dev/null
+    _configure32
+    logcmd gmake -C $TMPDIR/$BUILDDIR/src/liblzma foo
 }
 
+save_function configure64 _configure64
 configure64() {
-    configure64_orig
-    pushd $TMPDIR/$BUILDDIR > /dev/null
-    pushd src/liblzma > /dev/null
-    logcmd gmake foo 2>&1 /dev/null
-    popd > /dev/null
-    logcmd perl -pi -e 's#^^(archive_cmds=.*)"$#$1 -nostdlib -lc"#g;' libtool || \
-        logerr "patching libtool failed"
-    popd > /dev/null
+    _configure64
+    logcmd gmake -C $TMPDIR/$BUILDDIR/src/liblzma foo
 }
+
+TESTSUITE_SED="/libtool/d"
     
 init
 download_source $PROG $PROG $VER
 patch_source
-run_autoconf
+run_autoreconf
 prep_build
 build
+run_testsuite check
 make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/xz/local.mog
+++ b/build/xz/local.mog
@@ -1,4 +1,21 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 license COPYING license=xz
 license COPYING.LGPLv2.1 license="LGPLv2.1"
 license COPYING.GPLv2 license=GPLv2
 license COPYING.GPLv3 license=GPLv3
+
+<transform file dir path=usr/share/doc -> drop>
+

--- a/build/xz/patches/pthread.diff
+++ b/build/xz/patches/pthread.diff
@@ -1,6 +1,11 @@
---- xz-5.0.4/m4/ax_pthread.m4.orig	Fri Nov  2 17:25:20 2012
-+++ xz-5.0.4/m4/ax_pthread.m4	Fri Nov  2 17:25:23 2012
-@@ -156,7 +156,7 @@
+
+illumos does  not need the -mt and -pthreads flags. pthreads are native to
+libc these days.
+
+diff -pruN '--exclude=*.orig' xz-5.2.3~/m4/ax_pthread.m4 xz-5.2.3/m4/ax_pthread.m4
+--- xz-5.2.3~/m4/ax_pthread.m4	2016-12-30 11:08:20.000000000 +0000
++++ xz-5.2.3/m4/ax_pthread.m4	2018-03-16 11:20:33.162971475 +0000
+@@ -156,7 +156,7 @@ case ${host_os} in
          # who knows whether they'll stub that too in a future libc.)  So,
          # we'll just look for -pthreads and -lpthread first:
  

--- a/build/xz/testsuite.log
+++ b/build/xz/testsuite.log
@@ -1,0 +1,27 @@
+Making check in src
+Making check in liblzma
+Making check in api
+Making check in xzdec
+Making check in xz
+Making check in lzmainfo
+Making check in scripts
+Making check in po
+Making check in tests
+PASS: test_check
+PASS: test_stream_flags
+PASS: test_filter_flags
+PASS: test_block_header
+PASS: test_index
+PASS: test_bcj_exact_size
+PASS: test_files.sh
+test_compress.sh:
+  generated_abc.............
+  generated_random.............
+  generated_text.............
+  prepared_bcj_sparc.............
+  prepared_bcj_x86.............
+PASS: test_compress.sh
+PASS: test_scripts.sh
+==================
+All 9 tests passed
+==================

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -480,21 +480,11 @@ run_inbuild() {
     popd > /dev/null
 }
 
-run_autoheader() {
-    run_inbuild autoheader
-}
-
-run_autoconf() {
-    run_inbuild autoconf
-}
-
-run_automake() {
-    run_inbuild automake
-}
-
-run_aclocal() {
-    run_inbuild aclocal
-}
+run_autoheader() { run_inbuild autoheader; }
+run_autoreconf() { run_inbuild autoreconf; }
+run_autoconf() { run_inbuild autoconf; }
+run_automake() { run_inbuild automake; }
+run_aclocal() { run_inbuild aclocal; }
 
 #############################################################################
 # Stuff that needs to be done/set before we start building


### PR DESCRIPTION
since it was built with autoconf 1.15 and we now have 1.16, build fails with:

`/data/omnios-build/omniosorg/bloody/_build/xz-5.2.3/build-aux/missing[81]: aclocal-1.15: not found [No such file or directory]`

the solution is to run `autoreconf` instead of `autoconf`.

Also took the opportunity to tidy up the build script, add test suite and remove documentation from the final package.