### PR TITLE
Split off gcc runtime libraries into per-version directories

### DIFF
--- a/build/gcc-runtime/runtime++.mog
+++ b/build/gcc-runtime/runtime++.mog
@@ -1,20 +1,18 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 license files/COPYING.LIB license=LGPLv2.1
 license files/COPYING.RUNTIME license="GCC runtime license"
 license files/COPYING3.LIB license=LGPLv3
-
-# libssp
-
-link path=usr/lib/libssp.so.0 target=libssp.so.0.0.0
-link path=usr/lib/libssp.so target=libssp.so.0.0.0
-
-link path=usr/lib/amd64/libssp.so.0 target=libssp.so.0.0.0
-link path=usr/lib/amd64/libssp.so target=libssp.so.0.0.0
-
-# libstdc++
-
-link path=usr/lib/libstdc++.so.6 target=libstdc++.so.$(STDCVER)
-link path=usr/lib/libstdc++.so target=libstdc++.so.$(STDCVER)
-
-link path=usr/lib/amd64/libstdc++.so.6 target=libstdc++.so.$(STDCVER)
-link path=usr/lib/amd64/libstdc++.so target=libstdc++.so.$(STDCVER)
 

--- a/build/gcc-runtime/runtime.mog
+++ b/build/gcc-runtime/runtime.mog
@@ -1,7 +1,18 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 license files/COPYING.LIB license=LGPLv2.1
 license files/COPYING.RUNTIME license="GCC runtime license"
 license files/COPYING3.LIB license=LGPLv3
-
-link path=usr/lib/libgcc_s.so target=libgcc_s.so.1
-link path=usr/lib/amd64/libgcc_s.so target=libgcc_s.so.1
 

--- a/build/gcc-runtime/runtimef.mog
+++ b/build/gcc-runtime/runtimef.mog
@@ -1,17 +1,18 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 license files/COPYING.LIB license=LGPLv2.1
 license files/COPYING.RUNTIME license="GCC runtime license"
 license files/COPYING3.LIB license=LGPLv3
-
-link path=usr/lib/$(LIB).3 target=$(LIB).3.0.0
-link path=usr/lib/$(LIB).4 target=$(LIB).$(LIBVER)
-link path=usr/lib/$(LIB) target=$(LIB).$(LIBVER)
-
-link path=usr/lib/amd64/$(LIB).3 target=$(LIB).3.0.0
-link path=usr/lib/amd64/$(LIB).4 target=$(LIB).$(LIBVER)
-link path=usr/lib/amd64/$(LIB) target=$(LIB).$(LIBVER)
-
-link path=usr/lib/libquadmath.so.0 target=libquadmath.so.0.0.0
-link path=usr/lib/libquadmath.so target=libquadmath.so.0.0.0
-link path=usr/lib/amd64/libquadmath.so.0 target=libquadmath.so.0.0.0
-link path=usr/lib/amd64/libquadmath.so target=libquadmath.so.0.0.0
 

--- a/build/gcc-runtime/runtimef_post.mog
+++ b/build/gcc-runtime/runtimef_post.mog
@@ -1,3 +1,16 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 <transform depend type=require-any -> drop>
 

--- a/build/gcc5/patches/ld-flags.patch
+++ b/build/gcc5/patches/ld-flags.patch
@@ -1,0 +1,24 @@
+--- ./gcc/config/sol2.h.orig	2016-05-08 21:13:10.810423614 +0200
++++ ./gcc/config/sol2.h	2016-05-08 21:16:55.681535743 +0200
+@@ -195,8 +195,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
+-	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/5/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/5/lib -L %R/usr/gcc/5/lib} \
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/5/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/5/lib -L %R/usr/gcc/5/lib}}}"
+ 
+ #undef LINK_ARCH32_SPEC
+ #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
+@@ -208,8 +208,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
+-	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/5/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/5/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/5/lib/" ARCH64_SUBDIR "}	\
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/5/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/5/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/5/lib/" ARCH64_SUBDIR "}}}"
+ 
+ #undef LINK_ARCH64_SPEC
+ #ifndef USE_GLD

--- a/build/gcc5/patches/series
+++ b/build/gcc5/patches/series
@@ -1,3 +1,4 @@
 ld_eh_frame_hdr.patch
 patch-libgo_runtime_proc.c
 no-lrt.patch
+ld-flags.patch

--- a/build/gcc7/patches/1000-ld-flags.patch
+++ b/build/gcc7/patches/1000-ld-flags.patch
@@ -1,0 +1,24 @@
+--- ./gcc/config/sol2.h.orig	2016-05-08 21:13:10.810423614 +0200
++++ ./gcc/config/sol2.h	2016-05-08 21:16:55.681535743 +0200
+@@ -195,8 +195,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
+-	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/7/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/7/lib -L %R/usr/gcc/7/lib} \
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/7/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/7/lib -L %R/usr/gcc/7/lib}}}"
+ 
+ #undef LINK_ARCH32_SPEC
+ #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
+@@ -208,8 +208,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
+-	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/7/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/7/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/7/lib/" ARCH64_SUBDIR "}	\
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/7/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/7/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/7/lib/" ARCH64_SUBDIR "}}}"
+ 
+ #undef LINK_ARCH64_SPEC
+ #ifndef USE_GLD

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -11,3 +11,4 @@ no-lrt.patch
 0011-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
 0012-16-update-cmn_err-format-specifier.patch
 0013-19-cmn_err-b-conversion-should-accept-0-flag.patch
+1000-ld-flags.patch

--- a/build/gcc8/patches/1000-ld-flags.patch
+++ b/build/gcc8/patches/1000-ld-flags.patch
@@ -1,0 +1,24 @@
+--- ./gcc/config/sol2.h.orig	2016-05-08 21:13:10.810423614 +0200
++++ ./gcc/config/sol2.h	2016-05-08 21:16:55.681535743 +0200
+@@ -195,8 +195,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
+-	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/8/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/8/lib -L %R/usr/gcc/8/lib} \
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/8/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/8/lib -L %R/usr/gcc/8/lib}}}"
+ 
+ #undef LINK_ARCH32_SPEC
+ #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
+@@ -208,8 +208,8 @@
+   "%{G:-G} \
+    %{YP,*} \
+    %{R*} \
+-   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
+-	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/8/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/8/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/8/lib/" ARCH64_SUBDIR "}	\
++	   %{!p:%{!pg:-Y P,%R/usr/gcc/8/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/8/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/8/lib/" ARCH64_SUBDIR "}}}"
+ 
+ #undef LINK_ARCH64_SPEC
+ #ifndef USE_GLD

--- a/build/gcc8/patches/series
+++ b/build/gcc8/patches/series
@@ -13,3 +13,4 @@ no-lrt.patch
 libstdc++-aligned_alloc.patch
 1005-use-compare-debug.patch
 0002-compare_tests-Use-nawk-on-OmniOS.patch
+1000-ld-flags.patch

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1705,6 +1705,17 @@ strip_install() {
 }
 
 #############################################################################
+# Check for dangling symlinks
+#############################################################################
+
+check_symlinks() {
+    logmsg "Checking for dangling symlinks"
+    for link in `find "$1" -type l`; do
+        readlink -e $link >/dev/null || logerr "Dangling symlink $link"
+    done
+}
+
+#############################################################################
 # Clean up and print Done message
 #############################################################################
 


### PR DESCRIPTION
I've placed the version-specific libraries in /usr/gcc/<ver> to mirror what OpenIndiana already do, and what Joyent are in the process of doing for SmartOS (https://smartos.org/bugview/OS-7042) - at least in terms of the extra runpath that gcc adds to binaries.
I've also added a generic dangling symlink checker as I created a few danglers during development.. this would also have spotted the one that was in the sccs package for a long time - I'll look at enabling this by default as part of the pre-packaging checks in another PR.

Please review the resulting symlink structure (below) before approving as I had to make some choices along the way. The main system GCC version is still 7 and so this is the version to which the unversioned links in /usr/lib point. This will fix the compatibility problems caused by the new libstdc++.6 in gcc 8.

## /usr/gcc/X

Each major gcc version has a runtime directory under `/usr/gcc/X/lib/` which looks like this:

```
64 -> amd64
amd64/libgcc_s.so -> libgcc_s.so.1
amd64/libgcc_s.so.1
amd64/libgfortran.so -> libgfortran.so.4
amd64/libgfortran.so.4 -> libgfortran.so.4.0.0
amd64/libgfortran.so.4.0.0
amd64/libquadmath.so -> libquadmath.so.0
amd64/libquadmath.so.0 -> libquadmath.so.0.0.0
amd64/libquadmath.so.0.0.0
amd64/libssp.so -> libssp.so.0
amd64/libssp.so.0 -> libssp.so.0.0.0
amd64/libssp.so.0.0.0
amd64/libstdc++.so -> libstdc++.so.6
amd64/libstdc++.so.6 -> libstdc++.so.6.0.24
amd64/libstdc++.so.6.0.24
libgcc_s.so -> libgcc_s.so.1
libgcc_s.so.1
libgfortran.so -> libgfortran.so.4
libgfortran.so.4 -> libgfortran.so.4.0.0
libgfortran.so.4.0.0
libquadmath.so -> libquadmath.so.0
libquadmath.so.0 -> libquadmath.so.0.0.0
libquadmath.so.0.0.0
libssp.so -> libssp.so.0
libssp.so.0 -> libssp.so.0.0.0
libssp.so.0.0.0
libstdc++.so -> libstdc++.so.6
libstdc++.so.6 -> libstdc++.so.6.0.24
libstdc++.so.6.0.24
```

## gcc-runtime

These are the links delivered to `/usr/lib` by the gcc-runtime package:

```
amd64/libgcc_s.so -> libgcc_s.so.1
amd64/libgcc_s.so.1 -> ../../gcc/7/lib/amd64/libgcc_s.so.1
libgcc_s.so -> libgcc_s.so.1
libgcc_s.so.1 -> ../gcc/7/lib/libgcc_s.so.1
```
## g++-runtime

```
amd64/libssp.so -> libssp.so.0
amd64/libssp.so.0 -> ../../gcc/7/lib/amd64/libssp.so.0
amd64/libssp.so.0.0.0 -> ../../gcc/7/lib/amd64/libssp.so.0.0.0
amd64/libstdc++.so -> libstdc++.so.6
amd64/libstdc++.so.6 -> ../../gcc/7/lib/amd64/libstdc++.so.6
amd64/libstdc++.so.6.0.13 -> ../../gcc/legacy/lib/amd64/libstdc++.so.6.0.13
amd64/libstdc++.so.6.0.16 -> ../../gcc/legacy/lib/amd64/libstdc++.so.6.0.16
amd64/libstdc++.so.6.0.17 -> ../../gcc/legacy/lib/amd64/libstdc++.so.6.0.17
amd64/libstdc++.so.6.0.18 -> ../../gcc/legacy/lib/amd64/libstdc++.so.6.0.18
amd64/libstdc++.so.6.0.21 -> ../../gcc/5/lib/amd64/libstdc++.so.6.0.21
amd64/libstdc++.so.6.0.22 -> ../../gcc/6/lib/amd64/libstdc++.so.6.0.22
amd64/libstdc++.so.6.0.24 -> ../../gcc/7/lib/amd64/libstdc++.so.6.0.24
amd64/libstdc++.so.6.0.25 -> ../../gcc/8/lib/amd64/libstdc++.so.6.0.25
libssp.so -> libssp.so.0
libssp.so.0 -> ../gcc/7/lib/libssp.so.0
libssp.so.0.0.0 -> ../gcc/7/lib/libssp.so.0.0.0
libstdc++.so -> libstdc++.so.6
libstdc++.so.6 -> ../gcc/7/lib/libstdc++.so.6
libstdc++.so.6.0.13 -> ../gcc/legacy/lib/libstdc++.so.6.0.13
libstdc++.so.6.0.16 -> ../gcc/legacy/lib/libstdc++.so.6.0.16
libstdc++.so.6.0.17 -> ../gcc/legacy/lib/libstdc++.so.6.0.17
libstdc++.so.6.0.18 -> ../gcc/legacy/lib/libstdc++.so.6.0.18
libstdc++.so.6.0.21 -> ../gcc/5/lib/libstdc++.so.6.0.21
libstdc++.so.6.0.22 -> ../gcc/6/lib/libstdc++.so.6.0.22
libstdc++.so.6.0.24 -> ../gcc/7/lib/libstdc++.so.6.0.24
libstdc++.so.6.0.25 -> ../gcc/8/lib/libstdc++.so.6.0.25
```

## gfortran-runtime

```
amd64/libgfortran.so -> ../../gcc/7/lib/amd64/libgfortran.so
amd64/libgfortran.so.3 -> libgfortran.so.3.0.0
amd64/libgfortran.so.3.0.0 -> ../../gcc/6/lib/amd64/libgfortran.so.3.0.0
amd64/libgfortran.so.4 -> libgfortran.so.4.0.0
amd64/libgfortran.so.4.0.0 -> ../../gcc/7/lib/amd64/libgfortran.so.4.0.0
amd64/libgfortran.so.5 -> libgfortran.so.5.0.0
amd64/libgfortran.so.5.0.0 -> ../../gcc/8/lib/amd64/libgfortran.so.5.0.0
amd64/libquadmath.so -> ../../gcc/7/lib/amd64/libquadmath.so
amd64/libquadmath.so.0 -> libquadmath.so.0.0.0
amd64/libquadmath.so.0.0.0 -> ../../gcc/7/lib/amd64/libquadmath.so.0.0.0
libgfortran.so -> ../gcc/7/lib/libgfortran.so
libgfortran.so.3 -> libgfortran.so.3.0.0
libgfortran.so.3.0.0 -> ../gcc/6/lib/libgfortran.so.3.0.0
libgfortran.so.4 -> libgfortran.so.4.0.0
libgfortran.so.4.0.0 -> ../gcc/7/lib/libgfortran.so.4.0.0
libgfortran.so.5 -> libgfortran.so.5.0.0
libgfortran.so.5.0.0 -> ../gcc/8/lib/libgfortran.so.5.0.0
libquadmath.so -> ../gcc/7/lib/libquadmath.so
libquadmath.so.0 -> libquadmath.so.0.0.0
libquadmath.so.0.0.0 -> ../gcc/7/lib/libquadmath.so.0.0.0
```
