### PR TITLE
cryptography: update to 2.2.2

### DIFF
--- a/build/python27/cryptography/build.sh
+++ b/build/python27/cryptography/build.sh
@@ -27,7 +27,7 @@
 
 PKG=library/python-2/cryptography-27
 PROG=cryptography
-VER=2.2.1
+VER=2.2.2
 SUMMARY="cryptography - cryptographic recipes and primitives"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -101,7 +101,7 @@
 | library/python-2/cheroot-27		| 6.0.0			| https://pypi.python.org/pypi/cheroot
 | library/python-2/cherrypy-27		| 14.0.1		| https://pypi.python.org/pypi/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-2/coverage-27		| 4.5.1			| https://pypi.python.org/pypi/coverage
-| library/python-2/cryptography-27	| 2.2.1			| https://pypi.python.org/pypi/cryptography
+| library/python-2/cryptography-27	| 2.2.2			| https://pypi.python.org/pypi/cryptography
 | library/python-2/enum-27		| 1.1.6			| https://pypi.python.org/pypi/enum34
 | library/python-2/functools32-27	| 3.2.3-2		| https://pypi.python.org/pypi/functools32
 | library/python-2/idna-27		| 2.6			| https://pypi.python.org/pypi/idna


### PR DESCRIPTION
Like last time, the changes between 2.2.1 and this are for other platforms but we need to be on the latest version ready for branching r26.