### PR TITLE
Python module updates

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -148,7 +148,7 @@ library/ncurses					6	require
 library/nghttp2					1	require
 library/nspr					4	require
 library/pcre					8	require
-library/python-2/setuptools-27			39	require
+library/python-2/setuptools-27			40	require
 library/readline				7.0	require
 library/security/openssl			1.1	require
 library/security/tcp-wrapper			7.6	require

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -76,10 +76,10 @@ library/python-2/pybonjour-27		1.1.1
 library/python-2/pycurl-27		7.43
 library/python-2/pyopenssl-27		18
 library/python-2/pytz-27		2018
-library/python-2/setuptools-27		39
+library/python-2/setuptools-27		40
 library/python-2/simplejson-27		3
 library/python-2/six-27			1.11
-library/python-2/tempora-27		1.11
+library/python-2/tempora-27		1
 library/python-2/functools_lru_cache-27	1
 library/readline			7.0
 library/security/openssl		1.1

--- a/build/python27/cheroot/build.sh
+++ b/build/python27/cheroot/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-2/cheroot-27
 PROG=cheroot
-VER=6.3.2
+VER=6.3.3
 SUMMARY="cheroot - Highly-optimized, pure-python HTTP server"
 DESC="$SUMMARY"
 

--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/cherrypy-27
 PROG=CherryPy
-VER=16.0.2
+VER=16.0.3
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/build/python27/jaraco.functools/build.sh
+++ b/build/python27/jaraco.functools/build.sh
@@ -10,17 +10,17 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
+#
 # }}}
-#
+
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-# Use is subject to license terms.
-#
+
 . ../../../lib/functions.sh
 
-PKG=library/python-2/pytz-27
-PROG=pytz
-VER=2018.5
-SUMMARY="pytz - World Timezone Definitions for Python"
+PKG=library/python-2/jaraco.functools-27
+PROG=jaraco.functools
+VER=1.20
+SUMMARY="jaraco.functools - Additional functools"
 DESC="$SUMMARY"
 
 . $SRCDIR/../common.sh

--- a/build/python27/jaraco.functools/local.mog
+++ b/build/python27/jaraco.functools/local.mog
@@ -1,0 +1,1 @@
+license LICENSE license=MIT

--- a/build/python27/setuptools/build.sh
+++ b/build/python27/setuptools/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/setuptools-27
 PROG=setuptools
-VER=39.2.0
+VER=40.0.0
 SUMMARY="setuptools - Easily download, build, install, upgrade, and uninstall Python packages"
 DESC="$SUMMARY"
 

--- a/build/python27/simplejson/build.sh
+++ b/build/python27/simplejson/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/simplejson-27
 PROG=simplejson
-VER=3.15.0
+VER=3.16.0
 SUMMARY="simplejson - Python interface to JSON for Python"
 DESC="$SUMMARY"
 

--- a/build/python27/tempora/build.sh
+++ b/build/python27/tempora/build.sh
@@ -25,7 +25,10 @@ DESC="$SUMMARY"
 
 . $SRCDIR/../common.sh
 
-RUN_DEPENDS_IPS="library/python-2/pytz-27"
+RUN_DEPENDS_IPS="
+    library/python-2/pytz-27
+    library/python-2/jaraco.functools-27
+"
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python35/cheroot/build.sh
+++ b/build/python35/cheroot/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cheroot-35
 PROG=cheroot
-VER=6.3.2
+VER=6.3.3
 SUMMARY="cheroot - Highly-optimized, pure-python HTTP server"
 DESC="$SUMMARY"
 

--- a/build/python35/cherrypy/build.sh
+++ b/build/python35/cherrypy/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cherrypy-35
 PROG=CherryPy
-VER=16.0.2
+VER=16.0.3
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/build/python35/jaraco.functools/build.sh
+++ b/build/python35/jaraco.functools/build.sh
@@ -10,17 +10,17 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
+#
 # }}}
-#
+
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-# Use is subject to license terms.
-#
+
 . ../../../lib/functions.sh
 
-PKG=library/python-2/pytz-27
-PROG=pytz
-VER=2018.5
-SUMMARY="pytz - World Timezone Definitions for Python"
+PKG=library/python-3/jaraco.functools-35
+PROG=jaraco.functools
+VER=1.20
+SUMMARY="jaraco.functools - Additional functools"
 DESC="$SUMMARY"
 
 . $SRCDIR/../common.sh

--- a/build/python35/jaraco.functools/local.mog
+++ b/build/python35/jaraco.functools/local.mog
@@ -1,0 +1,1 @@
+license LICENSE license=MIT

--- a/build/python35/pytz/build.sh
+++ b/build/python35/pytz/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/pytz-35
 PROG=pytz
-VER=2018.4
+VER=2018.5
 SUMMARY="pytz - World Timezone Definitions for Python"
 DESC="$SUMMARY"
 

--- a/build/python35/setuptools/build.sh
+++ b/build/python35/setuptools/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-35
 PROG=setuptools
-VER=39.2.0
+VER=40.0.0
 SUMMARY="setuptools - Easily download, build, install, upgrade, and uninstall Python packages"
 DESC="$SUMMARY"
 

--- a/build/python35/simplejson/build.sh
+++ b/build/python35/simplejson/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/simplejson-35
 PROG=simplejson
-VER=3.15.0
+VER=3.16.0
 SUMMARY="simplejson - Python interface to JSON for Python"
 DESC="$SUMMARY"
 

--- a/build/python35/tempora/build.sh
+++ b/build/python35/tempora/build.sh
@@ -26,6 +26,7 @@ DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS+="
     library/python-$PYMVER/pytz-$SPYVER
+    library/python-$PYMVER/jaraco.functools-$SPYVER
 "
 
 init

--- a/doc/baseline
+++ b/doc/baseline
@@ -286,6 +286,7 @@ omnios library/python-2/functools_lru_cache-27
 omnios library/python-2/idna-27
 omnios library/python-2/ipaddress-27
 omnios library/python-2/jaraco.classes-27
+omnios library/python-2/jaraco.functools-27
 omnios library/python-2/jsonrpclib-27
 omnios library/python-2/jsonschema-27
 omnios library/python-2/lxml-27 o
@@ -316,6 +317,7 @@ omnios library/python-3/coverage-35
 omnios library/python-3/cryptography-35
 omnios library/python-3/functools_lru_cache-35
 omnios library/python-3/idna-35
+omnios library/python-3/jaraco.functools-35
 omnios library/python-3/jsonrpclib-35
 omnios library/python-3/jsonschema-35
 omnios library/python-3/mako-35

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -105,8 +105,8 @@
 | library/python-3/functools_lru_cache-35	| 1.5		| https://pypi.org/project/backports.functools_lru_cache/
 | library/python-3/asn1crypto-35	| 0.24.0		| https://pypi.org/project/asn1crypto
 | library/python-3/cffi-35		| 1.11.5		| https://pypi.org/project/cffi
-| library/python-3/cheroot-35		| 6.3.2			| https://pypi.org/project/cheroot
-| library/python-3/cherrypy-35		| 16.0.2		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
+| library/python-3/cheroot-35		| 6.3.3			| https://pypi.org/project/cheroot
+| library/python-3/cherrypy-35		| 16.0.3		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/coverage-35		| 4.5.1			| https://pypi.org/project/coverage
 | library/python-3/cryptography-35	| 2.2.2			| https://pypi.org/project/cryptography
 | library/python-3/idna-35		| 2.7			| https://pypi.org/project/idna
@@ -121,9 +121,9 @@
 | library/python-3/pycparser-35		| 2.18			| https://pypi.org/project/pycparser
 | library/python-3/pycurl-35		| 7.43.0.2		| https://pypi.org/project/pycurl
 | library/python-3/pyopenssl-35		| 18.0.0		| https://pypi.org/project/pyOpenSSL
-| library/python-3/pytz-35		| 2018.4		| https://pypi.org/project/pytz
-| library/python-3/setuptools-35	| 39.2.0		| https://pypi.org/project/setuptools
-| library/python-3/simplejson-35	| 3.15.0		| https://pypi.org/project/simplejson
+| library/python-3/pytz-35		| 2018.5		| https://pypi.org/project/pytz
+| library/python-3/setuptools-35	| 40.0.0		| https://pypi.org/project/setuptools
+| library/python-3/simplejson-35	| 3.16.0		| https://pypi.org/project/simplejson
 | library/python-3/six-35		| 1.11.0		| https://pypi.org/project/six
-| library/python-3/tempora-35		| 1.11			| https://pypi.org/project/tempora
+| library/python-3/tempora-35		| 1.11			| https://pypi.org/project/tempora | At present, cherrypy requires tempora\<1.13
 


### PR DESCRIPTION
Also adding `jaraco.functools` since the new `tempora` module requires it.
However, the `cherrypy` module does not like the new `tempora` update.. this is actually an artificial constraint added to allow people to freeze the cherrypy package, but it has been reverted in trunk so the next cherrypy release will work with the updated tempora.

pkg5 test-suite passes with both python2.7 & 3.5 - modulo using an older compiler, see upcoming PR.