### PR TITLE
Reverse components of dash-revision

### DIFF
--- a/build/jeos/build-userland.sh
+++ b/build/jeos/build-userland.sh
@@ -45,7 +45,7 @@ add_constraints()
 		fi
 		[ -z "$dash" ] && dash=0
 		echo "depend facet.version-lock.$pkg=true"\
-		    "fmri=$pkg@$ver,5.11-$dash.@RELVER@ type=incorporate" \
+		    "fmri=$pkg@$ver,5.11-@RELVER@.$dash type=incorporate" \
 		    >> $cmf
 	done
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -68,7 +68,8 @@ LC_TIME=C;      export LC_TIME
 
 # Default branch
 RELVER=151027
-PVER=0.$RELVER
+DASHREV=0
+PVER=$RELVER.$DASHREV
 
 # Default package publisher
 PKGPUBLISHER=omnios

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -952,8 +952,7 @@ make_package() {
     if [ -n "$FLAVORSTR" ]; then
         DESCSTR="$DESCSTR ($FLAVOR)"
     fi
-    # Add the local dash-revision if specified.
-    [ -n "$DASHREV" ] && PVER=$DASHREV.$RELVER
+    PVER=$RELVER.$DASHREV
     PKGSEND=/usr/bin/pkgsend
     PKGLINT=/usr/bin/pkglint
     PKGMOGRIFY=/usr/bin/pkgmogrify


### PR DESCRIPTION
This is extracted from the `pkg(5)` man page:

> A package version consists of four sequences of numbers, separated by punctuation.

>The first part of the version is the component version. For a component with its own development life-cycle, this sequence is a dotted release number, such as 2.4.10.

> The second part of the version, which if present must follow a comma (,), is the build version. The build version specifies what version of the operating system the contents of the package were built on.

> The third part of the version, which if present must follow a hyphen (-), is the branch version. The branch version is a versioning component that provides vendor-specific information. The branch version can be incremented when the packaging metadata is changed, independently of the component version. The branch version might contain a build number or other information.

> The fourth part of the version, which if present must follow a colon (:), is a timestamp.

This PR is about the third part, the branch version. We currently build package versions that look like this, with the branch version emboldened.

_pkg://omnios/terminal/screen@4.6.2,5.11-**0.151026**:20180420T095117Z_

and this PR proposes that this be reversed:

_pkg://omnios/terminal/screen@4.6.2,5.11-**151026.0**:20180420T095117Z_

This will allow us to increment the dash revision when republishing packages without changing the major version number and without causing problems with upgrading to future versions of OmniOS.
So for example if we published an updated package for screen 4.6.2 but with a security patch, we would bump the dash revision (the timestamp would also be incremented as it is now).

_pkg://omnios/terminal/screen@4.6.2,5.11-**151026.1**:20180726....._

There's easy provision for this in the build system, we just set `DASHREV=1` in the build script.

The problem with the current ordering is that _1.151026_ > _0.151028_ and so we would have to make the dashrev an increment-only property, only resetting it to zero when a new software version is released, whereas it would be better to start with zero on a release.

Since 151028.0 > 0.151026, this reversal will not cause a problem when we release r151028