### PR TITLE
GNU make - 64-bit, default to CC=gcc, clean testsuite output

### DIFF
--- a/build/gnu-make/build.sh
+++ b/build/gnu-make/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,14 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=make
@@ -33,16 +31,28 @@ VER=4.2.1
 VERHUMAN=$VER
 PKG=developer/build/gnu-make
 SUMMARY="gmake - GNU make"
-DESC="GNU make - A utility used to build software (gmake)"
+DESC="GNU make - A utility used to build software"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=32
+BUILDARCH=64
 CONFIGURE_OPTS="--bindir=$PREFIX/bin --program-prefix=g"
+
+TESTSUITE_SED="
+    /-srcdir/d
+    /Making /d
+    /on SunOS/d
+    /getloadavg/d
+    /getlogin_r/d
+    /load average/d
+    /1-minute/d
+    /~~~~~~~~~/d
+"
 
 init
 download_source $PROG $PROG $VER
 patch_source
+run_autoreconf -fi      # As Makefile.am has been modified
 prep_build
 build
 run_testsuite check
@@ -51,4 +61,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gnu-make/patches/gcc.patch
+++ b/build/gnu-make/patches/gcc.patch
@@ -1,0 +1,19 @@
+The native compiler on OmniOS is gcc. Modify GNU make to suit.
+We don't define GCC_IS_NATIVE since this also modifies the native
+lex and yacc defitions and makes the POSIX tests fail.
+
+diff -ru make-4.2.1~/default.c make-4.2.1/default.c
+--- make-4.2.1~/default.c	2016-02-28 17:48:44.000000000 +0000
++++ make-4.2.1/default.c	2018-05-14 09:00:13.656611463 +0000
+@@ -529,9 +529,9 @@
+ # endif /* __MSDOS__ */
+     "OBJC", "gcc",
+ #else
+-    "CC", "cc",
++    "CC", "gcc",
+     "CXX", "g++",
+-    "OBJC", "cc",
++    "OBJC", "gcc",
+ #endif
+ 
+     /* This expands to $(CO) $(COFLAGS) $< $@ if $@ does not exist,

--- a/build/gnu-make/patches/series
+++ b/build/gnu-make/patches/series
@@ -1,0 +1,2 @@
+testsuite.patch
+gcc.patch

--- a/build/gnu-make/patches/testsuite.patch
+++ b/build/gnu-make/patches/testsuite.patch
@@ -1,0 +1,15 @@
+Modern perl does not include '.' in its include path.
+Need to patch the GNU make test.
+
+diff -ru make-4.2.1~/Makefile.am make-4.2.1/Makefile.am
+--- make-4.2.1~/Makefile.am	2016-05-22 13:16:06.000000000 +0000
++++ make-4.2.1/Makefile.am	2018-05-14 08:32:17.213552437 +0000
+@@ -189,7 +189,7 @@
+ 		   done; fi ;; \
+ 	    esac; \
+ 	    echo "cd tests && $(PERL) ./run_make_tests.pl -srcdir $(abs_srcdir) -make ../make$(EXEEXT) $(MAKETESTFLAGS)"; \
+-	    cd tests && $(PERL) ./run_make_tests.pl -srcdir '$(abs_srcdir)' -make '../make$(EXEEXT)' $(MAKETESTFLAGS); \
++	    cd tests && $(PERL) -I. ./run_make_tests.pl -srcdir '$(abs_srcdir)' -make '../make$(EXEEXT)' $(MAKETESTFLAGS); \
+ 	  else \
+ 	    echo "Can't find a working Perl ($(PERL)); the test suite requires Perl."; \
+ 	  fi; \

--- a/build/gnu-make/testsuite.log
+++ b/build/gnu-make/testsuite.log
@@ -1,18 +1,7 @@
-Making check in glob
-Making check in config
-Making check in po
-Making check in doc
-getloadavg.c: In function 'main':
-getloadavg.c:1004:15: warning: implicit declaration of function 'getloadavg' [-Wimplicit-function-declaration]
-       loads = getloadavg (avg, 3);
-               ^
-cd tests && perl ./run_make_tests.pl -srcdir /tmp/build_af/make-4.2.1 -make ../make 
 ------------------------------------------------------------------------------
-             Running tests for GNU make on SunOS build 5.11 i86pc
                                 GNU Make 4.2.1
 ------------------------------------------------------------------------------
 
-Clearing work...
 Finding tests...
 
 features/archives ....................................... ok     (10 passed)
@@ -83,7 +72,7 @@ functions/warning ....................................... ok     (5 passed)
 functions/wildcard ...................................... ok     (6 passed)
 functions/word .......................................... ok     (16 passed)
 misc/bs-nl .............................................. ok     (28 passed)
-misc/close_stdout ....................................... FAILED (no tests found!)
+misc/close_stdout ....................................... ok     (1 passed)
 misc/fopen-fail ......................................... ok     (1 passed)
 misc/general1 ........................................... ok     (1 passed)
 misc/general2 ........................................... ok     (1 passed)
@@ -138,12 +127,8 @@ variables/special ....................................... ok     (6 passed)
 variables/undefine ...................................... ok     (4 passed)
 vms/library ............................................. N/A
 
-584 Tests in 119 Categories Complete ... No Failures :-)
+585 Tests in 120 Categories Complete ... No Failures :-)
 
-The system uptime program believes the load average to be:
-10:06:22    up 20 day(s), 22:55,  2 users,  load average: 0.20, 0.09, 0.04
-The GNU load average checking code thinks:
-1-minute: 0.195312  5-minute: 0.089844  15-minute: 0.035156  
 
 ========================================================================
  Regression PASSED: GNU Make 4.2.1 (i386-pc-solaris2.11) built with gcc 


### PR DESCRIPTION
Since gcc is the native compiler on OmniOS, make utilities should default to it in the absence of a CC environment variable.

Before:
```
build% gmake c
cc     c.c   -o c
gmake: cc: Command not found
```

After:
```
bloody% gmake c
gcc     c.c   -o c
```

While there, switch this to 64-bit and remove the run-dependant parts of the test-suite output.
