### PR TITLE
Provide easy way to build single-architecture and skip the isaexec links.

### DIFF
--- a/build/autoconf/build.sh
+++ b/build/autoconf/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,26 +18,25 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=autoconf                 # App name
-VER=2.69                      # App version
-PKG=developer/build/autoconf  # Package name (without prefix)
+PROG=autoconf
+VER=2.69
+PKG=developer/build/autoconf
 SUMMARY="autoconf - GNU autoconf utility"
 DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu developer/macro/gnu-m4"
 
 NO_PARALLEL_MAKE=1
-BUILDARCH=32
-CONFIGURE_OPTS="--infodir=$PREFIX/share/info --bindir=$PREFIX/bin"
+set_arch 32
+CONFIGURE_OPTS="--infodir=$PREFIX/share/info"
 
 init
 download_source $PROG $PROG $VER
@@ -45,9 +44,8 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/automake/build.sh
+++ b/build/automake/build.sh
@@ -33,14 +33,11 @@ PKG=developer/build/automake
 SUMMARY="GNU Automake"
 DESC="GNU Automake - A Makefile generator"
 
-BUILDARCH=32
 BUILD_DEPENDS_IPS="compress/xz developer/build/autoconf"
 RUN_DEPENDS_IPS="developer/macro/gnu-m4 runtime/perl"
-
 HARDLINK_TARGETS="usr/bin/aclocal usr/bin/automake"
 
-# Since it's 32-bit only we don't worry about isaexec for bins
-CONFIGURE_OPTS="--bindir=$PREFIX/bin"
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
@@ -48,7 +45,6 @@ patch_source
 prep_build
 build
 PATH=/usr/gnu/bin:$PATH run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/bash/build.sh
+++ b/build/bash/build.sh
@@ -37,7 +37,7 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu system/library"
 
-BUILDARCH=32
+set_arch 32
 NO_PARALLEL_MAKE=1
 
 # Cribbed from upstream but modified for gcc
@@ -48,7 +48,6 @@ LDFLAGS="-Wl,-z -Wl,redlocsym"
 #   We only do 32-bit so forgo the isaexec stuff
 #   Don't bother building static
 CONFIGURE_OPTS="
-    --bindir=$PREFIX/bin
     --localstatedir=/var
     --enable-alias
     --enable-arith-for-command
@@ -90,7 +89,6 @@ CONFIGURE_OPTS="
     --with-curses
     --with-installed-readline=no
 "
-reset_configure_opts
 
 # Files taken from upstream userland-gate
 install_files() {
@@ -103,7 +101,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 install_files
 VER=${VER}.$PATCHLEVEL
 make_package

--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -33,13 +33,11 @@ PKG=network/dns/bind
 SUMMARY="BIND DNS tools"
 DESC="$SUMMARY"
 
-BUILDARCH=32
+set_arch 32
 
 CONFIGURE_OPTS="
-    --bindir=$PREFIX/sbin
-    --sbindir=$PREFIX/sbin
     --libdir=$PREFIX/lib/dns
-    --sysconfdir=/etc
+    --bindir=$PREFIX/sbin
     --localstatedir=/var
     --with-libtool
     --with-openssl
@@ -65,7 +63,6 @@ prep_build
 build
 python_vendor_relocate
 run_testsuite test-force
-make_isa_stub
 VER=${VER//-P/.}
 VER=${VER//-W/.}
 make_package

--- a/build/bison/build.sh
+++ b/build/bison/build.sh
@@ -33,16 +33,7 @@ PKG=developer/parser/bison
 SUMMARY="Bison is a general-purpose parser generator"
 DESC="$SUMMARY"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-"
+set_arch 32
 CONFIGURE_OPTS="--disable-yacc"
 export M4=/usr/bin/gm4
 
@@ -58,7 +49,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/ca-bundle/build.sh
+++ b/build/ca-bundle/build.sh
@@ -42,8 +42,6 @@ MAKECAVER=0.6
 DESC="SSL Root CA certificates extracted from mozilla-nss $NSSVER source"
 DESC+=", plus OmniOSce CA cert."
 
-BUILDARCH=32
-
 build_pem() {
     BUILDDIR_ORIG=$BUILDDIR
 

--- a/build/cdrtools/build.sh
+++ b/build/cdrtools/build.sh
@@ -37,7 +37,7 @@ DEPENDS_IPS="system/library system/library/gcc-runtime"
 
 export MAKE=/usr/bin/make
 
-BUILDARCH=32
+set_arch 32
 
 make_clean() {
     logcmd ./.clean
@@ -81,7 +81,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/cpuid/build.sh
+++ b/build/cpuid/build.sh
@@ -23,7 +23,7 @@ PKG=system/cpuid
 SUMMARY="A simple CPUID decoder/dumper for x86/x86_64"
 DESC="$SUMMARY"
 
-BUILDARCH=64
+set_arch 64
 
 # No configure
 configure64() { :; }
@@ -36,7 +36,6 @@ download_source $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/diffutils/build.sh
+++ b/build/diffutils/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=diffutils
@@ -35,15 +34,8 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="--prefix=$PREFIX
-        --sysconfdir=/etc
-        --includedir=$PREFIX/include
-        --bindir=$PREFIX/bin
-        --sbindir=$PREFIX/sbin
-        --libdir=$PREFIX/lib
-        --libexecdir=$PREFIX/libexec
-	--program-prefix=g"
+set_arch 32
+CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -53,10 +45,9 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 strip_install
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/dma/build.sh
+++ b/build/dma/build.sh
@@ -12,10 +12,8 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
-#
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=dma
@@ -25,7 +23,7 @@ PKG=service/network/smtp/dma
 SUMMARY="The DragonFly Mail Agent"
 DESC="$SUMMARY"
 
-BUILDARCH=32
+set_arch 32
 
 # adding ASLR flags to compiler and linker since
 # dma:             gets ASLR if linker flag is set
@@ -83,7 +81,6 @@ move_manpage dma 8 1m
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/findutils/build.sh
+++ b/build/findutils/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=findutils
@@ -35,15 +34,8 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="--prefix=$PREFIX
-        --sysconfdir=/etc
-        --includedir=$PREFIX/include
-        --bindir=$PREFIX/bin
-        --sbindir=$PREFIX/sbin
-        --libdir=$PREFIX/lib
-        --libexecdir=$PREFIX/libexec
-	--program-prefix=g"
+set_arch 32
+CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -53,10 +45,9 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 strip_install
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gawk/build.sh
+++ b/build/gawk/build.sh
@@ -35,8 +35,7 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32+=" --bindir=/usr/bin"
+set_arch 32
 CPPFLAGS+=" -I/usr/include/gmp"
 CFLAGS+=" -D_XPG6"
 
@@ -48,7 +47,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/gcc44/build-libgmp.sh
+++ b/build/gcc44/build-libgmp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 GCCVER=4.4.4
@@ -62,3 +60,6 @@ build
 make_isa_stub
 make_package libgmp.mog depends.mog
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gcc44/build-libmpc.sh
+++ b/build/gcc44/build-libmpc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PATH=/usr/gnu/bin:/opt/gcc-4.4.4/bin:$PATH
@@ -47,7 +45,10 @@ BUILDARCH=32
 GCCVER=4.4.4
 PREFIX=/opt/gcc-${GCCVER}
 CC=gcc
-CONFIGURE_OPTS="--with-gmp=/opt/gcc-${GCCVER} --with-mpfr=/opt/gcc-${GCCVER}"
+CONFIGURE_OPTS="
+    --with-gmp=/opt/gcc-${GCCVER}
+    --with-mpfr=/opt/gcc-${GCCVER}
+"
 
 make_install32() {
     make_install
@@ -62,3 +63,6 @@ build
 make_isa_stub
 make_package libmpc.mog depends.mog
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gcc44/build-libmpfr.sh
+++ b/build/gcc44/build-libmpfr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=mpfr
@@ -61,3 +59,6 @@ build
 make_isa_stub
 make_package libmpfr.mog depends.mog
 clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gcc44/build.sh
+++ b/build/gcc44/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,11 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=gcc
@@ -71,11 +69,19 @@ export LD
 HSTRING=i386-pc-solaris2.11
 
 CONFIGURE_OPTS_32="--prefix=/opt/gcc-${VER}"
-CONFIGURE_OPTS="--host ${HSTRING} --build ${HSTRING} --target ${HSTRING} \
-    --with-boot-ldflags=-R/opt/gcc-${VER}/lib \
-    --with-gmp=/opt/gcc-${VER} --with-mpfr=/opt/gcc-${VER} --with-mpc=/opt/gcc-${VER} \
-    --enable-languages=c,c++,fortran --without-gnu-ld --with-ld=/bin/ld \
-    --with-as=/usr/bin/gas --with-gnu-as --with-build-time-tools=/usr/gnu/${HSTRING}/bin"
+CONFIGURE_OPTS="
+    --host ${HSTRING}
+    --build ${HSTRING}
+    --target ${HSTRING}
+    --with-boot-ldflags=-R/opt/gcc-${VER}/lib
+    --with-gmp=/opt/gcc-${VER}
+    --with-mpfr=/opt/gcc-${VER}
+    --with-mpc=/opt/gcc-${VER}
+    --enable-languages=c,c++,fortran
+    --without-gnu-ld --with-ld=/bin/ld
+    --with-as=/usr/bin/gas --with-gnu-as
+    --with-build-time-tools=/usr/gnu/${HSTRING}/bin
+"
 LDFLAGS32="-R/opt/gcc-${VER}/lib"
 export LD_OPTIONS="-zignore -zcombreloc -Bdirect -i"
 
@@ -97,4 +103,4 @@ make_package gcc.mog depends.mog
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gettext/build.sh
+++ b/build/gettext/build.sh
@@ -34,18 +34,19 @@ SUMMARY="gettext - GNU gettext utility"
 DESC="GNU gettext - GNU gettext utility"
 
 NO_PARALLEL_MAKE=1
-BUILDARCH=32
+set_arch 32
 
 DEPENDS_IPS="system/prerequisite/gnu developer/macro/gnu-m4"
 
-CONFIGURE_OPTS="--infodir=$PREFIX/share/info
-	--disable-java
-	--disable-libasprintf
-	--without-emacs
-	--disable-openmp
-	--disable-static
-	--disable-shared
-	--bindir=/usr/bin"
+CONFIGURE_OPTS="
+    --infodir=$PREFIX/share/info
+    --disable-java
+    --disable-libasprintf
+    --without-emacs
+    --disable-openmp
+    --disable-static
+    --disable-shared
+"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -55,7 +56,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/gnu-make/build.sh
+++ b/build/gnu-make/build.sh
@@ -35,8 +35,8 @@ DESC="GNU make - A utility used to build software"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=64
-CONFIGURE_OPTS="--bindir=$PREFIX/bin --program-prefix=g"
+set_arch 64
+CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_SED="
     /-srcdir/d
@@ -56,7 +56,6 @@ run_autoreconf -fi      # As Makefile.am has been modified
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/grep/build.sh
+++ b/build/grep/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,14 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=grep       # App name
@@ -36,17 +34,8 @@ DESC="$SUMMARY"
 
 DEPENDS_IPS="system/prerequisite/gnu library/pcre"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-    --program-prefix=g
-"
+set_arch 32
+CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -56,10 +45,9 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 strip_install
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/groff/build.sh
+++ b/build/groff/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,19 +18,17 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=groff       # App name
-VER=1.22.3       # App version
-PKG=text/groff    # Package name (without prefix)
+PROG=groff
+VER=1.22.3
+PKG=text/groff
 SUMMARY="$PROG - GNU Troff typesetting package"
 DESC="$SUMMARY"
 
@@ -39,16 +37,7 @@ NO_PARALLEL_MAKE=1
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-"
+set_arch 32
 CONFIGURE_OPTS="--without-x"
 
 init
@@ -56,10 +45,9 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 strip_install
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/gtar/build.sh
+++ b/build/gtar/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 . ../../lib/functions.sh
@@ -40,10 +40,12 @@ RUN_DEPENDS_IPS="
     compress/xz
 "
 
-BUILDARCH=32
+set_arch 32
 
-CONFIGURE_OPTS="--program-prefix=g --with-rmt=/usr/sbin/rmt"
-CONFIGURE_OPTS_32+=" --bindir=/usr/bin"
+CONFIGURE_OPTS="
+    --program-prefix=g
+    --with-rmt=/usr/sbin/rmt
+"
 
 init
 download_source $PROG $PROG $VER
@@ -51,7 +53,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/gzip/build.sh
+++ b/build/gzip/build.sh
@@ -33,12 +33,10 @@ PKG=compress/gzip
 SUMMARY="The GNU Zip (gzip) compression utility"
 DESC="$SUMMARY $VER"
 
+set_arch 32
 CONFIGURE_OPTS="
-    --bindir=/usr/bin
     --infodir=/usr/sfw/share/info
 "
-
-BUILDARCH=32
 
 # /usr/bin/uncompress is a hardlink to gunzip but is also delivered by
 # system/extended-system-utilities. We therefore need to drop the version
@@ -64,7 +62,6 @@ rename_in_docs
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/illumos-kvm/build.sh
+++ b/build/illumos-kvm/build.sh
@@ -52,7 +52,7 @@ BUILD_DEPENDS_IPS="
 BUILDARCH=64
 
 # Unset the prefix because we actually DO want things in kernel etc
-PREFIX="" 
+PREFIX=""
 
 download_source() {
     logmsg "Obtaining source files"

--- a/build/intltool/build.sh
+++ b/build/intltool/build.sh
@@ -12,10 +12,9 @@
 # }}}
 #
 # Copyright 2014 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=intltool
@@ -23,20 +22,17 @@ VER=0.51.0
 VERHUMAN=$VER
 PKG=text/intltool
 SUMMARY="Extracts translatable strings from specific source file types."
-DESC="$SUMMARY $VER"
+DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/library"
 
-BUILDARCH=32
-
-CONFIGURE_OPTS="--bindir=$PREFIX/bin"
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/iperf/build.sh
+++ b/build/iperf/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=iperf
@@ -51,10 +50,9 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_symlinks
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/ipmitool/build.sh
+++ b/build/ipmitool/build.sh
@@ -35,7 +35,7 @@ DESC="$SUMMARY"
 
 BUILD_DEPENDS_IPS="driver/ipmi developer/build/libtool"
 
-BUILDARCH=32
+set_arch 32
 CONFIGURE_OPTS_32+=" --bindir=/usr/sbin --sbindir=/usr/lib"
 CONFIGURE_OPTS+="
     --mandir=/usr/share/man
@@ -55,7 +55,6 @@ prep_build
 run_autoconf
 build
 install_smf network ipmievd.xml svc-ipmievd
-make_isa_stub
 make_package
 clean_up
 

--- a/build/isc-dhcp/build.sh
+++ b/build/isc-dhcp/build.sh
@@ -27,20 +27,16 @@ DESC="$SUMMARY $VER"
 
 DEPENDS_IPS="system/library"
 
-BUILDARCH=64
+set_arch 64
 
 # Doesn't work with parallel gmake
 NO_PARALLEL_MAKE=1
 
 # This exposes msghdr.msg_control & msghdr.msg_controllen
 CFLAGS+=" -D_XPG4_2 -fstack-check"
-
 LDFLAGS="-zaslr"
 
 CONFIGURE_OPTS="
-    --prefix=$PREFIX
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
     --enable-use-sockets
     --enable-ipv4-pktinfo
 "

--- a/build/iso-codes/build.sh
+++ b/build/iso-codes/build.sh
@@ -21,7 +21,7 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 . ../../lib/functions.sh
@@ -37,14 +37,13 @@ DESC="$SUMMARY"
 BUILD_DEPENDS_IPS="ooce/runtime/python-36"
 export PATH=/opt/ooce/bin:$PATH
 
-BUILDARCH=32
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/less/build.sh
+++ b/build/less/build.sh
@@ -32,23 +32,13 @@ PKG=text/less
 SUMMARY="$PROG - GNU paginator"
 DESC="$SUMMARY"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-"
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 strip_install
 make_package
 clean_up

--- a/build/m4/build.sh
+++ b/build/m4/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,14 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=m4
@@ -35,10 +33,9 @@ SUMMARY="GNU m4"
 DESC="GNU m4 - A macro processor (gm4)"
 
 PREFIX=/usr/gnu
+set_arch 32
 
-reset_configure_opts
-BUILDARCH=32
-CONFIGURE_OPTS+=" --infodir=/usr/share/info"
+CONFIGURE_OPTS="--infodir=/usr/share/info"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -48,9 +45,8 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/mdata-client/build.sh
+++ b/build/mdata-client/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,39 +18,33 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
-PROG=mdata-client      # App name
-VER=20170105            # App version
-VERHUMAN=$VER   # Human-readable version
-#PVER=          # Branch (set in config.sh, override here if needed)
-PKG=system/management/mdata-client           # Package name (e.g. library/foo)
-BUILDARCH=32
-SUMMARY="Cross-platform metadata client tools for use in SDC guests (both Zones and KVM)"      # One-liner, must be filled in
-DESC="Metadata retrieval and manipulation tools for use within guests of the SmartOS (and SDC) hypervisor. These guests may be either SmartOS Zones or KVM virtual machines."         # Longer description, must be filled in
+PROG=mdata-client
+VER=20170105
+VERHUMAN=$VER
+PKG=system/management/mdata-client
+SUMMARY="Cross-platform metadata client tools for use in SDC guests (both Zones and KVM)"
+DESC="Metadata retrieval and manipulation tools for use within guests of the SmartOS (and SDC) hypervisor. These guests may be either SmartOS Zones or KVM virtual machines."
 
-BUILD_DEPENDS_IPS=
-RUN_DEPENDS_IPS=
+set_arch 32
 
 # There is no configure step here
 CONFIGURE_CMD=true
-
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/nasm/build.sh
+++ b/build/nasm/build.sh
@@ -24,21 +24,15 @@ PKG=developer/nasm
 SUMMARY="The Netwide Assembler"
 DESC="$SUMMARY"
 
-BUILDARCH=32
-
-# Nasm uses INSTALLROOT instead of the more standard DESTDIR
-make_install() {
-    logmsg "--- make install"
-    logcmd $MAKE INSTALLROOT=${DESTDIR} install || \
-        logerr "--- Make install failed"
-}
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
+# Nasm uses INSTALLROOT instead of the more standard DESTDIR
+MAKE_INSTALL_ARGS="INSTALLROOT=$DESTDIR"
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/netperf/build.sh
+++ b/build/netperf/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=netperf
@@ -36,18 +35,17 @@ DESC="$SUMMARY $VER"
 
 DEPENDS_IPS="system/library"
 
-BUILDARCH=64
+set_arch 64
 
-CONFIGURE_OPTS="--bindir=$PREFIX/bin LDFLAGS=-lxnet"
+CONFIGURE_OPTS="LDFLAGS=-lxnet"
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/ntp/build.sh
+++ b/build/ntp/build.sh
@@ -33,10 +33,9 @@ PKG=service/network/ntp
 SUMMARY="Network Time Services"
 DESC="$SUMMARY"
 
-BUILDARCH=64
+set_arch 64
 
-CONFIGURE_OPTS_64="
-    --prefix=/usr
+CONFIGURE_OPTS_64+="
     --bindir=/usr/sbin
     --with-binsubdir=sbin
     --libexecdir=/usr/lib/inet
@@ -67,7 +66,6 @@ prep_build
 build
 overlay_root
 install_smf network ntp.xml ntp
-make_isa_stub
 #NOTE: Uncomment these IFF we go back to ntp-dev versions or p-releases again.
 #VER=${VER//dev-/}
 VER=${VER//p/.}

--- a/build/openssh/build.sh
+++ b/build/openssh/build.sh
@@ -21,10 +21,9 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=openssh
@@ -34,18 +33,11 @@ PKG=network/openssh
 SUMMARY="OpenSSH Client and utilities"
 DESC="OpenSSH Secure Shell protocol Client and associated Utilities"
 
-BUILDARCH=64
-# Since we're only building 64-bit, don't bother with isaexec subdirs
-CONFIGURE_OPTS_64="
-    --prefix=$PREFIX
+set_arch 64
+CONFIGURE_OPTS_64+="
     --sysconfdir=/etc/ssh
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
 "
-# Feature choices
+
 CONFIGURE_OPTS="
     --with-audit=solaris
     --with-kerberos5=$PREFIX

--- a/build/patch/build.sh
+++ b/build/patch/build.sh
@@ -32,17 +32,8 @@ PKG=text/gnu-patch
 SUMMARY="The GNU Patch utility"
 DESC="$SUMMARY"
 
-BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-    --program-prefix=g
-"
+set_arch 32
+CONFIGURE_OPTS="--program-prefix=g"
 
 init
 download_source $PROG $PROG $VER
@@ -50,7 +41,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 strip_install
 make_package
 clean_up

--- a/build/pci.ids/build.sh
+++ b/build/pci.ids/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=pci.ids
@@ -52,7 +51,7 @@ make_install() {
     logmsg "--- make install"
     logcmd mkdir -p $DESTDIR$PREFIX/share || \
         logerr "------ Failed to create destination directory."
-    logcmd cp -p ${PROG}.gz $DESTDIR$PREFIX/share/ ||
+    logcmd cp -p ${PROG}.gz $DESTDIR$PREFIX/share/ || \
         logerr "------ Failed to copy file into place."
 }
 build32() {
@@ -70,4 +69,4 @@ clean_up
 logcmd rm -f $SRCDIR/$PROG
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/pciutils/build.sh
+++ b/build/pciutils/build.sh
@@ -21,9 +21,9 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=pciutils
@@ -35,8 +35,7 @@ DESC="$SUMMARY"
 
 DEPENDS_IPS="system/pciutils/pci.ids@2.2"
 
-BUILDARCH=32
-NO_PARALLEL_MAKE=1
+set_arch 32
 
 export PATH=/usr/gnu/bin:$PATH
 
@@ -45,19 +44,16 @@ configure32() {
 }
 
 make_prog() {
-    [[ -n $NO_PARALLEL_MAKE ]] && MAKE_JOBS=""
-    if [[ -n $LIBTOOL_NOSTDLIB ]]; then
-        libtool_nostdlib $LIBTOOL_NOSTDLIB $LIBTOOL_NOSTDLIB_EXTRAS
-    fi
     logmsg "--- make"
-    logcmd $MAKE $MAKE_JOBS PREFIX=$PREFIX OPT="-O2 -DBYTE_ORDER=1234 -DLITTLE_ENDIAN=1234" || \
-        logerr "--- Make failed"
+    logcmd $MAKE PREFIX=$PREFIX \
+        OPT="-O2 -DBYTE_ORDER=1234 -DLITTLE_ENDIAN=1234" \
+        || logerr "--- Make failed"
 }
 
 make_install() {
     logmsg "--- make install"
-    logcmd $MAKE DESTDIR=${DESTDIR} PREFIX=$PREFIX install || \
-        logerr "--- Make install failed"
+    logcmd $MAKE DESTDIR=${DESTDIR} PREFIX=$PREFIX install \
+        || logerr "--- Make install failed"
 }
 
 init
@@ -65,7 +61,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/pv/build.sh
+++ b/build/pv/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2015 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=pv
@@ -34,18 +33,20 @@ PKG=shell/pipe-viewer
 SUMMARY="Pipe Viewer"
 DESC="pv - a terminal-based tool for monitoring the progress of data through a pipeline."
 
-BUILDARCH=64
-DO_GZIP=true
-export DO_GZIP
-CONFIGURE_OPTS_64="$CONFIGURE_OPTS_64 --bindir=/usr/bin --mandir=/usr/share/man --disable-nls"
+set_arch 64
+export DO_GZIP=true
+CONFIGURE_OPTS="
+    --mandir=/usr/share/man
+    --disable-nls
+"
+
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/rsync/build.sh
+++ b/build/rsync/build.sh
@@ -33,10 +33,10 @@ PKG=network/rsync
 SUMMARY="rsync - faster, flexible replacement for rcp"
 DESC="$SUMMARY"
 
+set_arch 64
+CONFIGURE_OPTS="--with-included-popt"
+# Needed so that man pages are correctly installed every time
 REMOVE_PREVIOUS=1
-BUILDARCH=32
-
-CONFIGURE_OPTS_32+=" --bindir=/usr/bin --with-included-popt"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]|^-|[0-9] (passed|failed|skipped|missing)'
 
@@ -46,7 +46,6 @@ patch_source
 prep_build
 build
 run_testsuite
-make_isa_stub
 make_package
 clean_up
 

--- a/build/screen/build.sh
+++ b/build/screen/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,14 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=screen
@@ -34,9 +32,8 @@ PKG=terminal/screen
 SUMMARY="GNU Screen terminal multiplexer"
 DESC="$SUMMARY"
 
-BUILDARCH=32
-CONFIGURE_OPTS+="
-	--bindir=/usr/bin
+set_arch 32
+CONFIGURE_OPTS="
 	--with-sys-screenrc=/etc/screenrc
 	--enable-colors256
 	LDFLAGS=-lxnet
@@ -77,4 +74,4 @@ make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/sed/build.sh
+++ b/build/sed/build.sh
@@ -34,17 +34,9 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
+set_arch 32
 BUILDARCH=32
-CONFIGURE_OPTS_32="
-    --prefix=$PREFIX
-    --sysconfdir=/etc
-    --includedir=$PREFIX/include
-    --bindir=$PREFIX/bin
-    --sbindir=$PREFIX/sbin
-    --libdir=$PREFIX/lib
-    --libexecdir=$PREFIX/libexec
-    --program-prefix=g
-"
+CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 
@@ -54,7 +46,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 strip_install
 make_package
 clean_up

--- a/build/tcsh/build.sh
+++ b/build/tcsh/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=tcsh
@@ -32,22 +31,19 @@ VER=6.20.00
 VERHUMAN=$VER
 PKG=shell/tcsh
 SUMMARY="Tenex C-shell (tcsh)"
-DESC="$SUMMARY $VER"
+DESC="$SUMMARY"
 
 DEPENDS_IPS="system/library"
 
-BUILDARCH=32
-
-CONFIGURE_OPTS="--bindir=$PREFIX/bin"
+set_arch 32
 
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/tmux/build.sh
+++ b/build/tmux/build.sh
@@ -39,8 +39,7 @@ XFORM_ARGS+=" -DLIBEVENT=$LIBEVENT_VER"
 # Call init early to set up TMPDIR to use in CPPFLAGS/LDFLAGS.
 init
 
-BUILDARCH=32
-CONFIGURE_OPTS_32+=" --bindir=/usr/bin"
+set_arch 32
 CPPFLAGS="\
     -I$TMPDIR/$PROG-$VER/$LDIR/include/event2 \
     -I$TMPDIR/$PROG-$VER/$LDIR/include -I/usr/include/ncurses \
@@ -78,7 +77,6 @@ build_libevent
 
 patch_source
 build
-make_isa_stub
 strip_install
 make_package
 clean_up

--- a/build/unzip/build.sh
+++ b/build/unzip/build.sh
@@ -34,10 +34,10 @@ SUMMARY="The Info-Zip (unzip) compression utility"
 DESC="$SUMMARY"
 
 BUILDDIR=$PROG${VER//./}
-BUILDARCH=32
+set_arch 32
 
 HARDLINK_TARGETS="
-    usr/bin/i386/unzip
+    usr/bin/unzip
 "
 
 # Copied from upstream's pkg makefile
@@ -47,25 +47,16 @@ configure32() {
     export ISAPART
 }
 
-make_prog() {
-    [ -n "$NO_PARALLEL_MAKE" ] && MAKE_JOBS=
-    logmsg "--- make"
-    logcmd $MAKE $MAKE_JOBS -f unix/Makefile generic_gcc || \
-        logerr "--- Make failed"
-}
-
-make_install() {
-    logmsg "--- make install"
-    logcmd $MAKE -f unix/Makefile prefix=$DESTDIR$PREFIX install || \
-        logerr "--- Make install failed"
-}
+BASE_MAKE_ARGS="-f unix/Makefile"
+MAKE_ARGS="$BASE_MAKE_ARGS generic_gcc"
+MAKE_INSTALL_ARGS="$BASE_MAKE_ARGS install"
 
 init
 download_source $PROG $PROG${VER//./}
 patch_source
 prep_build
+MAKE_INSTALL_ARGS+=" prefix=$DESTDIR$PREFIX"
 build
-make_isa_stub
 make_package
 clean_up
 

--- a/build/unzip/patches/unix_Makefile.patch
+++ b/build/unzip/patches/unix_Makefile.patch
@@ -1,15 +1,14 @@
-diff -pruN '--exclude=*.orig' unzip60~/unix/Makefile unzip60/unix/Makefile
+diff -wpruN '--exclude=*.orig' unzip60~/unix/Makefile unzip60/unix/Makefile
 --- unzip60~/unix/Makefile	2009-01-18 22:41:18.000000000 +0000
-+++ unzip60/unix/Makefile	2018-03-29 23:42:33.883704643 +0000
++++ unzip60/unix/Makefile	2018-06-14 21:57:26.827700631 +0000
 @@ -121,9 +121,9 @@ INSTALL_PROGRAM = $(INSTALL)
  INSTALL_D = mkdir -p
  # on some systems, manext=l and MANDIR=/usr/man/man$(manext) may be appropriate
  manext = 1
 -prefix = /usr/local
--BINDIR = $(prefix)/bin#			where to install executables
--MANDIR = $(prefix)/man/man$(manext)#	where to install man pages
 +prefix = $(PREFIX)
-+BINDIR = $(prefix)/bin/$(ISAPART)#			where to install executables
+ BINDIR = $(prefix)/bin#			where to install executables
+-MANDIR = $(prefix)/man/man$(manext)#	where to install man pages
 +MANDIR = $(prefix)/share/man/man$(manext)#	where to install man pages
  INSTALLEDBIN = $(BINDIR)/funzip$E $(BINDIR)/unzip$E $(BINDIR)/unzipsfx$E \
  	$(BINDIR)/zipgrep$E $(BINDIR)/zipinfo$E

--- a/build/vim/build.sh
+++ b/build/vim/build.sh
@@ -34,7 +34,8 @@ DESC="$SUMMARY"
 
 SVER=${VER//./}
 BUILDDIR=$PROG$SVER
-BUILDARCH=64
+
+set_arch 64
 
 XFORM_ARGS+=" -D SVER=$SVER"
 
@@ -42,9 +43,7 @@ XFORM_ARGS+=" -D SVER=$SVER"
 # a GNU-ism we are strict about.  Either way, use GNU msgfmt for now.
 export MSGFMT=/usr/gnu/bin/msgfmt
 
-# We're only shipping 64-bit so forgo isaexec
 CONFIGURE_OPTS="
-    --bindir=$PREFIX/bin
     --with-features=huge
     --without-x
     --disable-gui

--- a/build/wget/build.sh
+++ b/build/wget/build.sh
@@ -34,9 +34,9 @@ SUMMARY="$PROG - a utility to retrieve files from the World Wide Web"
 DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="library/libidn web/ca-bundle"
-BUILD_DEPENDS_IPS="developer/lexer/flex $RUN_DEPENDS_IPS"
+BUILD_DEPENDS_IPS+="developer/lexer/flex"
 
-BUILDARCH=32
+set_arch 32
 CONFIGURE_OPTS="
     --with-ssl=openssl
     --mandir=$PREFIX/share/man
@@ -51,7 +51,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_isa_stub
 make_package
 clean_up
 

--- a/build/zip/build.sh
+++ b/build/zip/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
 # Common Development and Distribution License, Version 1.0 only
@@ -18,13 +18,12 @@
 # fields enclosed by brackets "[]" replaced with your own identifying
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
-# CDDL HEADER END
-#
+# CDDL HEADER END }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
-# Load support functions
 . ../../lib/functions.sh
 
 PROG=zip
@@ -35,36 +34,25 @@ SUMMARY="The Info-Zip (zip) compression utility"
 DESC="$SUMMARY"
 
 BUILDDIR=$PROG${VER//./}
-BUILDARCH=32
+set_arch 32
 
-CPP="gcc -E"
-export CPP
+export CPP="gcc -E"
 
 configure32() {
     export ISAPART DESTDIR PREFIX
 }
 
-make_prog() {
-    [[ -n $NO_PARALLEL_MAKE ]] && MAKE_JOBS=""
-    logmsg "--- make"
-    logcmd $MAKE $MAKE_JOBS -f unix/Makefile generic_gcc || \
-        logerr "--- Make failed"
-}
-
-make_install() {
-    logmsg "--- make install"
-    logcmd $MAKE -f unix/Makefile install || \
-        logerr "--- Make install failed"
-}
+BASE_MAKE_ARGS="-f unix/Makefile"
+MAKE_ARGS="$BASE_MAKE_ARGS generic_gcc"
+MAKE_INSTALL_ARGS="$BASE_MAKE_ARGS install"
 
 init
 download_source $PROG $PROG${VER//./}
 patch_source
 prep_build
 build
-make_isa_stub
 make_package
 clean_up
 
 # Vim hints
-# vim:ts=4:sw=4:et:
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/zip/patches/unix_Makefile.patch
+++ b/build/zip/patches/unix_Makefile.patch
@@ -1,13 +1,13 @@
---- zip30/unix/Makefile.orig	Wed May  7 06:33:56 2008
-+++ zip30/unix/Makefile	Mon Feb 27 21:34:26 2012
-@@ -38,10 +38,10 @@
+diff -wpruN '--exclude=*.orig' zip30~/unix/Makefile zip30/unix/Makefile
+--- zip30~/unix/Makefile	2008-05-07 06:33:56.000000000 +0000
++++ zip30/unix/Makefile	2018-06-14 21:23:59.084923759 +0000
+@@ -38,10 +38,10 @@ BINFLAGS = 755
  MANFLAGS = 644
  
  # target directories - where to install executables and man pages to
 -prefix = /usr/local
--BINDIR = $(prefix)/bin
 +prefix = $(DESTDIR)$(PREFIX)
-+BINDIR = $(prefix)/bin/$(ISAPART)
+ BINDIR = $(prefix)/bin
  MANEXT=1
 -MANDIR = $(prefix)/man/man$(MANEXT)
 +MANDIR = $(prefix)/share/man/man$(MANEXT)

--- a/build/zip/patches/unix_configure.patch
+++ b/build/zip/patches/unix_configure.patch
@@ -1,6 +1,7 @@
---- zip30/unix/configure.orig	Wed Mar 28 22:52:04 2012
-+++ zip30/unix/configure	Wed Mar 28 22:52:22 2012
-@@ -220,13 +220,6 @@
+diff -wpruN '--exclude=*.orig' zip30~/unix/configure zip30/unix/configure
+--- zip30~/unix/configure	2008-06-20 03:32:20.000000000 +0000
++++ zip30/unix/configure	2018-06-14 21:23:59.144368022 +0000
+@@ -220,13 +220,6 @@ fi
  echo Check for the C preprocessor
  # on SVR4, cc -E does not produce correct assembler files. Need /lib/cpp.
  CPP="${CC} -E"

--- a/build/zsh/build.sh
+++ b/build/zsh/build.sh
@@ -33,10 +33,10 @@ PKG=shell/zsh
 SUMMARY="Z shell"
 DESC="Z shell"
 
-BUILDARCH=32
+set_arch 32
+
 CPPFLAGS32+=" -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 CONFIGURE_OPTS_32+="
-    --bindir=/usr/bin
 	--enable-cap
 	--enable-dynamic
 	--enable-etcdir=/etc
@@ -50,13 +50,17 @@ CONFIGURE_OPTS_32+="
 	--disable-gdbm
 "
 
+HARDLINK_TARGETS=usr/bin/zsh-$VER
+
 install_zshrc() {
-  mkdir -p $DESTDIR/etc
-  cp $SRCDIR/files/system-zshrc $DESTDIR/etc/zshrc
-  chmod 644 $DESTDIR/etc/zshrc
+    mkdir -p $DESTDIR/etc
+    cp $SRCDIR/files/system-zshrc $DESTDIR/etc/zshrc
+    chmod 644 $DESTDIR/etc/zshrc
 }
+
 install_license() {
-  iconv -f 8859-1 -t utf-8 $TMPDIR/$BUILDDIR/LICENCE > $TMPDIR/$BUILDDIR/LICENSE
+    iconv -f 8859-1 -t utf-8 \
+        $TMPDIR/$BUILDDIR/LICENCE > $TMPDIR/$BUILDDIR/LICENSE
 }
 
 init
@@ -66,7 +70,6 @@ prep_build
 build
 install_zshrc
 install_license
-make_isa_stub
 sed -i 's/diff -a/g&/' $TMPDIR/$BUILDDIR/Test/ztst.zsh
 run_testsuite
 make_package

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -228,43 +228,16 @@ CXXFLAGS64="-m64"
 # Default configure command - almost always sufficient
 CONFIGURE_CMD="./configure"
 
-# Default configure options - replace/add to as needed
-# This is a function so it can be called again if you change $PREFIX
-# This is far from ideal, but works
-reset_configure_opts() {
-    # If it's the global default (/usr), we want sysconfdir to be /etc
-    # otherwise put it under PREFIX
-    [ $PREFIX = "/usr" ] && SYSCONFDIR=/etc || SYSCONFDIR=$PREFIX/etc
-
-    CONFIGURE_OPTS_32="
-        --prefix=$PREFIX
-        --sysconfdir=$SYSCONFDIR
-        --includedir=$PREFIX/include
-        --bindir=$PREFIX/bin/$ISAPART
-        --sbindir=$PREFIX/sbin/$ISAPART
-        --libdir=$PREFIX/lib
-        --libexecdir=$PREFIX/libexec
-    "
-
-    CONFIGURE_OPTS_64="
-        --prefix=$PREFIX
-        --sysconfdir=$SYSCONFDIR
-        --includedir=$PREFIX/include
-        --bindir=$PREFIX/bin/$ISAPART64
-        --sbindir=$PREFIX/sbin/$ISAPART64
-        --libdir=$PREFIX/lib/$ISAPART64
-        --libexecdir=$PREFIX/libexec/$ISAPART64
-    "
-}
-reset_configure_opts
-
 # Configure options to apply to both builds - this is the one you usually want
 # to change for things like --enable-feature
 CONFIGURE_OPTS=
+CONFIGURE_OPTS_32=
+CONFIGURE_OPTS_64=
 # Configure options that can contain embedded white-space within escaped quotes
 CONFIGURE_OPTS_WS=
 CONFIGURE_OPTS_WS_32=
 CONFIGURE_OPTS_WS_64=
+FORGO_ISAEXEC=
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -346,6 +346,58 @@ set_gccver() {
 
 set_gccver $DEFAULT_GCC_VER -q
 
+#############################################################################
+# Default configure options.
+#############################################################################
+
+reset_configure_opts() {
+    # If it's the global default (/usr), we want sysconfdir to be /etc
+    # otherwise put it under PREFIX
+    [ $PREFIX = "/usr" ] && SYSCONFDIR=/etc || SYSCONFDIR=$PREFIX/etc
+
+    CONFIGURE_OPTS_32="
+        --prefix=$PREFIX
+        --sysconfdir=$SYSCONFDIR
+        --includedir=$PREFIX/include
+    "
+    CONFIGURE_OPTS_64="$CONFIGURE_OPTS_32"
+
+    if [ -n "$FORGO_ISAEXEC" ]; then
+        CONFIGURE_OPTS_32+="
+            --bindir=$PREFIX/bin
+            --sbindir=$PREFIX/sbin
+            --libdir=$PREFIX/lib
+            --libexecdir=$PREFIX/libexec
+        "
+        CONFIGURE_OPTS_64="$CONFIGURE_OPTS_32"
+    else
+        CONFIGURE_OPTS_32+="
+            --bindir=$PREFIX/bin/$ISAPART
+            --sbindir=$PREFIX/sbin/$ISAPART
+            --libdir=$PREFIX/lib
+            --libexecdir=$PREFIX/libexec
+        "
+        CONFIGURE_OPTS_64+="
+            --bindir=$PREFIX/bin/$ISAPART64
+            --sbindir=$PREFIX/sbin/$ISAPART64
+            --libdir=$PREFIX/lib/$ISAPART64
+            --libexecdir=$PREFIX/libexec/$ISAPART64
+        "
+    fi
+}
+reset_configure_opts
+
+forgo_isaexec() {
+    FORGO_ISAEXEC=1
+    reset_configure_opts
+}
+
+set_arch() {
+    [[ $1 =~ ^(32|64)$ ]] || logerr "Bad argument to set_arch"
+    BUILDARCH=$1
+    forgo_isaexec
+}
+
 BasicRequirements() {
     local needed=""
     [ -x $GCCPATH/bin/gcc ] || needed+=" developer/gcc$GCCVER"
@@ -1174,6 +1226,8 @@ install_smf() {
 #############################################################################
 
 make_isa_stub() {
+    [ -n "$FORGO_ISAEXEC" ] \
+        && logerr "-- Calling make_isa_stub after forgo_isaexec"
     logmsg "Making isaexec stub binaries"
     [ -z "$ISAEXEC_DIRS" ] && ISAEXEC_DIRS="bin sbin"
     for DIR in $ISAEXEC_DIRS; do


### PR DESCRIPTION
then update the single-architecture packages to use this, simplifying their build scripts.

For some of the packages which used to provide 32-bit only binaries but linked through isaexec, the isaexec link has been removed. The release notes will be updated to cover this in case anyone has dependencies on the old /usr/bin/i386/ paths (which is unlikely).

In the future, this change will also make it easier to start migrating packages to 64-bit.
rsync has been moved to 64-bit as part of this change set, as we want to move that way and it may help with #820 