### PR TITLE
mercurial: update to 4.6

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -27,9 +27,9 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.5.3
+VER=4.6
 PKG=developer/versioning/mercurial
-SUMMARY="$PROG - a free and open source, distributed version control system"
+SUMMARY="$PROG - distributed version control system"
 DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="web/curl library/security/openssl"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -26,7 +26,7 @@
 | developer/parser/bison		| 3.0.4			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.17.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
-| developer/versioning/mercurial	| 4.5.3			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/mercurial	| 4.6			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.0.586		| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.29			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags


### PR DESCRIPTION
Tested by running openjdk build with this new version.