### PR TITLE
Fix KVM variants to allow r24->r26 upgrade

### DIFF
--- a/build/illumos-kvm/kvm.mog
+++ b/build/illumos-kvm/kvm.mog
@@ -23,10 +23,12 @@
 # Copyright 2011-2013 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+set name=variant.opensolaris.zone value=global value=nonglobal
+<transform file dir -> default variant.opensolaris.zone global>
 <transform file path=kernel.*kvm$ -> set mode 0755>
 <transform file path=usr/lib/mdb/.*.so$ -> set mode 0755>
 <transform file path=usr/lib/devfsadm/.*.so$ -> set mode 0755>
-set name=variant.opensolaris.zone value=global
 driver name=kvm
 license COPYING.linux license=GPLv2
 license OPENSOLARIS.LICENSE license=CDDL
+


### PR DESCRIPTION
Rather than making the `system/virtualisation/kvm` package a global-zone only package, revert it to both GZ & NGZ but make all of the actions GZ only.

Tested with this change and upgrade from r24 -> r26 with linked image zones now works.