### PR TITLE
Adjust openssh excludes for corrected libexec path

### DIFF
--- a/build/openssh/client.mog
+++ b/build/openssh/client.mog
@@ -1,8 +1,22 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 <transform file path=etc/ssh/moduli -> drop>
 <transform file path=etc/ssh/sshd_config -> drop>
 <transform file dir path=lib/svc/manifest/network -> drop>
 <transform file dir path=lib/svc/method -> drop>
-<transform file path=usr/libexec/sftp-server -> drop>
+<transform file path=usr/libexec/amd64/sftp-server -> drop>
 <transform file dir path=usr/lib/dtrace -> drop>
 <transform dir path=usr/sbin -> drop>
 <transform file path=usr/sbin/sshd -> drop>

--- a/build/openssh/local.mog
+++ b/build/openssh/local.mog
@@ -1,2 +1,16 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 license LICENCE license=OpenSSH
 <transform dir path=etc/ssh -> set group sys>

--- a/build/openssh/server.mog
+++ b/build/openssh/server.mog
@@ -1,13 +1,29 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
 group groupname=sshd gid=92
-user ftpuser=false gcos-field="OpenSSH privsep user" group=sshd login-shell=/bin/false password=NP uid=92 username=sshd home-dir=/var/empty
+user ftpuser=false gcos-field="OpenSSH privsep user" group=sshd \
+    login-shell=/bin/false password=NP uid=92 username=sshd home-dir=/var/empty
+
 <transform file path=etc/ssh/moduli -> set preserve true>
 <transform file path=etc/ssh/ssh_config -> drop>
 <transform file path=etc/ssh/sshd_config -> set preserve renamenew>
 <transform dir path=usr/bin -> drop>
 <transform file path=usr/bin/.* -> drop>
 <transform link path=usr/bin/.* -> drop>
-<transform file path=usr/libexec/ssh-keysign -> drop>
-<transform file path=usr/libexec/ssh-pkcs11-helper -> drop>
+<transform file path=usr/libexec/amd64/ssh-keysign -> drop>
+<transform file path=usr/libexec/amd64/ssh-pkcs11-helper -> drop>
 <transform dir path=usr/share/man/man1 -> drop>
 <transform file path=usr/share/man/man1/.* -> drop>
 <transform link path=usr/share/man/man1/.* -> drop>


### PR DESCRIPTION
A recent fix for multiarch changed the libexec directory for 64-bit only components to include the ISA part (i.e. /usr/libexec/amd64/ instead of just /usr/libexec/). The openssh exclusions within the mog files need updating as a result.