### PR TITLE
Make /usr/bin/python a mediated link

### DIFF
--- a/build/python27/local.mog
+++ b/build/python27/local.mog
@@ -20,3 +20,8 @@ license LICENSE license=PSF
 # Prevent pkgdepend from reporting an error
 <transform file path=. -> set pkg.depend.bypass-generate .*>
 
+# Make /usr/bin/python a mediated link,  this the default.
+<transform link path=usr/bin/python$ -> set mediator python>
+<transform link path=usr/bin/python$ -> set mediator-version 2>
+<transform link path=usr/bin/python$ -> set mediator-priority vendor>
+

--- a/build/python35/local.mog
+++ b/build/python35/local.mog
@@ -21,3 +21,6 @@ license LICENSE license=PSF
 # Prevent pkgdepend from reporting an error
 <transform file path=. -> set pkg.depend.bypass-generate .*>
 
+# Add mediated link for /usr/bin/python
+link path=usr/bin/python target=python3 mediator=python mediator-version=3
+


### PR DESCRIPTION
```
% python
Python 2.7.15 (default, Jul  9 2018, 19:40:41)
[GCC 7.3.0] on sunos5
Type "help", "copyright", "credits" or "license" for more information.
>>>

% pfexec pkg set-mediator -V 3 python
            Packages to change:  1
           Mediators to change:  1
       Create boot environment: No
Create backup boot environment: No
PHASE                                          ITEMS
Updating modified actions                        1/1
Updating package state database                 Done
Updating package cache                           0/0
Updating image state                            Done
Creating fast lookup database                   Done

% python
Python 3.5.5 (default, Jul  9 2018, 19:47:08)
[GCC 7.3.0] on sunos5
Type "help", "copyright", "credits" or "license" for more information.
>>>
```