### PR TITLE
Add out-of-tree build support

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -561,6 +561,15 @@ prep_build() {
         mkdir -p $DESTDIR || \
             logerr "Failed to create temporary install dir"
     fi
+
+    if [ -n "$OUT_OF_TREE_BUILD" ]; then
+        logmsg "-- Setting up for out-of-tree build"
+        CONFIGURE_CMD=$TMPDIR/$BUILDDIR/configure
+        SRC_BUILDDIR=$BUILDDIR
+        BUILDDIR+=-build
+        [ -d $TMPDIR/$BUILDDIR ] && logcmd rm -rf $TMPDIR/$BUILDDIR
+        logcmd mkdir -p $TMPDIR/$BUILDDIR
+    fi
 }
 
 #############################################################################
@@ -1213,9 +1222,7 @@ make_isaexec_stub_arch() {
 
 make_clean() {
     logmsg "--- make (dist)clean"
-    logcmd $MAKE distclean || \
-        logcmd $MAKE clean || \
-        logmsg "--- *** WARNING *** make (dist)clean Failed"
+    logcmd $MAKE distclean || logcmd $MAKE clean
 }
 
 configure32() {


### PR DESCRIPTION
Some software packages are only supported/tested with builds that are done out of the source tree. Gcc is an example of this, from the installation instructions:

>First, we **highly** recommend that GCC be built into a
> separate directory from the sources which does **not** reside
> within the source tree.  This is how we generally build GCC; building
> where `srcdir` == `objdir` should still work, but doesn't
> get extensive testing; building where `objdir` is a subdirectory
> of `srcdir` is unsupported.

This PR adds support for building in this way by setting the new `OUT_OF_TREE_BUILD` variable in the build script.
