### PR TITLE
nss: upgrade to 3.37.3

### DIFF
--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=nss
-VER=3.37.1
+VER=3.37.3
 # Include NSPR version since we're downloading a combined tarball.
 NSPRVER=4.19
 # But set BUILDDIR to just be the NSS version.

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,7 +45,7 @@
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.1.20180428		| http://invisible-mirror.net/archives/ncurses/current/ https://ftp.gnu.org/gnu/ncurses/ | Updated every week
 | library/nghttp2			| 1.32.0		| https://github.com/nghttp2/nghttp2/releases
-| library/nss				| 3.37.1		| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
+| library/nss				| 3.37.3		| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.19			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.42			| https://ftp.pcre.org/pub/pcre/
 | library/readline			| 7.0			| https://ftp.gnu.org/gnu/readline/

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -704,15 +704,18 @@ get_resource() {
 #   $2 - program name
 #   $3 - program version
 #   $4 - target directory
+#   $5 - passed to extract_archive
 #
 # E.g.
 #       download_source myprog myprog 1.2.3 will try:
 #       http://mirrors.omniosce.org/myprog/myprog-1.2.3.tar.gz
 download_source() {
-    local DLDIR="$1"
-    local PROG="$2"
-    local VER="$3"
-    local TARGETDIR="$4"
+    local DLDIR="$1"; shift
+    local PROG="$1"; shift
+    local VER="$1"; shift
+    local TARGETDIR="$1"; shift
+    local EXTRACTARGS="$@"
+
     local ARCHIVEPREFIX="$PROG"
     [ -n "$VER" ] && ARCHIVEPREFIX+="-$VER"
     [ -z "$TARGETDIR" ] && TARGETDIR="$TMPDIR"
@@ -784,7 +787,8 @@ download_source() {
 
     # Extract the archive
     logmsg "Extracting archive: $FILENAME"
-    logcmd extract_archive $FILENAME || logerr "--- Unable to extract archive."
+    logcmd extract_archive $FILENAME $EXTRACTARGS \
+        || logerr "--- Unable to extract archive."
 
     # Make sure the archive actually extracted some source where we expect
     if [ ! -d "$BUILDDIR" ]; then
@@ -799,27 +803,23 @@ download_source() {
 # Example: find_archive myprog-1.2.3 FILENAME
 #   Stores myprog-1.2.3.tar.gz in $FILENAME
 find_archive() {
-    FILES=`ls $1.{tar.bz2,tar.gz,tar.xz,tgz,tbz,tar,zip} 2>/dev/null`
+    FILES=`ls $1.{tar.gz,tgz,tar.bz2,tbz,tar.xz,tar,zip} 2>/dev/null`
     FILES=${FILES%% *} # Take only the first filename returned
     # This dereferences the second parameter passed
     eval "$2=\"$FILES\""
 }
 
-# Extracts an archive regardless of its extension
+# Extracts various types of archive
 extract_archive() {
-    if [[ $1 =~ .tar.gz|.tgz ]]; then
-        $GZIP -dc $1 | $TAR -xvf -
-    elif [[ $1 =~ .tar.bz2|.tbz ]]; then
-        $BUNZIP2 -dc $1 | $TAR -xvf -
-    elif [[ $1 = *.tar.xz ]]; then
-        $XZCAT $1 | $TAR -xvf -
-    elif [[ $1 = *.tar ]]; then
-        $TAR -xvf $1
-    elif [[ $1 = *.zip ]]; then
-        $UNZIP $1
-    else
-        return 1
-    fi
+    local file="$1"; shift
+    case $file in
+        *.tar.gz|*.tgz)     $GZIP -dc $file | $TAR -xvf - $* ;;
+        *.tar.bz2|*.tbz)    $BUNZIP2 -dc $file | $TAR -xvf - $* ;;
+        *.tar.xz)           $XZCAT $file | $TAR -xvf - $* ;;
+        *.tar)              $TAR -xvf $file $* ;;
+        *.zip)              $UNZIP $file $* ;;
+        *)                  return 1 ;;
+    esac
 }
 
 #############################################################################


### PR DESCRIPTION
I've also made change to ca-bundle so that it extracts certificates from the same archive file used to build nss/nspr packages, rather than us having to put and maintain both the combined and nss-only files on the mirror.l

Additionally, since ca-bundle only needs two files from the archive, I've extended extract_archive to take additional arguments so that we only need to extract the required files. This may be generally useful elsewhere too since it allows passing arbitrary arguments into $TAR for example.