### PR TITLE
sqlite3: update to 3.23.1

### DIFF
--- a/build/sqlite3/build.sh
+++ b/build/sqlite3/build.sh
@@ -27,11 +27,21 @@
 . ../../lib/functions.sh
 
 PROG=sqlite-autoconf
-VER=3230000
-VERHUMAN=3.23.0
+VER=3230100
 PKG=database/sqlite-3
 SUMMARY="SQL database engine library"
 DESC="$SUMMARY"
+
+VERHUMAN="`echo $VER | sed '
+    # Mmmsspp -> M.mm.ss.pp
+    s/\(.\)\(..\)\(..\)\(..\)/\1.\2.\3.\4/
+    # Remove leading zeros
+    s/\.0/./g
+    # Remove empty last component
+    s/\.0$//
+'`"
+[ -n "$VERHUMAN" ] || logerr "-- Could not build VERHUMAN"
+logmsg "-- Building version $VERHUMAN"
 
 init
 download_source sqlite $PROG $VER

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -9,7 +9,7 @@
 | compress/xz				| 5.2.3			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/ http://www.info-zip.org/Zip.html
 | data/iso-codes			| 3.77			| http://pkg-isocodes.alioth.debian.org/downloads/
-| database/sqlite-3			| 3230000		| https://www.sqlite.org/download.html
+| database/sqlite-3			| 3230100		| https://www.sqlite.org/download.html
 | developer/acpi/compiler		| 20180313		| https://www.acpica.org/downloads/
 | developer/bmake			| 20180222		| http://ftp.netbsd.org/pub/NetBSD/misc/sjg/ http://www.crufty.net/ftp/pub/sjg/
 | developer/build/autoconf		| 2.69			| https://git.savannah.gnu.org/cgit/autoconf.git/refs/tags


### PR DESCRIPTION
Requires back-port to r151026 as it fixes some bugs introduced in 3.23.0