### PR TITLE
ncurses: update to 6.1.20180428

### DIFF
--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=ncurses
-VER=6.1-20180331
+VER=6.1-20180428
 VERHUMAN=$VER
 BUILDDIR=$PROG-$VER
 VER=${VER/-/.}

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -43,7 +43,7 @@
 | library/libffi			| 3.2.1			| https://sourceware.org/libffi/
 | library/libxml2			| 2.9.8			| https://github.com/GNOME/libxml2/releases http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
-| library/ncurses			| 6.1.20180331		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/ | Updated every week
+| library/ncurses			| 6.1.20180428		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/ | Updated every week
 | library/nghttp2			| 1.31.1		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.36.1		| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.19			| http://archive.mozilla.org/pub/nspr/releases/


### PR DESCRIPTION
This is a fix for CVE-2018-10754 In ncurses before 6.1.20180414, there is a NULL Pointer Dereference...