### PR TITLE
Add ooce prefix to release/name properties

### DIFF
--- a/build/release/local.mog
+++ b/build/release/local.mog
@@ -12,10 +12,10 @@
 
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
-set name=release value="$(RELEASE)"
-set name=release.base value="$(RELNUM)"
-set name=release.build value="$(RELDATE)"
-set name=release.rev value="$(RELREV)"
+set name=ooce.release value="$(RELEASE)"
+set name=ooce.release.base value="$(RELNUM)"
+set name=ooce.release.build value="$(RELDATE)"
+set name=ooce.release.rev value="$(RELREV)"
 
 <transform file -> set owner root>
 <transform file -> set group sys>


### PR DESCRIPTION
This is to support automatic BE naming in pkg5. At present, the property names are too generic so adding an `ooce.` prefix so that they can be distinguished from any other packages that might use a property called `release`.