### PR TITLE
nghttp2: update to 1.31.1

### DIFF
--- a/build/nghttp2/build.sh
+++ b/build/nghttp2/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=nghttp2
-VER=1.31.0
+VER=1.31.1
 VERHUMAN=$VER
 PKG=library/nghttp2
 SUMMARY="Nghttp2: HTTP/2 C Library"

--- a/build/nghttp2/testsuite.log
+++ b/build/nghttp2/testsuite.log
@@ -5,7 +5,7 @@ Making check in src
 Making check in includes
 Making all in includes
 ============================================================================
-Testsuite summary for nghttp2 1.31.0
+Testsuite summary for nghttp2 1.31.1
 ============================================================================
 # TOTAL: 0
 # PASS:  0
@@ -21,7 +21,7 @@ Making check in tests
 Making check in testdata
 Making all in testdata
 ============================================================================
-Testsuite summary for nghttp2 1.31.0
+Testsuite summary for nghttp2 1.31.1
 ============================================================================
 # TOTAL: 0
 # PASS:  0

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -44,7 +44,7 @@
 | library/libxml2			| 2.9.8			| https://github.com/GNOME/libxml2/releases http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.1.20180331		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/ | Updated every week
-| library/nghttp2			| 1.31.0		| https://github.com/nghttp2/nghttp2/releases
+| library/nghttp2			| 1.31.1		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.36			| https://ftp.mozilla.org/pub/security/nss/releases/
 | library/nspr				| 4.19			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.42			| https://ftp.pcre.org/pub/pcre/


### PR DESCRIPTION
CVE-2018-1000168: Denial of service due to NULL pointer dereference.