### PR TITLE
zsh: update to 5.5.1

### DIFF
--- a/build/zsh/build.sh
+++ b/build/zsh/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=zsh
-VER=5.5
+VER=5.5.1
 VERHUMAN=$VER
 PKG=shell/zsh
 SUMMARY="Z shell"

--- a/build/zsh/testsuite.log
+++ b/build/zsh/testsuite.log
@@ -8,7 +8,7 @@ Test ./A01grammar.ztst failed: bad status 127, expected 0 from:
   export PATH
   $ZTST_testdir/../Src/zsh -f -o pathscript myscript
 Error output:
-/data/omnios-build/omniosorg/bloody/_build/zsh-5.5/Test/../Src/zsh: can't open input file: myscript
+/data/omnios-build/omniosorg/bloody/_build/zsh-5.5.1/Test/../Src/zsh: can't open input file: myscript
 Was testing: PATHSCRIPT option
 ./A01grammar.ztst: test failed.
 ./A02alias.ztst: starting.

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -69,7 +69,7 @@
 | shell/bash-patchlvl			| 019			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches
 | shell/pipe-viewer			| 1.6.6			| http://www.ivarch.com/programs/pv.shtml
 | shell/tcsh				| 6.20.00		| https://github.com/tcsh-org/tcsh/releases
-| shell/zsh				| 5.5			| https://sourceforge.net/projects/zsh/files/zsh
+| shell/zsh				| 5.5.1			| https://sourceforge.net/projects/zsh/files/zsh
 | system/cpuid				| 1.6.3			| https://github.com/tycho/cpuid/releases
 | system/library/dbus			| 1.12.6		| https://dbus.freedesktop.org/releases/dbus | 1.13.x is an unstable/dev version.
 | system/library/libdbus-glib		| 0.110			| https://dbus.freedesktop.org/releases/dbus-glib/


### PR DESCRIPTION
Although there are only minor changes from 5.5, we should backport this to r26.

> Apart from a fix for a configuration problem finding singal names from
> some) recent versions of glibc, there are only minor changes.
