### PR TITLE
openssl: update to 1.1.0h/1.0.2o

### DIFF
--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -27,8 +27,8 @@
 . ../../lib/functions.sh
 
 PROG=openssl
-VER=1.1.0g
-LVER=1.0.2n
+VER=1.1.0h
+LVER=1.0.2o
 VERHUMAN=$VER
 PKG=library/security/openssl
 SUMMARY="$PROG - A toolkit for Secure Sockets Layer and Transport Layer protocols and general purpose cryptographic library"

--- a/build/openssl/patches/libs.patch
+++ b/build/openssl/patches/libs.patch
@@ -11,10 +11,10 @@ unecessary library is linked.
 Openssl is one of the libraries used by illumos-omnios and therefore we
 patch the configuration script to stop linking against these two libraries.
 
-diff -ru openssl-1.1.0g~/Configurations/10-main.conf openssl-1.1.0g/Configurations/10-main.conf
---- openssl-1.1.0g~/Configurations/10-main.conf	2017-11-02 14:29:01.000000000 +0000
-+++ openssl-1.1.0g/Configurations/10-main.conf	2018-01-24 22:17:29.180632536 +0000
-@@ -179,7 +179,7 @@
+diff -pruN '--exclude=*.orig' openssl-1.1.0h~/Configurations/10-main.conf openssl-1.1.0h/Configurations/10-main.conf
+--- openssl-1.1.0h~/Configurations/10-main.conf	2018-03-27 15:50:37.000000000 +0000
++++ openssl-1.1.0h/Configurations/10-main.conf	2018-03-27 20:07:14.443512101 +0000
+@@ -179,7 +179,7 @@ sub vms_info {
          inherit_from     => [ "BASE_unix" ],
          template         => 1,
          cflags           => "-DFILIO_H",
@@ -23,22 +23,24 @@ diff -ru openssl-1.1.0g~/Configurations/10-main.conf openssl-1.1.0g/Configuratio
          dso_scheme       => "dlfcn",
          thread_scheme    => "pthreads",
          shared_target    => "solaris-shared",
-@@ -202,8 +202,7 @@
+@@ -202,9 +202,7 @@ sub vms_info {
          cc               => "gcc",
          cflags           => add_before(picker(default => "-Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM",
                                                debug   => "-O0 -g",
 -                                              release => "-O3 -fomit-frame-pointer"),
 -                                       threads("-pthread")),
+-        ex_libs          => add(threads("-pthread")),
 +                                              release => "-O3 -fomit-frame-pointer")),
          bn_ops           => "BN_LLONG",
          shared_cflag     => "-fPIC",
          shared_ldflag    => "-shared -static-libgcc",
-@@ -221,8 +220,7 @@
+@@ -222,9 +220,7 @@ sub vms_info {
          cc               => "gcc",
          cflags           => add_before(picker(default => "-m64 -Wall -DL_ENDIAN",
                                                debug   => "-O0 -g",
 -                                              release => "-O3"),
 -                                       threads("-pthread")),
+-        ex_libs          => add(threads("-pthread")),
 +                                              release => "-O3")),
          bn_ops           => "SIXTY_FOUR_BIT_LONG",
          perlasm_scheme   => "elf",

--- a/build/openssl/testsuite.log
+++ b/build/openssl/testsuite.log
@@ -1,4 +1,3 @@
-File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() instead. at .././test/run_tests.pl line 45.
 ../test/recipes/01-test_abort.t ............ ok
 ../test/recipes/01-test_sanity.t ........... ok
 ../test/recipes/01-test_symbol_presence.t .. ok
@@ -82,6 +81,7 @@ File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() inste
 ../test/recipes/90-test_bio_enc.t .......... ok
 ../test/recipes/90-test_bioprint.t ......... ok
 ../test/recipes/90-test_constant_time.t .... ok
+../test/recipes/90-test_fatalerr.t ......... ok
 ../test/recipes/90-test_fuzz.t ............. ok
 ../test/recipes/90-test_gmdiff.t ........... ok
 ../test/recipes/90-test_heartbeat.t ........ skipped: heartbeats is not supported by this OpenSSL build
@@ -95,5 +95,5 @@ File::Glob::glob() will disappear in perl 5.30. Use File::Glob::bsd_glob() inste
 ../test/recipes/90-test_threads.t .......... ok
 ../test/recipes/90-test_v3name.t ........... ok
 All tests successful.
-Files=95, Tests=556, 71 wallclock secs ( 0.39 usr  0.30 sys + 29.37 cusr  4.59 csys = 34.65 CPU)
+Files=96, Tests=557, 60 wallclock secs ( 0.65 usr  0.21 sys + 20.16 cusr  5.63 csys = 26.65 CPU)
 Result: PASS

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -49,8 +49,8 @@
 | library/nspr				| 4.19			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.42			| https://ftp.pcre.org/pub/pcre/
 | library/readline			| 7.0			| https://ftp.gnu.org/gnu/readline/
-| library/security/openssl-1.0		| 1.0.2n		| https://www.openssl.org/source/
-| library/security/openssl-1.1		| 1.1.0g		| https://www.openssl.org/source/
+| library/security/openssl-1.0		| 1.0.2o		| https://www.openssl.org/source/
+| library/security/openssl-1.1		| 1.1.0h		| https://www.openssl.org/source/
 | library/unixodbc			| 2.3.6			| http://www.unixodbc.org/download.html
 | library/zlib				| 1.2.11		| http://www.zlib.net/
 | network/dns/bind			| 9.10.7		| https://www.isc.org/downloads/


### PR DESCRIPTION
- fixing [CVE-2018-0739](https://www.openssl.org/news/vulnerabilities.html#2018-0739)