### PR TITLE
update curl to 7.60

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=curl
-VER=7.59.0
+VER=7.60.0
 PKG=web/curl
 SUMMARY="$PROG - command line tool for transferring data with URL syntax"
 DESC="$SUMMARY"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -87,7 +87,7 @@
 | text/gnu-sed				| 4.5			| http://git.savannah.gnu.org/cgit/sed.git/refs/tags https://savannah.gnu.org/news/?group=sed
 | text/groff				| 1.22.3		| https://ftp.gnu.org/gnu/groff/
 | text/less				| 530			| https://ftp.gnu.org/gnu/less/
-| web/curl				| 7.59.0		| https://curl.haxx.se/download.html
+| web/curl				| 7.60.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.19.5		| https://git.savannah.gnu.org/cgit/wget.git/refs/tags
 | library/glib2				| 2.56.1		| https://download.gnome.org/sources/glib/cache.json https://developer.gnome.org/glib/ | Odd minor versions are dev/unstable
 | developer/gnu-binutils		| 2.30			| https://ftp.gnu.org/gnu/binutils


### PR DESCRIPTION
update curl to 7.60. test 1139 fails as this version is missing changes on curl.1
 Current  curl 7.60-DEV has this solved.