### PR TITLE
Export CC so that mozilla-nss uses the right compiler

### DIFF
--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -60,6 +60,8 @@ NSPR_BINS=
 
 NSPR_SAVE="$TMPDIR/nspr-save.$$"
 
+export CC
+
 make_clean() {
     # Assume PWD == top-level with nss & nspr subdirs.
     /bin/rm -rf dist

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -341,7 +341,6 @@ set_gccver() {
         PATH="$CCACHE_PATH:$PATH"
     fi
     export GCCVER GCCPATH PATH
-    logmsg "-- New PATH=$PATH"
 }
 
 set_gccver $DEFAULT_GCC_VER


### PR DESCRIPTION
Export CC so that mozilla-nss uses the right compiler
