### PR TITLE
Build each package in a sub-directory of the temporary area.

### DIFF
--- a/build/as/build.sh
+++ b/build/as/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,49 +18,32 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
-#
-# this will build
-#
-#   * assorted bin-only bits: (from sub root)
-#     * as
-#     * libtdf
-#     * libxprof
-#     * libxprof_audit
 
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=make
+PROG=as
 VER=0.5.11
 PKG=developer/as
 SUMMARY="OmniOS Bundled Assembler (aka DevPro)"
 DESC="$SUMMARY"
 
-DEPENDS_IPS="system/library SUNWcs system/library/math"
-
-CONFIGURE_OPTS=""
-PKGE=$(url_encode $PKG)
-DESTDIR=$DTMPDIR/as
-
-prebuild_clean() {
-    logmsg "Cleaning destdir: $DESTDIR"
-    logcmd rm -rf $DESTDIR
-    logcmd mkdir -p $DESTDIR
-}
-
 place_bins() {
     logmsg "Moving closed bins into place"
-    (cd $SRCDIR/root && tar cf - .) | (cd $DESTDIR && tar xf -) ||
-        logerr "Failed to copy closed bins"
+    pushd $SRCDIR/root >/dev/null
+    find . | cpio -pvmud $DESTDIR
+    popd >/dev/null
 }
 
 init
-prebuild_clean
+prep_build
 place_bins
 make_package
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/entire/build-entire.sh
+++ b/build/entire/build-entire.sh
@@ -17,6 +17,7 @@
 #
 . ../../lib/functions.sh
 
+PROG=entire
 PKG=entire
 VER=0.5.11
 SUMMARY="Builds the OmniOS entire meta-package"

--- a/build/gcc5/build.sh
+++ b/build/gcc5/build.sh
@@ -42,11 +42,6 @@ XFORM_ARGS="-D MAJOR=$GCCMAJOR -D OPT=$OPT -D GCCVER=$VER"
 export LD_LIBRARY_PATH=$OPT/lib
 export PATH=/usr/perl5/$PERLVER/bin:$OPT/bin:$PATH
 
-# Use a dedicated temporary directory
-# (avoids conflicts with other gcc versions during parallel builds)
-export TMPDIR=$TMPDIR/gcc-$GCCMAJOR
-export DTMPDIR=$TMPDIR
-
 RUN_DEPENDS_IPS="
     developer/library/lint
     developer/linker

--- a/build/jeos/build-gate.sh
+++ b/build/jeos/build-gate.sh
@@ -15,6 +15,7 @@
 # Load support functions
 . ../../lib/functions.sh
 
+PROG=jeos
 PKG=incorporation/jeos/illumos-gate
 VER=0.5.11
 SUMMARY="Builds the OmniOS illumos-gate incorporation"

--- a/build/jeos/build-userland.sh
+++ b/build/jeos/build-userland.sh
@@ -15,6 +15,7 @@
 # Load support functions
 . ../../lib/functions.sh
 
+PROG=jeos
 PKG=incorporation/jeos/omnios-userland
 VER=0.5.11
 SUMMARY="Builds the OmniOS userland incorporation"

--- a/build/kayak-kernel/build.sh
+++ b/build/kayak-kernel/build.sh
@@ -19,10 +19,15 @@
 
 # We have to build as root to manipulate ZFS datasets
 export ROOT_OK=yes
+. ../../lib/functions.sh
+
+PROG=kayak-kernel
+PKG=system/install/kayak-kernel
+VER=1.1
+SUMMARY="Kayak - network installer media"
+DESC="$SUMMARY"
 
 KAYAK_CLOBBER=${KAYAK_CLOBBER:=0}
-
-. ../../lib/functions.sh
 
 if [ -n "$SKIP_KAYAK_KERNEL" ]; then
     logmsg "Skipping kayak-kernel build"
@@ -61,8 +66,6 @@ else
     PREBUILT_ILLUMOS="/dev/null"
 fi
 
-VER=1.1
-
 # NOTE: If PKGURL is specified, allow it to be different than the destination
 # PKGSRVR. PKGURL is from where kayak-kernel takes its bits. PKGSRVR is where
 # this package (with a prebuilt miniroot and unix) will be installed.
@@ -86,20 +89,13 @@ clone_source() {
     VERHUMAN="${COMMIT:0:7} from $REVDATE"
 }
 
-PKG=system/install/kayak-kernel
-SUMMARY="Kayak - network installer media"
-PKGE=$(url_encode $PKG)
-PKGD=${PKGE//%/_}
-DESTDIR=$DTMPDIR/${PKGD}_pkg
-DEPENDS_IPS=""
-
+init
+prep_build
 clone_source
 logmsg "Now building $PKG"
 $SUDO ./sudo-bits.sh $KAYAK_CLOBBER $TMPDIR/$BUILDDIR \
-    $PREBUILT_ILLUMOS $DESTDIR $PKGURL $VER $OLDUSER $BATCHMODE
-if [ $? != 0 ]; then
-    logerr "--- sudo-bits sub-script failed."
-fi
+    $PREBUILT_ILLUMOS $DESTDIR $PKGURL $VER $OLDUSER $BATCHMODE \
+    || logerr "--- sudo-bits sub-script failed."
 make_package kayak-kernel.mog
 clean_up
 

--- a/build/sccs/build.sh
+++ b/build/sccs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,66 +18,55 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
-#
-# this will build
-#
-#   * sccs
-#
 
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=make
+PROG=sccs
 VER=0.5.11
 PKG=developer/versioning/sccs
 SUMMARY="Source Code Control System (SCCS)"
 DESC="$SUMMARY"
 
 BUILD_DEPENDS_IPS="sunstudio12.1 compatibility/ucb"
-DEPENDS_IPS="system/library SUNWcs system/library/math"
-
-CONFIGURE_OPTS=""
-PKGE=$(url_encode $PKG)
-DESTDIR=$DTMPDIR/sccs
-
-prebuild_clean() {
-    logmsg "Cleaning destdir: $DESTDIR"
-    logcmd rm -rf $DESTDIR
-    mkdir -p $DESTDIR/usr/bin
-}
+RUN_DEPENDS_IPS="system/library/math"
 
 build() {
     logmsg "Building and installing ($1)"
     pushd $TMPDIR/$1/usr/src > /dev/null || logerr "can't enter build harness"
-    logcmd env STUDIOBIN=/opt/sunstudio12.1/bin DESTDIR=$DESTDIR ./build ||
-        logerr "make/install ($1) failed"
+    logcmd env STUDIOBIN=$SUNSTUDIO_BIN DESTDIR=$DESTDIR ./build \
+        || logerr "make/install ($1) failed"
     popd > /dev/null
 }
 
 move_and_links() {
     logmsg "Shifting binaries and setting up links"
-    logcmd mv $DESTDIR/usr/ccs/bin/help $DESTDIR/usr/bin/sccshelp
+    logcmd mkdir -p $DESTDIR/usr/bin
+    logcmd mv $DESTDIR/usr/ccs/bin/help $DESTDIR/usr/bin/sccshelp \
+        || logerr "help move failed"
     pushd $DESTDIR/usr/ccs/bin > /dev/null || logerr "Cannot chdir"
-    for cmd in *
-    do
-        logcmd mv $cmd $DESTDIR/usr/bin/ || logerr "Cannot relocate /usr/ccs/bin/$cmd"
-        logcmd ln -s ../../$cmd $cmd
+    for cmd in *; do
+        [ -x "$cmd" ] || continue
+        logcmd mv $cmd ../../bin/ || logerr "Cannot relocate /usr/ccs/bin/$cmd"
+        logcmd ln -s ../../bin/$cmd $cmd || logerr "Link $cmd failed"
     done
-    logcmd ln -s ../../sccshelp $DESTDIR/usr/ccs/bin/sccshelp
-    logcmd ln -s ../../sccshelp $DESTDIR/usr/ccs/bin/help
+    logcmd ln -s ../../bin/sccshelp sccshelp || logerr "sccshelp link"
+    logcmd ln -s ../../bin/sccshelp help || logerr "sccshelp link2"
     popd > /dev/null
 }
 
 init
-prebuild_clean
+prep_build
 BUILDDIR=devpro-sccs-20061219
 download_source devpro devpro-sccs src-20061219
 build devpro-sccs-20061219
 move_and_links
 make_package
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/tmux/build.sh
+++ b/build/tmux/build.sh
@@ -36,6 +36,9 @@ LIBEVENT_VER=2.1.8
 LDIR=libevent-${LIBEVENT_VER}-stable
 XFORM_ARGS+=" -DLIBEVENT=$LIBEVENT_VER"
 
+# Call init early to set up TMPDIR to use in CPPFLAGS/LDFLAGS.
+init
+
 BUILDARCH=32
 CONFIGURE_OPTS_32+=" --bindir=/usr/bin"
 CPPFLAGS="\
@@ -63,7 +66,7 @@ build_libevent() {
     popd > /dev/null
 }
 
-init
+prep_build
 download_source $PROG $PROG $VER
 
 # Download and build libevent as that is not part of core
@@ -74,7 +77,6 @@ BUILDDIR=$_BUILDDIR
 build_libevent
 
 patch_source
-prep_build
 build
 make_isa_stub
 strip_install

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -162,6 +162,8 @@ GIT=git
 # Command for privilege escalation. Can be overridden in site.sh
 PFEXEC=sudo
 
+SUNSTUDIO_BIN=/opt/sunstudio12.1/bin
+
 # Figure out number of logical CPUs for use with parallel gmake jobs (-j)
 # Default to 1.5*nCPUs as we assume the build machine is 100% devoted to
 # compiling.

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -301,6 +301,7 @@ SRCDIR=$PWD/`dirname $0`
 #############################################################################
 . $MYDIR/config.sh
 [ -f $MYDIR/site.sh ] && . $MYDIR/site.sh
+BASE_TMPDIR=$TMPDIR
 
 # Platform information, e.g. 5.11
 SUNOSVER=`uname -r`
@@ -471,6 +472,14 @@ init() {
     # built in (i.e. what the tarball extracts to). This defaults to the name
     # and version of the program, which works in most cases.
     [ -z "$BUILDDIR" ] && BUILDDIR=$PROG-$VER
+
+    # Build each package in a sub-directory of the temporary area.
+    # In addition to keeping everything related to a package together,
+    # this also prevents problems with packages which have non-unique archive
+    # names (1.2.3.tar.gz) or non-unique prog names.
+    [ -n "$PROG" ] || logerr "\$PROG is not defined for this package."
+    [ "$TMPDIR" = "$BASE_TMPDIR" ] && TMPDIR="$BASE_TMPDIR/$PROG-$VER"
+    [ "$DTMPDIR" = "$BASE_TMPDIR" ] && DTMPDIR="$TMPDIR"
 
     init_repo
     pkgrepo get -s $PKGSRVR > /dev/null 2>&1 || \


### PR DESCRIPTION
Aside from tidying up the temporary area by keeping related files together, this also fixes a problem with packages where the download archive is just a plain version number (1.2.3.tar.gz) - common with releases posted on github. If two packages like this have the same version number and are built in parallel, chaos ensues.

I've done a full userland build with this change and tweaked a few other packages along the way.
Mainly this was to add missing PROG= lines or change ones that had the wrong value, fix packages that didn't fully use the build framework (taking care of their own DESTDIR instead of using `init` & `prep_build` for example)
The sccs package was one of those but was also broken as the symlinks delivered into /usr/ccs/bin pointed nowhere.