### PR TITLE
Provide tools area for consistent build environment.

### DIFF
--- a/build/cdrtools/build.sh
+++ b/build/cdrtools/build.sh
@@ -39,11 +39,12 @@ export MAKE=/usr/bin/make
 
 BUILDARCH=32
 
-# cdrtools doesn't use configure, just make
 make_clean() {
-    :
+    logcmd ./.clean
 }
 
+# cdrtools doesn't use configure in the normal way, just make will invoke
+# configure automatically.
 configure32() {
     export CC
     MAKE_ARGS="CC=$CC"


### PR DESCRIPTION
This change creates a tools/ area which is placed early in the path in our build environment (just after the specific GCC compiler version).

This area contains binaries called `cc` and `CC` which link to `/bin/false`, preventing configuration scripts from detecting a studio compiler even if there is a `/usr/bin/cc` on the system (for example).
Further links can be added to this in the future to ensure a consistent build environment across systems.

```
% ls -l ../_build/tools
total 4
lrwxrwxrwx   1 af       other         10 May 15 09:55 CC -> /bin/false*
lrwxrwxrwx   1 af       other         10 May 15 09:55 cc -> /bin/false*
lrwxrwxrwx   1 af       other         18 May 15 10:03 g++ -> /opt/gcc-7/bin/g++*
lrwxrwxrwx   1 af       other         18 May 15 10:03 gcc -> /opt/gcc-7/bin/gcc*
```