### PR TITLE
perl: update to 5.24.4 (r151024)

### DIFF
--- a/build/perl/build.sh
+++ b/build/perl/build.sh
@@ -35,7 +35,7 @@ export SHELL
 
 case $DEPVER in
     "")
-	DEPVER=5.24.3
+	DEPVER=5.24.4
         logmsg "no version specified, using $DEPVER"
         ;;
 esac

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,10 @@ Weekly release for w/c 16th of April 2018.
 
 ### Security fixes
 
+* `perl` upgraded to 5.24.4 to fix:
+  * [CVE-2018-6797](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6797)
+  * [CVE-2018-6798](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6798)
+  * [CVE-2018-6913](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6913)
 * `zsh` updated to fix:
   * [CVE-2018-1100](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-1100)
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -81,7 +81,7 @@ FFIVERS=`pkg list -H libffi | awk '{print $(NF-1)}' | cut -d- -f1`
 #############################################################################
 
 # Perl versions we currently build against
-PERLVER=5.24.3
+PERLVER=5.24.4
 SPERLVER=${PERLVER%.*}
 
 # Full paths to bins


### PR DESCRIPTION
I've included the release notes update here since the draft release notes for tomorrow's r151024x have already been merged in error.