### PR TITLE
SMF ipfilter does not work with ssh

### DIFF
--- a/build/openssh/files/ssh.xml
+++ b/build/openssh/files/ssh.xml
@@ -23,6 +23,8 @@
 	Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 	Use is subject to license terms.
 
+	Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+
 	NOTE:  This service manifest is not editable; its contents will
 	be overwritten by package or patch operations, including
 	operating system upgrade.  Make customizations in a different
@@ -147,8 +149,14 @@
 
 	<property_group name='firewall_config' type='com.sun,fw_configuration'>
 		<propval name='policy' type='astring' value='use_global' />
+		<propval name='block_policy' type='astring'
+			value='use_global' />
 		<propval name='apply_to' type='astring' value='' />
+		<propval name='apply_to_6' type='astring' value='' />
 		<propval name='exceptions' type='astring' value='' />
+		<propval name='exceptions_6' type='astring' value='' />
+		<propval name='target' type='astring' value='' />
+		<propval name='target_6' type='astring' value='' />
 		<propval name='value_authorization' type='astring'
 			value='solaris.smf.value.firewall.config' />
 	</property_group>

--- a/build/openssh/files/sshd
+++ b/build/openssh/files/sshd
@@ -3,6 +3,8 @@
 # Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+#
 
 . /lib/svc/share/ipf_include.sh
 . /lib/svc/share/smf_include.sh
@@ -11,13 +13,16 @@ create_ipf_rules()
 {
 	FMRI=$1
 	ipf_file=`fmri_to_file ${FMRI} $IPF_SUFFIX`
+	ipf6_file=`fmri_to_file ${FMRI} $IPF6_SUFFIX`
 	policy=`get_policy ${FMRI}`
 
 	tports=`/usr/sbin/sshd -T 2>/dev/null | awk '/^port / {print $2}'`
 
 	echo "# $FMRI" >$ipf_file
+	echo "# $FMRI" >$ipf6_file
 	for port in $tports; do
-		generate_rules $FMRI $policy "tcp" "any" $port $ipf_file
+		generate_rules $FMRI $policy "tcp" $port $ipf_file
+		generate_rules $FMRI $policy "tcp" $port $ipf6_file _6
 	done
 }
 
@@ -31,6 +36,10 @@ case $1 in
 	# them.
         /usr/bin/ssh-keygen -A || exit $SMF_EXIT_ERR_FATAL
 	exec /usr/sbin/sshd
+	;;
+
+'ipfilter')
+	create_ipf_rules $2
 	;;
 
 *)


### PR DESCRIPTION
Our SSH SMF files are out of sync with the SMF ipfilter framework changes from  https://github.com/illumos/illumos-gate/commit/7ddce99911fbb5e44b38ac65e991a22e42267ee9
