### PR TITLE
Python module updates

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -59,7 +59,7 @@ library/perl-5/xml-parser		2.44
 library/python-2/asn1crypto-27		0.24
 library/python-2/cffi-27		1.11
 library/python-2/cheroot-27		6
-library/python-2/cherrypy-27		16
+library/python-2/cherrypy-27		17
 library/python-2/coverage-27		4
 library/python-2/cryptography-27	2.2
 library/python-2/enum-27		1.1

--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/cherrypy-27
 PROG=CherryPy
-VER=16.0.3
+VER=17.0.0
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/build/python27/tempora/build.sh
+++ b/build/python27/tempora/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-2/tempora-27
 PROG=tempora
-VER=1.11
+VER=1.13
 SUMMARY="tempora - Objects and routines pertaining to date and time"
 DESC="$SUMMARY"
 

--- a/build/python35/cherrypy/build.sh
+++ b/build/python35/cherrypy/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cherrypy-35
 PROG=CherryPy
-VER=16.0.3
+VER=17.0.0
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/build/python35/cherrypy/test
+++ b/build/python35/cherrypy/test
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
-import cherrypy
+import cherrypy, pkg_resources, pprint
+
+pprint.pprint(pkg_resources.require('cherrypy'))
 
 class HelloWorld(object):
     def index(self):

--- a/build/python35/tempora/build.sh
+++ b/build/python35/tempora/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/tempora-35
 PROG=tempora
-VER=1.11
+VER=1.13
 SUMMARY="tempora - Objects and routines pertaining to date and time"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -106,7 +106,7 @@
 | library/python-3/asn1crypto-35	| 0.24.0		| https://pypi.org/project/asn1crypto
 | library/python-3/cffi-35		| 1.11.5		| https://pypi.org/project/cffi
 | library/python-3/cheroot-35		| 6.3.3			| https://pypi.org/project/cheroot
-| library/python-3/cherrypy-35		| 16.0.3		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
+| library/python-3/cherrypy-35		| 17.0.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/coverage-35		| 4.5.1			| https://pypi.org/project/coverage
 | library/python-3/cryptography-35	| 2.2.2			| https://pypi.org/project/cryptography
 | library/python-3/idna-35		| 2.7			| https://pypi.org/project/idna
@@ -125,5 +125,5 @@
 | library/python-3/setuptools-35	| 40.0.0		| https://pypi.org/project/setuptools
 | library/python-3/simplejson-35	| 3.16.0		| https://pypi.org/project/simplejson
 | library/python-3/six-35		| 1.11.0		| https://pypi.org/project/six
-| library/python-3/tempora-35		| 1.11			| https://pypi.org/project/tempora | At present, cherrypy requires tempora\<1.13
+| library/python-3/tempora-35		| 1.13			| https://pypi.org/project/tempora
 

--- a/tools/test
+++ b/tools/test
@@ -283,11 +283,36 @@ check_entire()
 	' | check_constraints entire
 }
 
+#
+# Check that the python3 and python2 package versions are in-sync since
+# packages are only listed under either python2 or 3.
+#
+check_python()
+{
+	echo "Checking python..."
+	for i in "${!targets[@]}"; do
+		[[ $i = library/python-3/* ]] || continue
+		# The python-3 version of jsonrpclib is different
+		[ $i = library/python-3/jsonrpclib-35 ] && continue
+		j="`echo $i | sed '
+			s/python-3/python-2/
+			s/-35/-27/
+		'`"
+		bver="${targets[$j]}"
+		# python-3-only package
+		[ -z "$bver" ] && continue
+		ver="${targets[$i]}"
+		[ "$ver" = "$bver" ] \
+		    || problem "$i - python2 $bver python3 $ver"
+	done
+}
+
 add_targets
-#print_targets
+[ "$1" = "-p" ] && print_targets && exit 0
 check_packages_md
 check_userland
 check_entire
+check_python
 
 exit $err
 


### PR DESCRIPTION
It did not take them long to release another CherryPy without the artificial constraint on the tempora module version. All tests match baseline with python2 & python3.
