### PR TITLE
Python module updates

### DIFF
--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -28,19 +28,21 @@
 
 PKG=library/python-2/cherrypy-27
 PROG=CherryPy
-VER=17.0.0
+VER=17.3.0
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 
 . $SRCDIR/../common.sh
 
 RUN_DEPENDS_IPS+="
-    library/python-2/tempora-27
-    library/python-2/six-27
-    library/python-2/portend-27
-    library/python-2/cheroot-27
-    library/python-2/jaraco.classes-27
-    library/python-2/functools_lru_cache-27
+    library/python-$PYMVER/tempora-$SPYVER
+    library/python-$PYMVER/six-$SPYVER
+    library/python-$PYMVER/portend-$SPYVER
+    library/python-$PYMVER/cheroot-$SPYVER
+    library/python-$PYMVER/jaraco.classes-$SPYVER
+    library/python-$PYMVER/functools_lru_cache-$SPYVER
+    library/python-$PYMVER/zc.lockfile-$SPYVER
+    library/python-$PYMVER/contextlib2-$SPYVER
 "
 
 init

--- a/build/python27/contextlib2/build.sh
+++ b/build/python27/contextlib2/build.sh
@@ -16,20 +16,13 @@
 #
 . ../../../lib/functions.sh
 
-PKG=library/python-3/cryptography-35
-PROG=cryptography
-VER=2.3.1
-SUMMARY="cryptography - cryptographic recipes and primitives"
-DESC="$SUMMARY"
+PKG=library/python-2/contextlib2-27
+PROG=contextlib2
+VER=0.5.5
+SUMMARY="Utilities for with-statement contexts"
+DESC="Provides utilities for common tasks involving the with statement"
 
 . $SRCDIR/../common.sh
-
-RUN_DEPENDS_IPS+="
-    library/python-$PYMVER/six-$SPYVER
-    library/python-$PYMVER/cffi-$SPYVER
-    library/python-$PYMVER/asn1crypto-$SPYVER
-    library/python-$PYMVER/idna-$SPYVER
-"
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python27/contextlib2/local.mog
+++ b/build/python27/contextlib2/local.mog
@@ -1,0 +1,15 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE.txt license=PSF
+

--- a/build/python27/cryptography/build.sh
+++ b/build/python27/cryptography/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-2/cryptography-27
 PROG=cryptography
-VER=2.3
+VER=2.3.1
 SUMMARY="cryptography - cryptographic recipes and primitives"
 DESC="$SUMMARY"
 
@@ -32,8 +32,6 @@ RUN_DEPENDS_IPS+="
     library/python-2/asn1crypto-27
     library/python-2/idna-27
 "
-
-FORCE_OPENSSL_VERSION=1.0
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python27/setuptools/build.sh
+++ b/build/python27/setuptools/build.sh
@@ -28,7 +28,7 @@
 
 PKG=library/python-2/setuptools-27
 PROG=setuptools
-VER=40.0.0
+VER=40.2.0
 SUMMARY="setuptools - Easily download, build, install, upgrade, and uninstall Python packages"
 DESC="$SUMMARY"
 

--- a/build/python27/zc.lockfile/build.sh
+++ b/build/python27/zc.lockfile/build.sh
@@ -16,20 +16,13 @@
 #
 . ../../../lib/functions.sh
 
-PKG=library/python-3/cryptography-35
-PROG=cryptography
-VER=2.3.1
-SUMMARY="cryptography - cryptographic recipes and primitives"
-DESC="$SUMMARY"
+PKG=library/python-2/zc.lockfile-27
+PROG=zc.lockfile
+VER=1.3.0
+SUMMARY="Portable inter-process lock implementation"
+DESC="A basic portable implementation of interprocess locks using lock files"
 
 . $SRCDIR/../common.sh
-
-RUN_DEPENDS_IPS+="
-    library/python-$PYMVER/six-$SPYVER
-    library/python-$PYMVER/cffi-$SPYVER
-    library/python-$PYMVER/asn1crypto-$SPYVER
-    library/python-$PYMVER/idna-$SPYVER
-"
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python27/zc.lockfile/local.mog
+++ b/build/python27/zc.lockfile/local.mog
@@ -1,0 +1,15 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE.txt license=ZPL
+

--- a/build/python35/README
+++ b/build/python35/README
@@ -10,6 +10,8 @@ pkg
 		portend
 			tempora
 				pytz
+		zc.lockfile
+		contextlib2
 	cryptography
 		six
 		cffi

--- a/build/python35/cherrypy/build.sh
+++ b/build/python35/cherrypy/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cherrypy-35
 PROG=CherryPy
-VER=17.0.0
+VER=17.3.0
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 
@@ -29,6 +29,8 @@ RUN_DEPENDS_IPS+="
     library/python-$PYMVER/six-$SPYVER
     library/python-$PYMVER/portend-$SPYVER
     library/python-$PYMVER/cheroot-$SPYVER
+    library/python-$PYMVER/zc.lockfile-$SPYVER
+    library/python-$PYMVER/contextlib2-$SPYVER
 "
 
 init

--- a/build/python35/contextlib2/build.sh
+++ b/build/python35/contextlib2/build.sh
@@ -16,20 +16,13 @@
 #
 . ../../../lib/functions.sh
 
-PKG=library/python-3/cryptography-35
-PROG=cryptography
-VER=2.3.1
-SUMMARY="cryptography - cryptographic recipes and primitives"
-DESC="$SUMMARY"
+PKG=library/python-3/contextlib2-35
+PROG=contextlib2
+VER=0.5.5
+SUMMARY="Utilities for with-statement contexts"
+DESC="Provides utilities for common tasks involving the with statement"
 
 . $SRCDIR/../common.sh
-
-RUN_DEPENDS_IPS+="
-    library/python-$PYMVER/six-$SPYVER
-    library/python-$PYMVER/cffi-$SPYVER
-    library/python-$PYMVER/asn1crypto-$SPYVER
-    library/python-$PYMVER/idna-$SPYVER
-"
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python35/contextlib2/local.mog
+++ b/build/python35/contextlib2/local.mog
@@ -1,0 +1,15 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE.txt license=PSF
+

--- a/build/python35/setuptools/build.sh
+++ b/build/python35/setuptools/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-35
 PROG=setuptools
-VER=40.0.0
+VER=40.2.0
 SUMMARY="setuptools - Easily download, build, install, upgrade, and uninstall Python packages"
 DESC="$SUMMARY"
 

--- a/build/python35/zc.lockfile/build.sh
+++ b/build/python35/zc.lockfile/build.sh
@@ -16,20 +16,13 @@
 #
 . ../../../lib/functions.sh
 
-PKG=library/python-3/cryptography-35
-PROG=cryptography
-VER=2.3.1
-SUMMARY="cryptography - cryptographic recipes and primitives"
-DESC="$SUMMARY"
+PKG=library/python-3/zc.lockfile-35
+PROG=zc.lockfile
+VER=1.3.0
+SUMMARY="Portable inter-process lock implementation"
+DESC="A basic portable implementation of interprocess locks using lock files"
 
 . $SRCDIR/../common.sh
-
-RUN_DEPENDS_IPS+="
-    library/python-$PYMVER/six-$SPYVER
-    library/python-$PYMVER/cffi-$SPYVER
-    library/python-$PYMVER/asn1crypto-$SPYVER
-    library/python-$PYMVER/idna-$SPYVER
-"
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python35/zc.lockfile/local.mog
+++ b/build/python35/zc.lockfile/local.mog
@@ -1,0 +1,15 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE.txt license=ZPL
+

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -106,9 +106,10 @@
 | library/python-3/asn1crypto-35	| 0.24.0		| https://pypi.org/project/asn1crypto
 | library/python-3/cffi-35		| 1.11.5		| https://pypi.org/project/cffi
 | library/python-3/cheroot-35		| 6.4.0			| https://pypi.org/project/cheroot
-| library/python-3/cherrypy-35		| 17.0.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
+| library/python-3/cherrypy-35		| 17.3.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
+| library/python-3/contextlib2-35	| 0.5.5			| https://pypi.org/project/contextlib2
 | library/python-3/coverage-35		| 4.5.1			| https://pypi.org/project/coverage
-| library/python-3/cryptography-35	| 2.3			| https://pypi.org/project/cryptography
+| library/python-3/cryptography-35	| 2.3.1			| https://pypi.org/project/cryptography
 | library/python-3/idna-35		| 2.7			| https://pypi.org/project/idna
 | library/python-3/jsonrpclib-35	| 0.3.1			| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-35	| 2.6.0			| https://pypi.org/project/jsonschema
@@ -123,8 +124,9 @@
 | library/python-3/pycurl-35		| 7.43.0.2		| https://pypi.org/project/pycurl
 | library/python-3/pyopenssl-35		| 18.0.0		| https://pypi.org/project/pyOpenSSL
 | library/python-3/pytz-35		| 2018.5		| https://pypi.org/project/pytz
-| library/python-3/setuptools-35	| 40.0.0		| https://pypi.org/project/setuptools
+| library/python-3/setuptools-35	| 40.2.0		| https://pypi.org/project/setuptools
 | library/python-3/simplejson-35	| 3.16.0		| https://pypi.org/project/simplejson
 | library/python-3/six-35		| 1.11.0		| https://pypi.org/project/six
 | library/python-3/tempora-35		| 1.13			| https://pypi.org/project/tempora
+| library/python-3/zc.lockfile-35	| 1.3.0			| https://pypi.org/project/zc.lockfile
 


### PR DESCRIPTION
Tested the kayak web server with the updated cherrypy.
Ran pkg5 regression tests with python2 & 3.

Of note, this update also changes the cryptography module to build with openssl 1.1 as it now works properly.