### PR TITLE
libsigc++: update to 2.99.11

### DIFF
--- a/build/sigcpp/build.sh
+++ b/build/sigcpp/build.sh
@@ -24,18 +24,21 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=libsigc++
-VER=2.99.10
+VER=2.99.11
 VERHUMAN=$VER
 PKG=library/c++/sigcpp
-SUMMARY="Libsigc++ - a library that implements typesafe callback system"
+SUMMARY="libsigc++ - a library that implements typesafe callback system"
 DESC="$SUMMARY"
 
 export MAKE
 CONFIGURE_OPTS="--includedir=/usr/include"
+
+TESTSUITE_SED="
+    /CXX/d
+"
 
 init
 download_source $PROG $PROG $VER

--- a/build/sigcpp/testsuite.log
+++ b/build/sigcpp/testsuite.log
@@ -1,82 +1,5 @@
 Making check in sigc++
 Making check in tests
-  CXX      test_accum_iter.o
-  CXX      testutilities.o
-  CXXLD    test_accum_iter
-  CXX      test_accumulated.o
-  CXXLD    test_accumulated
-  CXX      test_bind.o
-  CXXLD    test_bind
-  CXX      test_bind_as_slot.o
-  CXXLD    test_bind_as_slot
-  CXX      test_bind_ref.o
-  CXXLD    test_bind_ref
-  CXX      test_bind_refptr.o
-  CXXLD    test_bind_refptr
-  CXX      test_bind_return.o
-  CXXLD    test_bind_return
-  CXX      test_compose.o
-  CXXLD    test_compose
-  CXX      test_copy_invalid_slot.o
-  CXXLD    test_copy_invalid_slot
-  CXX      test_cpp11_lambda.o
-  CXXLD    test_cpp11_lambda
-  CXX      test_custom.o
-  CXXLD    test_custom
-  CXX      test_disconnect.o
-  CXXLD    test_disconnect
-  CXX      test_disconnect_during_emit.o
-  CXXLD    test_disconnect_during_emit
-  CXX      test_exception_catch.o
-  CXXLD    test_exception_catch
-  CXX      test_hide.o
-  CXXLD    test_hide
-  CXX      test_limit_reference.o
-  CXXLD    test_limit_reference
-  CXX      test_member_method_trait.o
-  CXXLD    test_member_method_trait
-  CXX      test_mem_fun.o
-  CXXLD    test_mem_fun
-  CXX      test_ptr_fun.o
-  CXXLD    test_ptr_fun
-  CXX      test_retype.o
-  CXXLD    test_retype
-  CXX      test_retype_return.o
-  CXXLD    test_retype_return
-  CXX      test_signal.o
-  CXXLD    test_signal
-  CXX      test_signal_move.o
-  CXXLD    test_signal_move
-  CXX      test_size.o
-  CXXLD    test_size
-  CXX      test_slot.o
-  CXXLD    test_slot
-  CXX      test_slot_disconnect.o
-  CXXLD    test_slot_disconnect
-  CXX      test_slot_move.o
-  CXXLD    test_slot_move
-  CXX      test_trackable.o
-  CXXLD    test_trackable
-  CXX      test_trackable_move.o
-  CXXLD    test_trackable_move
-  CXX      test_track_obj.o
-  CXXLD    test_track_obj
-  CXX      test_tuple_cdr.o
-  CXXLD    test_tuple_cdr
-  CXX      test_tuple_end.o
-  CXXLD    test_tuple_end
-  CXX      test_tuple_for_each.o
-  CXXLD    test_tuple_for_each
-  CXX      test_tuple_start.o
-  CXXLD    test_tuple_start
-  CXX      test_tuple_transform_each.o
-  CXXLD    test_tuple_transform_each
-  CXX      test_visit_each.o
-  CXXLD    test_visit_each
-  CXX      test_visit_each_trackable.o
-  CXXLD    test_visit_each_trackable
-  CXX      test_weak_raw_ptr.o
-  CXXLD    test_weak_raw_ptr
 PASS: test_accum_iter
 PASS: test_accumulated
 PASS: test_bind
@@ -116,7 +39,7 @@ PASS: test_visit_each
 PASS: test_visit_each_trackable
 PASS: test_weak_raw_ptr
 ============================================================================
-Testsuite summary for libsigc++ 2.99.10
+Testsuite summary for libsigc++ 2.99.11
 ============================================================================
 # TOTAL: 38
 # PASS:  38
@@ -128,4 +51,4 @@ Testsuite summary for libsigc++ 2.99.10
 ============================================================================
 Making check in examples
 Making check in cmake
-Making check in docs
+Making check in docs/docs

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -30,7 +30,7 @@
 | editor/vim				| 8.1			| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.29			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags
 | file/gnu-findutils			| 4.6.0			| https://ftp.gnu.org/pub/gnu/findutils/
-| library/c++/sigcpp			| 2.99.10		| https://download.gnome.org/sources/libsigc++/cache.json https://github.com/libsigcplusplus/libsigcplusplus/blob/master/NEWS
+| library/c++/sigcpp			| 2.99.11		| https://download.gnome.org/sources/libsigc++/cache.json https://github.com/libsigcplusplus/libsigcplusplus/blob/master/NEWS
 | library/expat				| 2.2.5			| https://sourceforge.net/projects/expat/files/expat
 | library/gmp				| 6.1.2			| https://gmplib.org/
 | library/mpc				| 1.1.0			| http://www.multiprecision.org/mpc/download.html


### PR DESCRIPTION
Now that illumos 9527 has been merged into bloody, we can update this package.