### PR TITLE
mercurial: update to 4.7

### DIFF
--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -27,39 +27,12 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.6.2
+VER=4.7
 PKG=developer/versioning/mercurial
 SUMMARY="$PROG - distributed version control system"
 DESC="$SUMMARY"
 
 RUN_DEPENDS_IPS="web/curl library/security/openssl"
-
-python_build() {
-    logmsg "Building using python setup.py"
-    pushd $TMPDIR/$BUILDDIR > /dev/null
-    ISALIST=i386
-    export ISALIST
-    logmsg "--- setup.py (32) build"
-    logcmd $PYTHON ./setup.py build \
-        || logerr "--- build failed"
-    logmsg "--- setup.py (32) install"
-    logcmd $PYTHON \
-        ./setup.py install --root=$DESTDIR \
-        || logerr "--- install failed"
-
-    ISALIST="amd64 i386"
-    export ISALIST
-    logmsg "--- setup.py (64) build"
-    logcmd $PYTHON ./setup.py build \
-        || logerr "--- build failed"
-    logmsg "--- setup.py (64) install"
-    logcmd $PYTHON \
-        ./setup.py install --root=$DESTDIR \
-        || logerr "--- install failed"
-    popd > /dev/null
-
-    python_vendor_relocate
-}
 
 init
 download_source $PROG $PROG $VER

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -26,7 +26,7 @@
 | developer/parser/bison		| 3.0.5			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags https://ftp.gnu.org/gnu/bison/
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.18.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
-| developer/versioning/mercurial	| 4.6.2			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/mercurial	| 4.7			| https://www.mercurial-scm.org/release/?M=D
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.1			| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.30			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -138,15 +138,6 @@ export PERL_MM_USE_DEFAULT=true
 PERL_MAKE_TEST=1
 
 #############################################################################
-# Python -- NOTE, these can be changed at runtime via set_python_version().
-#############################################################################
-: ${PYTHONVER:=2.7}
-: ${PYTHONPKGVER:=${PYTHONVER//./}}
-PYTHONPATH=/usr
-PYTHON=$PYTHONPATH/bin/python$PYTHONVER
-PYTHONLIB=$PYTHONPATH/lib
-
-#############################################################################
 # Paths to common tools
 #############################################################################
 WGET=wget
@@ -198,8 +189,11 @@ ISAPART64=amd64
 CC=gcc
 CXX=g++
 
-# Specify default GCC version for building packages
+# Specify default versions for building packages
 DEFAULT_GCC_VER=7
+PYTHON2VER=2.7
+PYTHON3VER=3.5
+DEFAULT_PYTHON_VER=$PYTHON2VER
 
 # CFLAGS applies to both builds, 32/64 only gets applied to the respective
 # build

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1482,6 +1482,17 @@ run_testsuite() {
 # Build function for python programs
 #############################################################################
 
+set_python_version() {
+    PYTHONVER=$1
+    PYTHONPKGVER=${PYTHONVER//./}
+    PYTHONPATH=/usr
+    PYTHON=$PYTHONPATH/bin/python$PYTHONVER
+    PYTHONLIB=$PYTHONPATH/lib
+    PYTHONVENDOR=$PYTHONLIB/python$PYTHONVER/vendor-packages
+    [[ $PYTHONVER = 3.* ]] && BUILDARCH=64
+}
+set_python_version $DEFAULT_PYTHON_VER
+
 pre_python_32() {
     logmsg "prepping 32bit python build"
 }
@@ -1782,15 +1793,6 @@ check_for_prebuilt() {
     else
         logerr "Prebuilt illumos not present, aborting."
     fi
-}
-
-# Change the PYTHON version so we can perform version-agile Python tricks.
-set_python_version() {
-    PYTHONVER=$1
-    PYTHONPKGVER=`echo $PYTHONVER | sed 's/\.//g'`
-    # Assume PYTHONPATH from config.sh is a constant.
-    PYTHON=$PYTHONPATH/bin/python$PYTHONVER
-    PYTHONLIB=$PYTHONPATH/lib
 }
 
 # Vim hints


### PR DESCRIPTION
Looked at switching this to python3 but Mercurial currently only supports 2.7
```
bloody:omnios.bloody:hg% hg version
Mercurial Distributed SCM (version 4.7)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2018 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

openjdk build succeeded with this new version.