### PR TITLE
acpica build requires GNU m4

### DIFF
--- a/build/acpica/build.sh
+++ b/build/acpica/build.sh
@@ -38,6 +38,7 @@ extract_licence() {
 # No configure
 configure32() {
     export CC=gcc
+    export M4=gm4
 }
 
 make_prog32() {


### PR DESCRIPTION
acpica build requires GNU m4
