### PR TITLE
cpuid: add support for L1D flush command

### DIFF
--- a/build/cpuid/patches/l1df.patch
+++ b/build/cpuid/patches/l1df.patch
@@ -1,0 +1,27 @@
+
+Patch to properly identify support for the new L1D Flush instruction.
+This has been accepted upstream so can be removed when cpuid is next
+updated.
+
+From 17b99a148a4b281d5088d98a8c7ac8298926e5a5 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <omnios@citrus-it.co.uk>
+Date: Wed, 15 Aug 2018 14:51:58 +0000
+Subject: [PATCH] Add L1D Flush detection
+
+---
+ feature.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/feature.c b/feature.c
+index db0b18f..4661acd 100644
+--- a/feature.c
++++ b/feature.c
+@@ -288,7 +288,7 @@ static const struct cpu_feature_t features [] = {
+ /*	{ 0x00000007, 0, REG_EDX, 0x02000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
+ 	{ 0x00000007, 0, REG_EDX, 0x04000000, VENDOR_INTEL                                , "Speculation Control (IBRS and IBPB)"},
+ 	{ 0x00000007, 0, REG_EDX, 0x08000000, VENDOR_INTEL                                , "Single Thread Indirect Branch Predictors (STIBP)"},
+-/*	{ 0x00000007, 0, REG_EDX, 0x10000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
++	{ 0x00000007, 0, REG_EDX, 0x10000000, VENDOR_INTEL                                , "L1 Data Cache (L1D) Flush"},
+ 	{ 0x00000007, 0, REG_EDX, 0x20000000, VENDOR_INTEL                                , "IA32_ARCH_CAPABILITIES MSR"},
+ /*	{ 0x00000007, 0, REG_EDX, 0x40000000, VENDOR_INTEL | VENDOR_AMD                   , ""}, */   /* Reserved */
+ 	{ 0x00000007, 0, REG_EDX, 0x80000000, VENDOR_INTEL                                , "Speculative Store Bypass Disable (SSBD)"},

--- a/build/cpuid/patches/series
+++ b/build/cpuid/patches/series
@@ -1,0 +1,1 @@
+l1df.patch


### PR DESCRIPTION
```
bloody# cpuid
...
Structured extended feature flags (ecx=0), edx:
  Speculation Control (IBRS and IBPB)
  Single Thread Indirect Branch Predictors (STIBP)
  L1 Data Cache (L1D) Flush
  Speculative Store Bypass Disable (SSBD)
```