### PR TITLE
perl: fixes for CVE-2018-6797,6798,6913 (r51022)

### DIFF
--- a/build/perl/patches/CVE-2018-6797.patch
+++ b/build/perl/patches/CVE-2018-6797.patch
@@ -1,0 +1,37 @@
+From e02d7478ebfc399a9d10ba0df60eee217aa7ab8f Mon Sep 17 00:00:00 2001
+From: Karl Williamson <khw@cpan.org>
+Date: Fri, 2 Feb 2018 15:14:27 -0700
+Subject: (perl #132227) restart a node if we change to uni rules within the
+ node and encounter a sharp S
+
+This could lead to a buffer overflow.
+---
+ regcomp.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/regcomp.c b/regcomp.c
+index c6c7cb4925..d79bd191c9 100644
+--- a/regcomp.c
++++ b/regcomp.c
+@@ -13323,6 +13323,18 @@ S_regatom(pTHX_ RExC_state_t *pRExC_state, I32 *flagp, U32 depth)
+                          * /u.  This includes the multi-char fold SHARP S to
+                          * 'ss' */
+                         if (UNLIKELY(ender == LATIN_SMALL_LETTER_SHARP_S)) {
++
++                            /* If the node started out having uni rules, we
++                             * wouldn't have gotten here.  So this means
++                             * something in the middle has changed it, but
++                             * didn't think it needed to reparse.  But this
++                             * sharp s now does indicate the need for
++                             * reparsing. */
++                            if (RExC_uni_semantics) {
++                                p = oldp;
++                                goto loopdone;
++                            }
++
+                             RExC_seen_unfolded_sharp_s = 1;
+                             maybe_exactfu = FALSE;
+                         }
+-- 
+2.11.0
+

--- a/build/perl/patches/CVE-2018-6798a.patch
+++ b/build/perl/patches/CVE-2018-6798a.patch
@@ -1,0 +1,123 @@
+From 29231d73407542051a287cab5e18546e5a622f4a Mon Sep 17 00:00:00 2001
+From: Karl Williamson <khw@cpan.org>
+Date: Tue, 6 Feb 2018 14:50:48 -0700
+Subject: [perl #132063]: Heap buffer overflow
+
+The proximal cause is several instances in regexec.c of the code
+assuming that the input was valid UTF-8, whereas the input was too short
+for what the start byte claimed it would be.
+
+I grepped through the core for any other similar uses, and did not find
+any.
+---
+ regexec.c              | 29 ++++++++++++++++-------------
+ t/lib/warnings/regexec |  7 +++++++
+ 2 files changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/regexec.c b/regexec.c
+index 5735b997fd..ea432c39d3 100644
+--- a/regexec.c
++++ b/regexec.c
+@@ -1466,7 +1466,9 @@ Perl_re_intuit_start(pTHX_
+                                            ? trie_utf8_fold                         \
+                                            :   trie_latin_utf8_fold)))
+ 
+-#define REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc, uscan, len, uvc, charid, foldlen, foldbuf, uniflags) \
++/* 'uscan' is set to foldbuf, and incremented, so below the end of uscan is
++ * 'foldbuf+sizeof(foldbuf)' */
++#define REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc, uc_end, uscan, len, uvc, charid, foldlen, foldbuf, uniflags) \
+ STMT_START {                                                                        \
+     STRLEN skiplen;                                                                 \
+     U8 flags = FOLD_FLAGS_FULL;                                                     \
+@@ -1474,7 +1476,7 @@ STMT_START {
+     case trie_flu8:                                                                 \
+         _CHECK_AND_WARN_PROBLEMATIC_LOCALE;                                         \
+         if (utf8_target && UTF8_IS_ABOVE_LATIN1(*uc)) {                             \
+-            _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(uc, uc + UTF8SKIP(uc));          \
++            _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(uc, uc_end - uc);                \
+         }                                                                           \
+         goto do_trie_utf8_fold;                                                     \
+     case trie_utf8_exactfa_fold:                                                    \
+@@ -1483,7 +1485,7 @@ STMT_START {
+     case trie_utf8_fold:                                                            \
+       do_trie_utf8_fold:                                                            \
+         if ( foldlen>0 ) {                                                          \
+-            uvc = utf8n_to_uvchr( (const U8*) uscan, UTF8_MAXLEN, &len, uniflags ); \
++            uvc = utf8n_to_uvchr( (const U8*) uscan, foldlen, &len, uniflags );     \
+             foldlen -= len;                                                         \
+             uscan += len;                                                           \
+             len=0;                                                                  \
+@@ -1500,7 +1502,7 @@ STMT_START {
+         /* FALLTHROUGH */                                                           \
+     case trie_latin_utf8_fold:                                                      \
+         if ( foldlen>0 ) {                                                          \
+-            uvc = utf8n_to_uvchr( (const U8*) uscan, UTF8_MAXLEN, &len, uniflags ); \
++            uvc = utf8n_to_uvchr( (const U8*) uscan, foldlen, &len, uniflags );     \
+             foldlen -= len;                                                         \
+             uscan += len;                                                           \
+             len=0;                                                                  \
+@@ -1519,7 +1521,7 @@ STMT_START {
+         }                                                                           \
+         /* FALLTHROUGH */                                                           \
+     case trie_utf8:                                                                 \
+-        uvc = utf8n_to_uvchr( (const U8*) uc, UTF8_MAXLEN, &len, uniflags );        \
++        uvc = utf8n_to_uvchr( (const U8*) uc, uc_end - uc, &len, uniflags );        \
+         break;                                                                      \
+     case trie_plain:                                                                \
+         uvc = (UV)*uc;                                                              \
+@@ -2599,10 +2601,10 @@ S_find_byclass(pTHX_ regexp * prog, const regnode *c, char *s,
+                     }
+                     points[pointpos++ % maxlen]= uc;
+                     if (foldlen || uc < (U8*)strend) {
+-                        REXEC_TRIE_READ_CHAR(trie_type, trie,
+-                                         widecharmap, uc,
+-                                         uscan, len, uvc, charid, foldlen,
+-                                         foldbuf, uniflags);
++                        REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
++                                             (U8 *) strend, uscan, len, uvc,
++                                             charid, foldlen, foldbuf,
++                                             uniflags);
+                         DEBUG_TRIE_EXECUTE_r({
+                             dump_exec_pos( (char *)uc, c, strend,
+                                         real_start, s, utf8_target, 0);
+@@ -5511,8 +5513,9 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
+ 		    if ( base && (foldlen || uc < (U8*)(reginfo->strend))) {
+ 			I32 offset;
+ 			REXEC_TRIE_READ_CHAR(trie_type, trie, widecharmap, uc,
+-					     uscan, len, uvc, charid, foldlen,
+-					     foldbuf, uniflags);
++                                             (U8 *) reginfo->strend, uscan,
++                                             len, uvc, charid, foldlen,
++                                             foldbuf, uniflags);
+ 			charcount++;
+ 			if (foldlen>0)
+ 			    ST.longfold = TRUE;
+@@ -5642,8 +5645,8 @@ S_regmatch(pTHX_ regmatch_info *reginfo, char *startpos, regnode *prog)
+ 			while (foldlen) {
+ 			    if (!--chars)
+ 				break;
+-			    uvc = utf8n_to_uvchr(uscan, UTF8_MAXLEN, &len,
+-					    uniflags);
++			    uvc = utf8n_to_uvchr(uscan, foldlen, &len,
++                                                 uniflags);
+ 			    uscan += len;
+ 			    foldlen -= len;
+ 			}
+diff --git a/t/lib/warnings/regexec b/t/lib/warnings/regexec
+index 900dd6ee7f..6635142dea 100644
+--- a/t/lib/warnings/regexec
++++ b/t/lib/warnings/regexec
+@@ -260,3 +260,10 @@ setlocale(&POSIX::LC_CTYPE, $utf8_locale);
+ "k" =~ /(?[ \N{KELVIN SIGN} ])/i;
+ ":" =~ /(?[ \: ])/;
+ EXPECT
++########
++# NAME perl #132063, read beyond buffer end
++# OPTION fatal
++"\xff" =~ /(?il)\x{100}|\x{100}/;
++EXPECT
++Malformed UTF-8 character: \xff (too short; 1 byte available, need 13) in pattern match (m//) at - line 2.
++Malformed UTF-8 character (fatal) at - line 2.
+-- 
+2.11.0
+

--- a/build/perl/patches/CVE-2018-6798b.patch
+++ b/build/perl/patches/CVE-2018-6798b.patch
@@ -1,0 +1,62 @@
+From a59dc1f157bd0f626b6b864b9996480f9bac44aa Mon Sep 17 00:00:00 2001
+From: Yves Orton <demerphq@gmail.com>
+Date: Mon, 19 Feb 2018 13:49:46 +1100
+Subject: v5.24.3: fix TRIE_READ_CHAR and DECL_TRIE_TYPE to account for
+ non-utf8 target
+
+---
+ regexec.c     | 14 ++++++++++----
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/regexec.c b/regexec.c
+index ea432c39d3..ff8e89cb65 100644
+--- a/regexec.c
++++ b/regexec.c
+@@ -1451,7 +1451,7 @@ Perl_re_intuit_start(pTHX_
+ #define DECL_TRIE_TYPE(scan) \
+     const enum { trie_plain, trie_utf8, trie_utf8_fold, trie_latin_utf8_fold,       \
+                  trie_utf8_exactfa_fold, trie_latin_utf8_exactfa_fold,              \
+-                 trie_utf8l, trie_flu8 }                                            \
++                 trie_utf8l, trie_flu8, trie_flu8_latin }                           \
+                     trie_type = ((scan->flags == EXACT)                             \
+                                  ? (utf8_target ? trie_utf8 : trie_plain)           \
+                                  : (scan->flags == EXACTL)                          \
+@@ -1461,10 +1461,12 @@ Perl_re_intuit_start(pTHX_
+                                          ? trie_utf8_exactfa_fold                   \
+                                          : trie_latin_utf8_exactfa_fold)            \
+                                       : (scan->flags == EXACTFLU8                   \
+-                                         ? trie_flu8                                \
++                                         ? (utf8_target                             \
++                                           ? trie_flu8                              \
++                                           : trie_flu8_latin)                       \
+                                          : (utf8_target                             \
+                                            ? trie_utf8_fold                         \
+-                                           :   trie_latin_utf8_fold)))
++                                           : trie_latin_utf8_fold)))
+ 
+ /* 'uscan' is set to foldbuf, and incremented, so below the end of uscan is
+  * 'foldbuf+sizeof(foldbuf)' */
+@@ -1475,7 +1477,7 @@ STMT_START {
+     switch (trie_type) {                                                            \
+     case trie_flu8:                                                                 \
+         _CHECK_AND_WARN_PROBLEMATIC_LOCALE;                                         \
+-        if (utf8_target && UTF8_IS_ABOVE_LATIN1(*uc)) {                             \
++        if (UTF8_IS_ABOVE_LATIN1(*uc)) {                                            \
+             _CHECK_AND_OUTPUT_WIDE_LOCALE_UTF8_MSG(uc, uc_end - uc);                \
+         }                                                                           \
+         goto do_trie_utf8_fold;                                                     \
+@@ -1497,10 +1499,14 @@ STMT_START {
+             uscan = foldbuf + skiplen;                                              \
+         }                                                                           \
+         break;                                                                      \
++    case trie_flu8_latin:                                                           \
++        _CHECK_AND_WARN_PROBLEMATIC_LOCALE;                                         \
++        goto do_trie_latin_utf8_fold;                                               \
+     case trie_latin_utf8_exactfa_fold:                                              \
+         flags |= FOLD_FLAGS_NOMIX_ASCII;                                            \
+         /* FALLTHROUGH */                                                           \
+     case trie_latin_utf8_fold:                                                      \
++      do_trie_latin_utf8_fold:                                                      \
+         if ( foldlen>0 ) {                                                          \
+             uvc = utf8n_to_uvchr( (const U8*) uscan, foldlen, &len, uniflags );     \
+             foldlen -= len;                                                         \

--- a/build/perl/patches/CVE-2018-6798c.patch
+++ b/build/perl/patches/CVE-2018-6798c.patch
@@ -1,0 +1,30 @@
+From 9dd4e0280eca2ba666cc0671ec3724610ed7d366 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Mon, 19 Feb 2018 15:11:42 +1100
+Subject: (perl #132063) we should no longer warn for this code
+
+The first patch for 132063 prevented the buffer read overflow when
+dumping the warning but didn't fix the underlying problem.
+
+The next change treats the supplied buffer correctly, preventing the
+non-UTF-8 SV from being treated as UTF-8, preventing the warning.
+---
+ t/lib/warnings/regexec | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/t/lib/warnings/regexec b/t/lib/warnings/regexec
+index 6635142dea..c370ddc3c7 100644
+--- a/t/lib/warnings/regexec
++++ b/t/lib/warnings/regexec
+@@ -262,8 +262,5 @@ setlocale(&POSIX::LC_CTYPE, $utf8_locale);
+ EXPECT
+ ########
+ # NAME perl #132063, read beyond buffer end
+-# OPTION fatal
+ "\xff" =~ /(?il)\x{100}|\x{100}/;
+ EXPECT
+-Malformed UTF-8 character: \xff (too short; 1 byte available, need 13) in pattern match (m//) at - line 2.
+-Malformed UTF-8 character (fatal) at - line 2.
+-- 
+2.11.0
+

--- a/build/perl/patches/CVE-2018-6913.patch
+++ b/build/perl/patches/CVE-2018-6913.patch
@@ -1,0 +1,140 @@
+From c3d9db7eb4dc1747fff423ebaf0c1bcd62c2e8a9 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Tue, 8 Aug 2017 09:32:58 +1000
+Subject: (perl #131844) fix various space calculation issues in pp_pack.c
+
+- for the originally reported case, if the start/cur pointer is in the
+  top 75% of the address space the add (cur) + glen addition would
+  overflow, resulting in the condition failing incorrectly.
+
+- the addition of the existing space used to the space needed could
+  overflow, resulting in too small an allocation and a buffer overflow.
+
+- the scaling for UTF8 could overflow.
+
+- the multiply to calculate the space needed for many items could
+  overflow.
+
+For the first case, do a space calculation without making new pointers.
+
+For the other cases, detect the overflow and croak if there's an
+overflow.
+
+Originally this used Size_t_MAX as the maximum size of a memory
+allocation, but for -DDEBUGGING builds realloc() throws a panic for
+allocations over half the address space in size, changing the error
+reported for the allocation.
+
+For non-DEBUGGING builds the Size_t_MAX limit has the small chance
+of finding a system that has 3GB of contiguous space available, and
+allocating that space, which could be a denial of servce in some cases.
+
+Unfortunately changing the limit to half the address space means that
+the exact case with the original issue can no longer occur, so the
+test is no longer testing against the address + length issue that
+caused the original problem, since the allocation is failing earlier.
+
+One option would be to change the test so the size request by pack is
+just under 2GB, but this has a higher (but still low) probability that
+the system has the address space available, and will actually try to
+allocate the memory, so let's not do that.
+---
+ pp_pack.c   | 25 +++++++++++++++++++++----
+ t/op/pack.t | 24 +++++++++++++++++++++++-
+ 2 files changed, 44 insertions(+), 5 deletions(-)
+
+diff --git a/pp_pack.c b/pp_pack.c
+index f6964c3f30..c0de5ab82b 100644
+--- a/pp_pack.c
++++ b/pp_pack.c
+@@ -358,11 +358,28 @@ STMT_START {							\
+     }								\
+ } STMT_END
+ 
++#define SAFE_UTF8_EXPAND(var)	\
++STMT_START {				\
++    if ((var) > SSize_t_MAX / UTF8_EXPAND) \
++        Perl_croak(aTHX_ "%s", "Out of memory during pack()"); \
++    (var) = (var) * UTF8_EXPAND; \
++} STMT_END
++
++#define GROWING2(utf8, cat, start, cur, item_size, item_count)	\
++STMT_START {							\
++    if (SSize_t_MAX / (item_size) < (item_count))		\
++        Perl_croak(aTHX_ "%s", "Out of memory during pack()");	\
++    GROWING((utf8), (cat), (start), (cur), (item_size) * (item_count)); \
++} STMT_END
++
+ #define GROWING(utf8, cat, start, cur, in_len)	\
+ STMT_START {					\
+     STRLEN glen = (in_len);			\
+-    if (utf8) glen *= UTF8_EXPAND;		\
+-    if ((cur) + glen >= (start) + SvLEN(cat)) {	\
++    STRLEN catcur = (STRLEN)((cur) - (start));	\
++    if (utf8) SAFE_UTF8_EXPAND(glen);		\
++    if (SSize_t_MAX - glen < catcur)		\
++        Perl_croak(aTHX_ "%s", "Out of memory during pack()"); \
++    if (catcur + glen >= SvLEN(cat)) {	\
+ 	(start) = sv_exp_grow(cat, glen);	\
+ 	(cur) = (start) + SvCUR(cat);		\
+     }						\
+@@ -372,7 +389,7 @@ STMT_START {					\
+ STMT_START {					\
+     const STRLEN glen = (in_len);		\
+     STRLEN gl = glen;				\
+-    if (utf8) gl *= UTF8_EXPAND;		\
++    if (utf8) SAFE_UTF8_EXPAND(gl);		\
+     if ((cur) + gl >= (start) + SvLEN(cat)) {	\
+         *cur = '\0';				\
+         SvCUR_set((cat), (cur) - (start));	\
+@@ -2126,7 +2143,7 @@ S_pack_rec(pTHX_ SV *cat, tempsym_t* symptr, SV **beglist, SV **endlist )
+ 	    if (props && !(props & PACK_SIZE_UNPREDICTABLE)) {
+ 		/* We can process this letter. */
+ 		STRLEN size = props & PACK_SIZE_MASK;
+-		GROWING(utf8, cat, start, cur, (STRLEN) len * size);
++		GROWING2(utf8, cat, start, cur, size, (STRLEN)len);
+ 	    }
+         }
+ 
+diff --git a/t/op/pack.t b/t/op/pack.t
+index a2da63689b..a480c3ad7f 100644
+--- a/t/op/pack.t
++++ b/t/op/pack.t
+@@ -12,7 +12,7 @@ my $no_endianness = $] > 5.009 ? '' :
+ my $no_signedness = $] > 5.009 ? '' :
+   "Signed/unsigned pack modifiers not available on this perl";
+ 
+-plan tests => 14712;
++plan tests => 14716;
+ 
+ use strict;
+ use warnings qw(FATAL all);
+@@ -2044,3 +2044,25 @@ ok(1, "argument underflow did not crash");
+     is(pack("H40", $up_nul), $twenty_nuls,
+        "check pack H zero fills (utf8 source)");
+ }
++
++SKIP:
++{
++  # [perl #131844] pointer addition overflow
++    $Config{ptrsize} == 4
++      or skip "[perl #131844] need 32-bit build for this test", 4;
++    # prevent ASAN just crashing on the allocation failure
++    local $ENV{ASAN_OPTIONS} = $ENV{ASAN_OPTIONS};
++    $ENV{ASAN_OPTIONS} .= ",allocator_may_return_null=1";
++    fresh_perl_like('pack "f999999999"', qr/Out of memory during pack/, { stderr => 1 },
++		    "pointer addition overflow");
++
++    # integer (STRLEN) overflow from addition of glen to current length
++    fresh_perl_like('pack "c10f1073741823"', qr/Out of memory during pack/, { stderr => 1 },
++		    "integer overflow calculating allocation (addition)");
++
++    fresh_perl_like('pack "W10f536870913", 256', qr/Out of memory during pack/, { stderr => 1 },
++		    "integer overflow calculating allocation (utf8)");
++
++    fresh_perl_like('pack "c10f1073741824"', qr/Out of memory during pack/, { stderr => 1 },
++		    "integer overflow calculating allocation (multiply)");
++}
+-- 
+2.11.0
+

--- a/build/perl/patches/series
+++ b/build/perl/patches/series
@@ -3,3 +3,8 @@ t_op_getppid.t.patch -p0
 dtrace.patch
 CVE-2017-12837.patch
 CVE-2017-12883.patch
+CVE-2018-6797.patch
+CVE-2018-6798a.patch
+CVE-2018-6798b.patch
+CVE-2018-6798c.patch
+CVE-2018-6913.patch

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,10 @@ Weekly release for w/c 16th of April 2018.
 
 ### Security fixes
 
+* `perl` updated to fix:
+  * [CVE-2018-6797](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6797)
+  * [CVE-2018-6798](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6798)
+  * [CVE-2018-6913](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-6913)
 * `zsh` updated to fix:
   * [CVE-2018-1100](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-1100)
 


### PR DESCRIPTION
As per #696 I've included the necessary release notes update for tomorrow due to the draft release notes having been merged in error.