### PR TITLE
openjdk: update to 1.7.0_171-b02

### DIFF
--- a/build/openjdk/build.sh
+++ b/build/openjdk/build.sh
@@ -23,15 +23,14 @@
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 # Copyright (c) 2014 by Delphix. All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=openjdk
 VER=1.7.0
-UPDATE=161
-BUILD=01
+UPDATE=171
+BUILD=02
 VERHUMAN="jdk7u${UPDATE}-b${BUILD}"
 
 # Taken from illumos...

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -19,7 +19,7 @@
 | developer/gcc5			| 5.5			| https://www.gnu.org/software/gcc/releases.html
 | developer/gcc6			| 6.4			| https://www.gnu.org/software/gcc/releases.html
 | developer/gcc7			| 7.3			| https://www.gnu.org/software/gcc/releases.html
-| developer/java/jdk			| 1.7.0_161-b01		| http://hg.openjdk.java.net/jdk7u/jdk7u/tags
+| developer/java/jdk			| 1.7.0_171-b02		| http://hg.openjdk.java.net/jdk7u/jdk7u/tags
 | developer/lexer/flex			| 2.6.4			| https://github.com/westes/flex/releases
 | developer/macro/gnu-m4		| 1.4.18		| http://git.savannah.gnu.org/cgit/m4.git/refs/tags
 | developer/nasm			| 2.13.03		| http://www.nasm.us/pub/nasm/releasebuilds


### PR DESCRIPTION
```
% java -version
openjdk version "1.7.0_171"
OpenJDK Runtime Environment (build 1.7.0_171-b02)
OpenJDK Server VM (build 24.171-b02, mixed mode)
```