### PR TITLE
Ship certutil with mozilla-nss

### DIFF
--- a/build/mozilla-nss-nspr/header-nspr.mog
+++ b/build/mozilla-nss-nspr/header-nspr.mog
@@ -21,7 +21,7 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 <transform file dir link path=usr/bin -> drop>
@@ -29,4 +29,4 @@
 <transform dir path=usr/lib -> drop>
 <transform dir file link path=usr/lib/mps -> drop>
 <transform dir path=usr/include/mps/pkgconfig -> drop>
-<transform file path=usr/lib/pkgconfig/nspr.pc -> set mode 0444>
+<transform file dir path=usr/lib/pkgconfig -> drop>

--- a/build/mozilla-nss-nspr/nspr.mog
+++ b/build/mozilla-nss-nspr/nspr.mog
@@ -21,11 +21,12 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 <transform file dir link path=usr/bin -> drop>
 <transform file dir link path=usr/include -> drop>
 <transform file dir link path=usr/share -> drop>
-<transform file dir path=usr/lib/pkgconfig -> drop>
+<transform dir path=usr/lib/pkgconfig -> drop>
+<transform file path=usr/lib/pkgconfig -> set mode 0444>
 

--- a/build/mozilla-nss-nspr/nss.mog
+++ b/build/mozilla-nss-nspr/nss.mog
@@ -24,7 +24,6 @@
 # Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-<transform file dir link path=usr/bin -> drop>
 <transform file dir link path=usr/include -> drop>
 <transform file dir link path=usr/share -> drop>
 <transform file link path=usr/.*/lib.*\.a$ -> drop>


### PR DESCRIPTION
certutil is required to complete TLS configuration of OmniOS as an ldap client.

See https://github.com/omniti-labs/omnios-build/issues/72