### PR TITLE
Gcc8 configure needs "gsed" to find linker version

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -83,7 +83,7 @@ CONFIGURE_OPTS="
 CONFIGURE_OPTS_WS="
     --with-boot-cflags=\"-g -O2\"
     --with-pkgversion=\"OmniOS $RELVER\"
-    --with-bugurl=https://github.com/omniosorg/omnios-build/issues
+    --with-bugurl=https://omniosce.org/about/contact
 "
 LDFLAGS32="-R$OPT/lib"
 

--- a/build/gcc8/build.sh
+++ b/build/gcc8/build.sh
@@ -83,7 +83,7 @@ CONFIGURE_OPTS="
 CONFIGURE_OPTS_WS="
     --with-boot-cflags=\"-g -O2\"
     --with-pkgversion=\"OmniOS $RELVER\"
-    --with-bugurl=https://github.com/omniosorg/omnios-build/issues
+    --with-bugurl=https://omniosce.org/about/contact
 "
 LDFLAGS32="-R$OPT/lib"
 

--- a/build/gcc8/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
+++ b/build/gcc8/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
@@ -3,10 +3,15 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 5 Mar 2014 04:12:52 +0000
 Subject: [PATCH 03/12] gcc: enable the .eh_frame based unwinder
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/configure gcc-8.1.0/gcc/configure
---- gcc-8.1.0~/gcc/configure	2018-04-18 09:46:58.000000000 +0000
-+++ gcc-8.1.0/gcc/configure	2018-05-24 11:09:43.616179828 +0000
-@@ -22812,6 +22812,7 @@ if test $in_tree_ld != yes ; then
+diff -ru gcc-8.1.0.orig/gcc/configure gcc-8.1.0/gcc/configure
+--- gcc-8.1.0.orig/gcc/configure	2018-04-18 09:46:58.000000000 +0000
++++ gcc-8.1.0/gcc/configure	2018-07-13 13:01:58.827021646 +0000
+@@ -22808,10 +22808,11 @@
+ 	# linker is configured.
+ 	ld_ver=`$gcc_cv_ld -V 2>&1`
+ 	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+-	  ld_vers=`echo $ld_ver | sed -n \
++	  ld_vers=`echo $ld_ver | gsed -n \
  	    -e 's,^.*: \(5\|1[0-9]\)\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\2,p'`
  	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
  	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
@@ -14,7 +19,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/configure gcc-8.1.0/gcc/configure
  	fi
  	;;
      esac
-@@ -28309,6 +28310,8 @@ elif test x$gcc_cv_ld != x; then
+@@ -28309,6 +28310,8 @@
          # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
          if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
            gcc_cv_ld_eh_frame_hdr=yes
@@ -23,10 +28,15 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/configure gcc-8.1.0/gcc/configure
          fi
          ;;
      esac
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/configure.ac gcc-8.1.0/gcc/configure.ac
---- gcc-8.1.0~/gcc/configure.ac	2018-04-18 09:46:58.000000000 +0000
-+++ gcc-8.1.0/gcc/configure.ac	2018-05-24 11:09:43.618715197 +0000
-@@ -2608,6 +2608,7 @@ if test $in_tree_ld != yes ; then
+diff -ru gcc-8.1.0.orig/gcc/configure.ac gcc-8.1.0/gcc/configure.ac
+--- gcc-8.1.0.orig/gcc/configure.ac	2018-04-18 09:46:58.000000000 +0000
++++ gcc-8.1.0/gcc/configure.ac	2018-07-13 13:02:10.342025120 +0000
+@@ -2604,10 +2604,11 @@
+ 	# linker is configured.
+ 	ld_ver=`$gcc_cv_ld -V 2>&1`
+ 	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+-	  ld_vers=`echo $ld_ver | sed -n \
++	  ld_vers=`echo $ld_ver | gsed -n \
  	    -e 's,^.*: \(5\|1[0-9]\)\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\2,p'`
  	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
  	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
@@ -34,7 +44,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/configure.ac gcc-8.1.0/gcc/configu
  	fi
  	;;
      esac
-@@ -5131,6 +5132,8 @@ elif test x$gcc_cv_ld != x; then
+@@ -5131,6 +5132,8 @@
          # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
          if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
            gcc_cv_ld_eh_frame_hdr=yes


### PR DESCRIPTION
Without this, it does not find the linker version and therefore does not detect that it has support for eh_frame headers. Without this linker support, gcc adds additional function calls to `crtbegin.o` which use functions in `libgcc_so.1` and cause all compiled programs to gain an unnecessary dependency.

```
bloody% cat c.c
#include <stdio.h>

int
main()
{
        printf("Hello\n");
        return 0;
}

bloody% /opt/gcc-8/bin/gcc -o c c.c
bloody% ldd c
        libgcc_s.so.1 =>         /usr/gcc/8/lib/libgcc_s.so.1
        libc.so.1 =>     /lib/libc.so.1
        libm.so.2 =>     /lib/libm.so.2

bloody% nm -gp /opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.1.0/crtbegin.o
0000000000 U _GLOBAL_OFFSET_TABLE_
0000000000 U _ITM_deregisterTMCloneTable
0000000000 U _ITM_registerTMCloneTable
0000000000 U __TMC_END__
0000000000 U __deregister_frame_info_bases
0000000000 D __dso_handle
0000000000 U __register_frame_info_bases
0000000000 T __x86.get_pc_thunk.bx
0000000000 T __x86.get_pc_thunk.dx
```

It is the _(de)register_frame_info_bases_ functions which cause the dependency on libgcc.so.1.

After this change:

```
bloody% /opt/gcc-8/bin/gcc -o c c.c
bloody% ldd c
        libc.so.1 =>     /lib/libc.so.1
        libm.so.2 =>     /lib/libm.so.2

bloody% nm -gp /opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.1.0/crtbegin.o
0000000000 U _GLOBAL_OFFSET_TABLE_
0000000000 U _ITM_deregisterTMCloneTable
0000000000 U _ITM_registerTMCloneTable
0000000000 U __TMC_END__
0000000000 D __dso_handle
0000000000 T __x86.get_pc_thunk.bx
0000000000 T __x86.get_pc_thunk.dx

```
