### PR TITLE
cherrypy: update to 14.0.1

### DIFF
--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/cherrypy-27
 PROG=CherryPy
-VER=14.0.0
+VER=14.0.1
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -99,7 +99,7 @@
 | library/python-2/asn1crypto-27	| 0.24.0		| https://pypi.python.org/pypi/asn1crypto
 | library/python-2/cffi-27		| 1.11.5		| https://pypi.python.org/pypi/cffi
 | library/python-2/cheroot-27		| 6.0.0			| https://pypi.python.org/pypi/cheroot
-| library/python-2/cherrypy-27		| 14.0.0		| https://pypi.python.org/pypi/cherrypy
+| library/python-2/cherrypy-27		| 14.0.1		| https://pypi.python.org/pypi/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-2/coverage-27		| 4.5.1			| https://pypi.python.org/pypi/coverage
 | library/python-2/cryptography-27	| 2.2.1			| https://pypi.python.org/pypi/cryptography
 | library/python-2/enum-27		| 1.1.6			| https://pypi.python.org/pypi/enum34


### PR DESCRIPTION
Only a windows-build related fix but bumping so we have the latest version.