### PR TITLE
nss: update to 3.37

### DIFF
--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=nss
-VER=3.36.1
+VER=3.37
 # Include NSPR version since we're downloading a combined tarball.
 NSPRVER=4.19
 # But set BUILDDIR to just be the NSS version.

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -44,7 +44,7 @@
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.1.20180428		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/ | Updated every week
 | library/nghttp2			| 1.32.0		| https://github.com/nghttp2/nghttp2/releases
-| library/nss				| 3.36.1		| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
+| library/nss				| 3.37			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.19			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.42			| https://ftp.pcre.org/pub/pcre/
 | library/readline			| 7.0			| https://ftp.gnu.org/gnu/readline/


### PR DESCRIPTION
In terms of certificates, this update removes four old CAs and adds no new ones therefore I'm not flagging this for back-port.