### PR TITLE
 gcc7/8: Ignore -fomit-frame-pointer

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -30,8 +30,8 @@ PKG=developer/gcc7
 PROG=gcc
 VER=7.3.0
 VERHUMAN=$VER
-SUMMARY="gcc ${VER}"
-DESC="$SUMMARY"
+SUMMARY="gcc $VER"
+DESC="The GNU Compiler Collection"
 
 GCCMAJOR=${VER%%.*}
 OPT=/opt/gcc-$GCCMAJOR
@@ -79,6 +79,7 @@ CONFIGURE_OPTS="
     --enable-__cxa_atexit
     --enable-initfini-array
     --disable-libitm
+    enable_frame_pointer=yes
 "
 CONFIGURE_OPTS_WS="
     --with-boot-cflags=\"-g -O2\"

--- a/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
+++ b/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 5 Mar 2014 04:12:52 +0000
 Subject: [PATCH 03/11] gcc: enable the .eh_frame based unwinder
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/configure gcc-7.3.0/gcc/configure
---- gcc-7.3.0~/gcc/configure	2017-11-21 09:31:12.135035000 +0000
-+++ gcc-7.3.0/gcc/configure	2018-05-08 14:43:51.065895571 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/configure a/gcc/configure
+--- a~/gcc/configure	1970-01-01 00:00:00
++++ a/gcc/configure	1970-01-01 00:00:00
 @@ -22787,6 +22787,7 @@ if test $in_tree_ld != yes ; then
  	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
  	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
@@ -23,9 +23,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/configure gcc-7.3.0/gcc/configure
          fi
          ;;
      esac
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/configure.ac gcc-7.3.0/gcc/configure.ac
---- gcc-7.3.0~/gcc/configure.ac	2017-11-21 09:31:12.135035000 +0000
-+++ gcc-7.3.0/gcc/configure.ac	2018-05-08 14:43:51.066960624 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/configure.ac a/gcc/configure.ac
+--- a~/gcc/configure.ac	1970-01-01 00:00:00
++++ a/gcc/configure.ac	1970-01-01 00:00:00
 @@ -2600,6 +2600,7 @@ if test $in_tree_ld != yes ; then
  	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
  	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`

--- a/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
+++ b/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 11 Mar 2014 21:50:30 +0000
 Subject: [PATCH 04/11] intl: Don't use UTF-8 quotes.  Ever.
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/intl.c gcc-7.3.0/gcc/intl.c
---- gcc-7.3.0~/gcc/intl.c	2017-01-01 12:07:43.905435000 +0000
-+++ gcc-7.3.0/gcc/intl.c	2018-05-08 14:43:58.180829334 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/intl.c a/gcc/intl.c
+--- a~/gcc/intl.c	1970-01-01 00:00:00
++++ a/gcc/intl.c	1970-01-01 00:00:00
 @@ -74,17 +74,11 @@ gcc_init_libintl (void)
  
    if (!strcmp (open_quote, "`") && !strcmp (close_quote, "'"))

--- a/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
+++ b/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
@@ -11,9 +11,9 @@ something we desire.
 Implement a flag which disables this behaviour, enabled by default.  The flag is
 global, though only effective on i386, to more easily allow its globalization
 later which, given the odds, is likely to be necessary.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/common.opt gcc-7.3.0/gcc/common.opt
---- gcc-7.3.0~/gcc/common.opt	2017-06-22 11:38:22.113724000 +0000
-+++ gcc-7.3.0/gcc/common.opt	2018-05-08 14:44:05.313234441 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/common.opt a/gcc/common.opt
+--- a~/gcc/common.opt	1970-01-01 00:00:00
++++ a/gcc/common.opt	1970-01-01 00:00:00
 @@ -2341,6 +2341,10 @@ fstrict-aliasing
  Common Report Var(flag_strict_aliasing) Optimization
  Assume strict aliasing rules apply.
@@ -25,9 +25,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/common.opt gcc-7.3.0/gcc/common.op
  fstrict-overflow
  Common Report Var(flag_strict_overflow) Optimization
  Treat signed overflow as undefined.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.c gcc-7.3.0/gcc/config/i386/i386.c
---- gcc-7.3.0~/gcc/config/i386/i386.c	2018-01-16 12:49:29.534125000 +0000
-+++ gcc-7.3.0/gcc/config/i386/i386.c	2018-05-08 14:44:05.322498433 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
 @@ -8015,6 +8015,7 @@ ix86_function_regparm (const_tree type,
  	 and callee not, or vice versa.  Instead look at whether the callee
  	 is optimized or not.  */
@@ -44,9 +44,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.c gcc-7.3.0/gcc/c
        && !(profile_flag && !flag_fentry))
      {
        cgraph_local_info *i = &target->local;
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/invoke.texi
---- gcc-7.3.0~/gcc/doc/invoke.texi	2018-01-16 11:22:01.161048000 +0000
-+++ gcc-7.3.0/gcc/doc/invoke.texi	2018-05-08 14:44:05.326300651 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
 @@ -8639,6 +8639,12 @@ int f() @{
  The @option{-fstrict-aliasing} option is enabled at levels
  @option{-O2}, @option{-O3}, @option{-Os}.
@@ -60,9 +60,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/
  @item -fstrict-overflow
  @opindex fstrict-overflow
  Allow the compiler to assume strict signed overflow rules, depending
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/local.c gcc-7.3.0/gcc/testsuite/gcc.target/i386/local.c
---- gcc-7.3.0~/gcc/testsuite/gcc.target/i386/local.c	2015-12-29 10:32:21.184118000 +0000
-+++ gcc-7.3.0/gcc/testsuite/gcc.target/i386/local.c	2018-05-08 14:44:05.326474379 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/local.c a/gcc/testsuite/gcc.target/i386/local.c
+--- a~/gcc/testsuite/gcc.target/i386/local.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/local.c	1970-01-01 00:00:00
 @@ -1,5 +1,6 @@
  /* { dg-do compile } */
 -/* { dg-options "-O2 -funit-at-a-time" } */
@@ -71,9 +71,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/local.c 
  /* { dg-final { scan-assembler "magic\[^\\n\]*eax" { target ia32 } } } */
  /* { dg-final { scan-assembler "magic\[^\\n\]*(edi|ecx)" { target { ! ia32 } } } } */
  
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/strict-cc.c gcc-7.3.0/gcc/testsuite/gcc.target/i386/strict-cc.c
---- gcc-7.3.0~/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-7.3.0/gcc/testsuite/gcc.target/i386/strict-cc.c	2018-05-08 14:44:05.326614380 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/strict-cc.c a/gcc/testsuite/gcc.target/i386/strict-cc.c
+--- a~/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00
 @@ -0,0 +1,24 @@
 +/* { dg-do compile { target { ilp32 } } } */
 +/* { dg-options "-O2 -funit-at-a-time -fstrict-calling-conventions"  } */

--- a/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
+++ b/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
@@ -11,9 +11,9 @@ having the actual source symbol name).
 
 This allows any function cloning to be disabled, and makes any such
 optimization ineffective, and our source safe for debuggers everywhere.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/common.opt gcc-7.3.0/gcc/common.opt
---- gcc-7.3.0~/gcc/common.opt	2018-05-08 14:44:05.313234441 +0000
-+++ gcc-7.3.0/gcc/common.opt	2018-05-08 14:44:12.445810516 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/common.opt a/gcc/common.opt
+--- a~/gcc/common.opt	1970-01-01 00:00:00
++++ a/gcc/common.opt	1970-01-01 00:00:00
 @@ -1076,6 +1076,11 @@ fcode-hoisting
  Common Report Var(flag_code_hoisting) Optimization
  Enable code hoisting.
@@ -26,9 +26,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/common.opt gcc-7.3.0/gcc/common.op
  fcombine-stack-adjustments
  Common Report Var(flag_combine_stack_adjustments) Optimization
  Looks for opportunities to reduce stack adjustments and stack references.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/invoke.texi
---- gcc-7.3.0~/gcc/doc/invoke.texi	2018-05-08 14:44:05.326300651 +0000
-+++ gcc-7.3.0/gcc/doc/invoke.texi	2018-05-08 14:44:12.450991031 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
 @@ -359,7 +359,7 @@ Objective-C and Objective-C++ Dialects}.
  -fauto-inc-dec  -fbranch-probabilities @gol
  -fbranch-target-load-optimize  -fbranch-target-load-optimize2 @gol
@@ -54,9 +54,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/
  @item -fipa-ra
  @opindex fipa-ra
  Use caller save registers for allocation if those registers are not used by
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/tree-inline.c gcc-7.3.0/gcc/tree-inline.c
---- gcc-7.3.0~/gcc/tree-inline.c	2017-10-27 20:33:35.593168000 +0000
-+++ gcc-7.3.0/gcc/tree-inline.c	2018-05-08 14:44:12.452028843 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/tree-inline.c a/gcc/tree-inline.c
+--- a~/gcc/tree-inline.c	1970-01-01 00:00:00
++++ a/gcc/tree-inline.c	1970-01-01 00:00:00
 @@ -5714,7 +5714,8 @@ bool
  tree_versionable_function_p (tree fndecl)
  {

--- a/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
+++ b/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
@@ -4,9 +4,9 @@ Date: Tue, 4 Mar 2014 02:58:33 +0000
 Subject: [PATCH 07/11] strict-cc2: check that disabling function cloning
  prevents constant propagation eliding or changing arguments
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c gcc-7.3.0/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
---- gcc-7.3.0~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-7.3.0/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	2018-05-08 14:44:19.463269382 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
+--- a~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00
 @@ -0,0 +1,27 @@
 +/* { dg-do compile { target { ilp32 } } } */
 +/* { dg-options "-O2 -funit-at-a-time -fipa-sra -fno-clone-functions"  } */

--- a/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
+++ b/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 22:11:03 +0000
 Subject: [PATCH 08/11] sol2: enable full __cxa_atexit support
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/sol2.h gcc-7.3.0/gcc/config/sol2.h
---- gcc-7.3.0~/gcc/config/sol2.h	2017-11-21 09:31:12.135035000 +0000
-+++ gcc-7.3.0/gcc/config/sol2.h	2018-05-08 14:44:26.269107565 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
 @@ -178,7 +178,7 @@ along with GCC; see the file COPYING3.
  				   shared|" PIE_SPEC ":crtbeginS.o%s; \
  				   :crtbegin.o%s}"
@@ -24,9 +24,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/sol2.h gcc-7.3.0/gcc/config
  #endif
  
  #undef  ENDFILE_SPEC
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/libgcc/config.host gcc-7.3.0/libgcc/config.host
---- gcc-7.3.0~/libgcc/config.host	2018-01-08 13:39:11.754860000 +0000
-+++ gcc-7.3.0/libgcc/config.host	2018-05-08 14:44:26.269557826 +0000
+diff -wpruN '--exclude=*.orig' a~/libgcc/config.host a/libgcc/config.host
+--- a~/libgcc/config.host	1970-01-01 00:00:00
++++ a/libgcc/config.host	1970-01-01 00:00:00
 @@ -270,7 +270,7 @@ case ${host} in
  *-*-solaris2*)
    # Unless linker support and dl_iterate_phdr are present,

--- a/build/gcc7/patches/0009-symtab-disable-non-interposable-alias-generation-if-.patch
+++ b/build/gcc7/patches/0009-symtab-disable-non-interposable-alias-generation-if-.patch
@@ -4,9 +4,9 @@ Date: Sun, 24 Jan 2016 18:30:00 +0000
 Subject: [PATCH 09/11] symtab: disable non-interposable alias generation if
  function cloning is disabled
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/symtab.c gcc-7.3.0/gcc/symtab.c
---- gcc-7.3.0~/gcc/symtab.c	2017-04-28 11:42:14.556427000 +0000
-+++ gcc-7.3.0/gcc/symtab.c	2018-05-08 14:44:33.242084116 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/symtab.c a/gcc/symtab.c
+--- a~/gcc/symtab.c	1970-01-01 00:00:00
++++ a/gcc/symtab.c	1970-01-01 00:00:00
 @@ -1744,6 +1744,10 @@ symtab_node::noninterposable_alias (void
    tree new_decl;
    symtab_node *new_node = NULL;

--- a/build/gcc7/patches/0010-sol2-Use-appropriate-values-objects-for-the-various-.patch
+++ b/build/gcc7/patches/0010-sol2-Use-appropriate-values-objects-for-the-various-.patch
@@ -17,9 +17,9 @@ C otherwise gets transitional ansi (and no UNIX standard)
 
 C++ gets strict ansi, other than in C++98.  And gets no UNIX standards
 objects at all.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/sol2.h gcc-7.3.0/gcc/config/sol2.h
---- gcc-7.3.0~/gcc/config/sol2.h	2018-05-08 14:44:26.269107565 +0000
-+++ gcc-7.3.0/gcc/config/sol2.h	2018-05-08 14:44:40.038242464 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
 @@ -170,8 +170,15 @@ along with GCC; see the file COPYING3.
  #define SUPPORTS_INIT_PRIORITY HAVE_INITFINI_ARRAY_SUPPORT
  

--- a/build/gcc7/patches/0011-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
+++ b/build/gcc7/patches/0011-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
@@ -29,9 +29,9 @@ Originally implemented in:
         	ix86_expand_prologue, ix86_expand_epilogue): Handle -msave-args.
 
         git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/csl-sol210-3_4-branch@101443 138bc75d-0d04-0410-961f-82ee72b054a4
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.c gcc-7.3.0/gcc/config/i386/i386.c
---- gcc-7.3.0~/gcc/config/i386/i386.c	2018-05-08 14:44:05.322498433 +0000
-+++ gcc-7.3.0/gcc/config/i386/i386.c	2018-05-08 14:44:46.903370820 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
 @@ -2572,6 +2572,8 @@ static unsigned int ix86_minimum_incomin
  
  static enum calling_abi ix86_function_abi (const_tree);
@@ -312,9 +312,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.c gcc-7.3.0/gcc/c
  /*  Nonzero if the symbol is marked as dllimport, or as stub-variable,
      otherwise zero.  */
  
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.h gcc-7.3.0/gcc/config/i386/i386.h
---- gcc-7.3.0~/gcc/config/i386/i386.h	2018-01-16 11:10:44.253204000 +0000
-+++ gcc-7.3.0/gcc/config/i386/i386.h	2018-05-08 14:44:46.904082067 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.h a/gcc/config/i386/i386.h
+--- a~/gcc/config/i386/i386.h	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.h	1970-01-01 00:00:00
 @@ -2463,6 +2463,11 @@ enum avx_u128_state
  
     saved frame pointer			if frame_pointer_needed
@@ -343,9 +343,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.h gcc-7.3.0/gcc/c
    HOST_WIDE_INT reg_save_offset;
    HOST_WIDE_INT sse_reg_save_offset;
  
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.opt gcc-7.3.0/gcc/config/i386/i386.opt
---- gcc-7.3.0~/gcc/config/i386/i386.opt	2018-01-16 11:17:49.509247000 +0000
-+++ gcc-7.3.0/gcc/config/i386/i386.opt	2018-05-08 14:44:46.904396604 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.opt a/gcc/config/i386/i386.opt
+--- a~/gcc/config/i386/i386.opt	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.opt	1970-01-01 00:00:00
 @@ -505,6 +505,16 @@ mtls-direct-seg-refs
  Target Report Mask(TLS_DIRECT_SEG_REFS)
  Use direct references against %gs when accessing tls data.
@@ -363,9 +363,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/i386/i386.opt gcc-7.3.0/gcc
  mtune=
  Target RejectNegative Joined Var(ix86_tune_string)
  Schedule code for given CPU.
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/invoke.texi
---- gcc-7.3.0~/gcc/doc/invoke.texi	2018-05-08 14:44:12.450991031 +0000
-+++ gcc-7.3.0/gcc/doc/invoke.texi	2018-05-08 14:44:46.908256712 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
 @@ -13887,6 +13887,10 @@ dynamically linked.  This is the default
  Generate code for the large code model.  This makes no assumptions about
  addresses and sizes of sections.  Programs can be statically linked only.
@@ -377,9 +377,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/doc/invoke.texi gcc-7.3.0/gcc/doc/
  @item -mstrict-align
  @opindex mstrict-align
  Avoid generating memory accesses that may not be aligned on a natural object
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/dwarf2out.c gcc-7.3.0/gcc/dwarf2out.c
---- gcc-7.3.0~/gcc/dwarf2out.c	2017-11-15 11:54:11.986064000 +0000
-+++ gcc-7.3.0/gcc/dwarf2out.c	2018-05-08 14:44:46.912755358 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/dwarf2out.c a/gcc/dwarf2out.c
+--- a~/gcc/dwarf2out.c	1970-01-01 00:00:00
++++ a/gcc/dwarf2out.c	1970-01-01 00:00:00
 @@ -22432,6 +22432,11 @@ gen_subprogram_die (tree decl, dw_die_re
      /* Add the calling convention attribute if requested.  */
      add_calling_convention_attribute (subr_die, decl);
@@ -392,9 +392,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/dwarf2out.c gcc-7.3.0/gcc/dwarf2ou
    /* Output Dwarf info for all of the stuff within the body of the function
       (if it has one - it may be just a declaration).
  
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-args-mov.c gcc-7.3.0/gcc/testsuite/gcc.target/i386/msave-args-mov.c
---- gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-7.3.0/gcc/testsuite/gcc.target/i386/msave-args-mov.c	2018-05-08 14:44:46.912998590 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/msave-args-mov.c a/gcc/testsuite/gcc.target/i386/msave-args-mov.c
+--- a~/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00
 @@ -0,0 +1,26 @@
 +/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
 +/* { dg-options "-msave-args -mforce-save-regs-using-mov -save-temps" } */
@@ -422,9 +422,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-ar
 +/* { dg-final { scan-assembler "movq\t%rcx, -32\\(%rbp\\)" } } */
 +/* { dg-final { scan-assembler "movq\t%r8, -40\\(%rbp\\)" } } */
 +/* { dg-final { cleanup-saved-temps } } */
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-args-push.c gcc-7.3.0/gcc/testsuite/gcc.target/i386/msave-args-push.c
---- gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-7.3.0/gcc/testsuite/gcc.target/i386/msave-args-push.c	2018-05-08 14:44:46.913162172 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/msave-args-push.c a/gcc/testsuite/gcc.target/i386/msave-args-push.c
+--- a~/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00
 @@ -0,0 +1,26 @@
 +/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
 +/* { dg-options "-msave-args -save-temps " } */
@@ -452,9 +452,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/testsuite/gcc.target/i386/msave-ar
 +/* { dg-final { scan-assembler "pushq\t%rcx" } } */
 +/* { dg-final { scan-assembler "pushq\t%r8" } } */
 +/* { dg-final { cleanup-saved-temps } } */
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/include/dwarf2.def gcc-7.3.0/include/dwarf2.def
---- gcc-7.3.0~/include/dwarf2.def	2017-02-25 08:18:24.431993000 +0000
-+++ gcc-7.3.0/include/dwarf2.def	2018-05-08 14:44:46.913445817 +0000
+diff -wpruN '--exclude=*.orig' a~/include/dwarf2.def a/include/dwarf2.def
+--- a~/include/dwarf2.def	1970-01-01 00:00:00
++++ a/include/dwarf2.def	1970-01-01 00:00:00
 @@ -457,6 +457,8 @@ DW_TAG (DW_AT_GNU_denominator, 0x2304)
  /* Biased integer extension.
     See https://gcc.gnu.org/wiki/DW_AT_GNU_bias .  */

--- a/build/gcc7/patches/0012-16-update-cmn_err-format-specifier.patch
+++ b/build/gcc7/patches/0012-16-update-cmn_err-format-specifier.patch
@@ -4,9 +4,9 @@ Date: Sat, 5 Nov 2016 05:26:47 +0300
 Subject: [PATCH 1/2] 16 update cmn_err format specifier Reviewed by: Richard
  Lowe <richlowe@richlowe.net> Reviewed by: Robert Mustacchi <rm@joyent.com>
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/sol2-c.c gcc-7.3.0/gcc/config/sol2-c.c
---- gcc-7.3.0~/gcc/config/sol2-c.c	2017-01-01 12:07:43.905435000 +0000
-+++ gcc-7.3.0/gcc/config/sol2-c.c	2018-05-08 14:44:53.969515286 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2-c.c a/gcc/config/sol2-c.c
+--- a~/gcc/config/sol2-c.c	1970-01-01 00:00:00
++++ a/gcc/config/sol2-c.c	1970-01-01 00:00:00
 @@ -40,7 +40,10 @@ static const format_length_info cmn_err_
  
  static const format_flag_spec cmn_err_flag_specs[] =

--- a/build/gcc7/patches/0013-19-cmn_err-b-conversion-should-accept-0-flag.patch
+++ b/build/gcc7/patches/0013-19-cmn_err-b-conversion-should-accept-0-flag.patch
@@ -5,9 +5,9 @@ Subject: [PATCH 2/2] 19 cmn_err %b conversion should accept 0 flag Reviewed
  by: Robert Mustacchi <rm@joyent.com> Reviewed by: Richard Lowe
  <richlowe@richlowe.net>
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/gcc/config/sol2-c.c gcc-7.3.0/gcc/config/sol2-c.c
---- gcc-7.3.0~/gcc/config/sol2-c.c	2018-05-08 14:44:53.969515286 +0000
-+++ gcc-7.3.0/gcc/config/sol2-c.c	2018-05-08 14:45:00.920118099 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2-c.c a/gcc/config/sol2-c.c
+--- a~/gcc/config/sol2-c.c	1970-01-01 00:00:00
++++ a/gcc/config/sol2-c.c	1970-01-01 00:00:00
 @@ -67,7 +67,7 @@ static const format_char_info cmn_err_ch
    { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
    { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },

--- a/build/gcc7/patches/1000-ld-flags.patch
+++ b/build/gcc7/patches/1000-ld-flags.patch
@@ -1,6 +1,7 @@
---- ./gcc/config/sol2.h.orig	2016-05-08 21:13:10.810423614 +0200
-+++ ./gcc/config/sol2.h	2016-05-08 21:16:55.681535743 +0200
-@@ -195,8 +195,8 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
+@@ -248,8 +248,8 @@ along with GCC; see the file COPYING3.
    "%{G:-G} \
     %{YP,*} \
     %{R*} \
@@ -11,7 +12,7 @@
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -208,8 +208,8 @@
+@@ -261,8 +261,8 @@ along with GCC; see the file COPYING3.
    "%{G:-G} \
     %{YP,*} \
     %{R*} \

--- a/build/gcc7/patches/never-omit-frame-pointer.patch
+++ b/build/gcc7/patches/never-omit-frame-pointer.patch
@@ -1,0 +1,19 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
+@@ -6281,6 +6281,15 @@ ix86_option_override_internal (bool main
+       free (str);
+     }
+ 
++  /*
++   * We never want to omit the frame pointer, regardless of the optimisation
++   * level or options to gcc - we like stack traces too much and it is of
++   * questionable benefit anyway, even on i386.
++   */
++
++  flag_omit_frame_pointer = 0;
++  opts->x_flag_omit_frame_pointer = 0;
++
+   /* Save the initial options in case the user does function specific
+      options.  */
+   if (main_args_p)

--- a/build/gcc7/patches/no-lrt.patch
+++ b/build/gcc7/patches/no-lrt.patch
@@ -1,6 +1,6 @@
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/libstdc++-v3/acinclude.m4 gcc-7.3.0/libstdc++-v3/acinclude.m4
---- gcc-7.3.0~/libstdc++-v3/acinclude.m4	2017-06-16 12:18:53.726871000 +0000
-+++ gcc-7.3.0/libstdc++-v3/acinclude.m4	2018-05-08 14:43:36.619391807 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/acinclude.m4 a/libstdc++-v3/acinclude.m4
+--- a~/libstdc++-v3/acinclude.m4	1970-01-01 00:00:00
++++ a/libstdc++-v3/acinclude.m4	1970-01-01 00:00:00
 @@ -1434,7 +1434,7 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME]
          ac_has_nanosleep=yes
          ;;
@@ -10,9 +10,9 @@ diff -prwuN '--exclude=*.orig' gcc-7.3.0~/libstdc++-v3/acinclude.m4 gcc-7.3.0/li
          ac_has_clock_monotonic=yes
          ac_has_clock_realtime=yes
          ac_has_nanosleep=yes
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/libstdc++-v3/configure gcc-7.3.0/libstdc++-v3/configure
---- gcc-7.3.0~/libstdc++-v3/configure	2017-06-21 08:55:52.630537000 +0000
-+++ gcc-7.3.0/libstdc++-v3/configure	2018-05-08 14:43:36.630504689 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/configure a/libstdc++-v3/configure
+--- a~/libstdc++-v3/configure	1970-01-01 00:00:00
++++ a/libstdc++-v3/configure	1970-01-01 00:00:00
 @@ -20576,7 +20576,7 @@ $as_echo "$glibcxx_glibc217" >&6; }
          ac_has_nanosleep=yes
          ;;

--- a/build/gcc7/patches/patch-libgo_runtime_proc.c
+++ b/build/gcc7/patches/patch-libgo_runtime_proc.c
@@ -2,9 +2,9 @@ $NetBSD: patch-libgo_runtime_proc.c,v 1.1 2013/04/02 09:57:52 jperkin Exp $
 
 SunOS libelf does not support largefile.
 
-diff -prwuN '--exclude=*.orig' gcc-7.3.0~/libgo/runtime/proc.c gcc-7.3.0/libgo/runtime/proc.c
---- gcc-7.3.0~/libgo/runtime/proc.c	2017-01-26 19:05:16.829028000 +0000
-+++ gcc-7.3.0/libgo/runtime/proc.c	2018-05-08 14:43:28.848574359 +0000
+diff -wpruN '--exclude=*.orig' a~/libgo/runtime/proc.c a/libgo/runtime/proc.c
+--- a~/libgo/runtime/proc.c	1970-01-01 00:00:00
++++ a/libgo/runtime/proc.c	1970-01-01 00:00:00
 @@ -12,6 +12,10 @@
  #include "config.h"
  

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -12,3 +12,4 @@ no-lrt.patch
 0012-16-update-cmn_err-format-specifier.patch
 0013-19-cmn_err-b-conversion-should-accept-0-flag.patch
 1000-ld-flags.patch
+never-omit-frame-pointer.patch

--- a/build/gcc8/build.sh
+++ b/build/gcc8/build.sh
@@ -30,8 +30,8 @@ PKG=developer/gcc8
 PROG=gcc
 VER=8.2.0
 VERHUMAN=$VER
-SUMMARY="gcc ${VER}"
-DESC="$SUMMARY"
+SUMMARY="gcc $VER"
+DESC="The GNU Compiler Collection"
 
 GCCMAJOR=${VER%%.*}
 OPT=/opt/gcc-$GCCMAJOR
@@ -79,6 +79,7 @@ CONFIGURE_OPTS="
     --enable-__cxa_atexit
     --enable-initfini-array
     --disable-libitm
+    enable_frame_pointer=yes
 "
 CONFIGURE_OPTS_WS="
     --with-boot-cflags=\"-g -O2\"

--- a/build/gcc8/patches/0002-compare_tests-Use-nawk-on-OmniOS.patch
+++ b/build/gcc8/patches/0002-compare_tests-Use-nawk-on-OmniOS.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 26 Jan 2016 14:24:11 -0500
 Subject: [PATCH 02/12] compare_tests: Use nawk on OmniOS
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/contrib/compare_tests gcc-8.1.0/contrib/compare_tests
---- gcc-8.1.0~/contrib/compare_tests	2018-02-19 08:03:17.000000000 +0000
-+++ gcc-8.1.0/contrib/compare_tests	2018-05-24 11:11:51.356020087 +0000
+diff -wpruN '--exclude=*.orig' a~/contrib/compare_tests a/contrib/compare_tests
+--- a~/contrib/compare_tests	1970-01-01 00:00:00
++++ a/contrib/compare_tests	1970-01-01 00:00:00
 @@ -108,8 +108,15 @@ elif [ -d "$1" -o -d "$2" ] ; then
  	usage "Must specify either two directories or two files"
  fi

--- a/build/gcc8/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
+++ b/build/gcc8/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
@@ -3,10 +3,10 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 5 Mar 2014 04:12:52 +0000
 Subject: [PATCH 03/12] gcc: enable the .eh_frame based unwinder
 
-diff -ru gcc-8.1.0.orig/gcc/configure gcc-8.1.0/gcc/configure
---- gcc-8.1.0.orig/gcc/configure	2018-04-18 09:46:58.000000000 +0000
-+++ gcc-8.1.0/gcc/configure	2018-07-13 13:01:58.827021646 +0000
-@@ -22808,10 +22808,11 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/configure a/gcc/configure
+--- a~/gcc/configure	1970-01-01 00:00:00
++++ a/gcc/configure	1970-01-01 00:00:00
+@@ -22808,10 +22808,11 @@ if test $in_tree_ld != yes ; then
  	# linker is configured.
  	ld_ver=`$gcc_cv_ld -V 2>&1`
  	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
@@ -19,7 +19,7 @@ diff -ru gcc-8.1.0.orig/gcc/configure gcc-8.1.0/gcc/configure
  	fi
  	;;
      esac
-@@ -28309,6 +28310,8 @@
+@@ -28309,6 +28310,8 @@ elif test x$gcc_cv_ld != x; then
          # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
          if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
            gcc_cv_ld_eh_frame_hdr=yes
@@ -28,10 +28,10 @@ diff -ru gcc-8.1.0.orig/gcc/configure gcc-8.1.0/gcc/configure
          fi
          ;;
      esac
-diff -ru gcc-8.1.0.orig/gcc/configure.ac gcc-8.1.0/gcc/configure.ac
---- gcc-8.1.0.orig/gcc/configure.ac	2018-04-18 09:46:58.000000000 +0000
-+++ gcc-8.1.0/gcc/configure.ac	2018-07-13 13:02:10.342025120 +0000
-@@ -2604,10 +2604,11 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/configure.ac a/gcc/configure.ac
+--- a~/gcc/configure.ac	1970-01-01 00:00:00
++++ a/gcc/configure.ac	1970-01-01 00:00:00
+@@ -2604,10 +2604,11 @@ if test $in_tree_ld != yes ; then
  	# linker is configured.
  	ld_ver=`$gcc_cv_ld -V 2>&1`
  	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
@@ -44,7 +44,7 @@ diff -ru gcc-8.1.0.orig/gcc/configure.ac gcc-8.1.0/gcc/configure.ac
  	fi
  	;;
      esac
-@@ -5131,6 +5132,8 @@
+@@ -5131,6 +5132,8 @@ elif test x$gcc_cv_ld != x; then
          # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
          if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
            gcc_cv_ld_eh_frame_hdr=yes

--- a/build/gcc8/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
+++ b/build/gcc8/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 11 Mar 2014 21:50:30 +0000
 Subject: [PATCH 04/12] intl: Don't use UTF-8 quotes.  Ever.
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/intl.c gcc-8.1.0/gcc/intl.c
---- gcc-8.1.0~/gcc/intl.c	2018-01-03 10:03:58.000000000 +0000
-+++ gcc-8.1.0/gcc/intl.c	2018-05-24 11:09:52.695857324 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/intl.c a/gcc/intl.c
+--- a~/gcc/intl.c	1970-01-01 00:00:00
++++ a/gcc/intl.c	1970-01-01 00:00:00
 @@ -74,17 +74,11 @@ gcc_init_libintl (void)
  
    if (!strcmp (open_quote, "`") && !strcmp (close_quote, "'"))

--- a/build/gcc8/patches/0005-Implement-fstrict-calling-conventions.patch
+++ b/build/gcc8/patches/0005-Implement-fstrict-calling-conventions.patch
@@ -11,10 +11,10 @@ something we desire.
 Implement a flag which disables this behaviour, enabled by default.  The flag is
 global, though only effective on i386, to more easily allow its globalization
 later which, given the odds, is likely to be necessary.
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/common.opt gcc-8.1.0/gcc/common.opt
---- gcc-8.1.0~/gcc/common.opt	2018-03-28 14:51:09.000000000 +0000
-+++ gcc-8.1.0/gcc/common.opt	2018-05-24 11:10:01.513110905 +0000
-@@ -2414,6 +2414,10 @@ fstrict-aliasing
+diff -wpruN '--exclude=*.orig' a~/gcc/common.opt a/gcc/common.opt
+--- a~/gcc/common.opt	1970-01-01 00:00:00
++++ a/gcc/common.opt	1970-01-01 00:00:00
+@@ -2418,6 +2418,10 @@ fstrict-aliasing
  Common Report Var(flag_strict_aliasing) Optimization
  Assume strict aliasing rules apply.
  
@@ -25,10 +25,10 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/common.opt gcc-8.1.0/gcc/common.op
  fstrict-overflow
  Common Report
  Treat signed overflow as undefined.  Negated as -fwrapv -fwrapv-pointer.
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/config/i386/i386.c
---- gcc-8.1.0~/gcc/config/i386/i386.c	2018-04-25 17:31:20.000000000 +0000
-+++ gcc-8.1.0/gcc/config/i386/i386.c	2018-05-24 11:10:01.523151611 +0000
-@@ -6730,6 +6730,7 @@ ix86_function_regparm (const_tree type,
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
+@@ -6733,6 +6733,7 @@ ix86_function_regparm (const_tree type,
  	 and callee not, or vice versa.  Instead look at whether the callee
  	 is optimized or not.  */
        if (target && opt_for_fn (target->decl, optimize)
@@ -36,7 +36,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  	  && !(profile_flag && !flag_fentry))
  	{
  	  cgraph_local_info *i = &target->local;
-@@ -6827,6 +6828,7 @@ ix86_function_sseregparm (const_tree typ
+@@ -6830,6 +6831,7 @@ ix86_function_sseregparm (const_tree typ
        /* TARGET_SSE_MATH */
        && (target_opts_for_fn (target->decl)->x_ix86_fpmath & FPMATH_SSE)
        && opt_for_fn (target->decl, optimize)
@@ -44,10 +44,10 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
        && !(profile_flag && !flag_fentry))
      {
        cgraph_local_info *i = &target->local;
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/invoke.texi
---- gcc-8.1.0~/gcc/doc/invoke.texi	2018-04-26 13:52:59.000000000 +0000
-+++ gcc-8.1.0/gcc/doc/invoke.texi	2018-05-24 11:10:01.528691725 +0000
-@@ -9185,6 +9185,12 @@ int f() @{
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
+@@ -9199,6 +9199,12 @@ int f() @{
  The @option{-fstrict-aliasing} option is enabled at levels
  @option{-O2}, @option{-O3}, @option{-Os}.
  
@@ -60,9 +60,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/
  @item -falign-functions
  @itemx -falign-functions=@var{n}
  @opindex falign-functions
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/local.c gcc-8.1.0/gcc/testsuite/gcc.target/i386/local.c
---- gcc-8.1.0~/gcc/testsuite/gcc.target/i386/local.c	2015-12-29 10:32:21.000000000 +0000
-+++ gcc-8.1.0/gcc/testsuite/gcc.target/i386/local.c	2018-05-24 11:10:01.528974387 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/local.c a/gcc/testsuite/gcc.target/i386/local.c
+--- a~/gcc/testsuite/gcc.target/i386/local.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/local.c	1970-01-01 00:00:00
 @@ -1,5 +1,6 @@
  /* { dg-do compile } */
 -/* { dg-options "-O2 -funit-at-a-time" } */
@@ -71,9 +71,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/local.c 
  /* { dg-final { scan-assembler "magic\[^\\n\]*eax" { target ia32 } } } */
  /* { dg-final { scan-assembler "magic\[^\\n\]*(edi|ecx)" { target { ! ia32 } } } } */
  
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/strict-cc.c gcc-8.1.0/gcc/testsuite/gcc.target/i386/strict-cc.c
---- gcc-8.1.0~/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-8.1.0/gcc/testsuite/gcc.target/i386/strict-cc.c	2018-05-24 11:10:01.529200959 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/strict-cc.c a/gcc/testsuite/gcc.target/i386/strict-cc.c
+--- a~/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/strict-cc.c	1970-01-01 00:00:00
 @@ -0,0 +1,24 @@
 +/* { dg-do compile { target { ilp32 } } } */
 +/* { dg-options "-O2 -funit-at-a-time -fstrict-calling-conventions"  } */

--- a/build/gcc8/patches/0006-allow-the-global-disabling-of-function-cloning.patch
+++ b/build/gcc8/patches/0006-allow-the-global-disabling-of-function-cloning.patch
@@ -11,10 +11,10 @@ having the actual source symbol name).
 
 This allows any function cloning to be disabled, and makes any such
 optimization ineffective, and our source safe for debuggers everywhere.
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/common.opt gcc-8.1.0/gcc/common.opt
---- gcc-8.1.0~/gcc/common.opt	2018-05-24 11:10:01.513110905 +0000
-+++ gcc-8.1.0/gcc/common.opt	2018-05-24 11:10:10.591926226 +0000
-@@ -1109,6 +1109,11 @@ fcode-hoisting
+diff -wpruN '--exclude=*.orig' a~/gcc/common.opt a/gcc/common.opt
+--- a~/gcc/common.opt	1970-01-01 00:00:00
++++ a/gcc/common.opt	1970-01-01 00:00:00
+@@ -1113,6 +1113,11 @@ fcode-hoisting
  Common Report Var(flag_code_hoisting) Optimization
  Enable code hoisting.
  
@@ -26,9 +26,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/common.opt gcc-8.1.0/gcc/common.op
  fcombine-stack-adjustments
  Common Report Var(flag_combine_stack_adjustments) Optimization
  Looks for opportunities to reduce stack adjustments and stack references.
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/invoke.texi
---- gcc-8.1.0~/gcc/doc/invoke.texi	2018-05-24 11:10:01.528691725 +0000
-+++ gcc-8.1.0/gcc/doc/invoke.texi	2018-05-24 11:10:10.597416961 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
 @@ -371,7 +371,7 @@ Objective-C and Objective-C++ Dialects}.
  -fauto-inc-dec  -fbranch-probabilities @gol
  -fbranch-target-load-optimize  -fbranch-target-load-optimize2 @gol
@@ -38,7 +38,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/
  -fcompare-elim  -fcprop-registers  -fcrossjumping @gol
  -fcse-follow-jumps  -fcse-skip-blocks  -fcx-fortran-rules @gol
  -fcx-limited-range @gol
-@@ -8506,6 +8506,15 @@ and then tries to find ways to combine t
+@@ -8513,6 +8513,15 @@ and then tries to find ways to combine t
  
  Enabled by default at @option{-O1} and higher.
  
@@ -54,9 +54,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/
  @item -fipa-ra
  @opindex fipa-ra
  Use caller save registers for allocation if those registers are not used by
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/tree-inline.c gcc-8.1.0/gcc/tree-inline.c
---- gcc-8.1.0~/gcc/tree-inline.c	2018-03-09 19:12:29.000000000 +0000
-+++ gcc-8.1.0/gcc/tree-inline.c	2018-05-24 11:10:10.598509488 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/tree-inline.c a/gcc/tree-inline.c
+--- a~/gcc/tree-inline.c	1970-01-01 00:00:00
++++ a/gcc/tree-inline.c	1970-01-01 00:00:00
 @@ -5689,7 +5689,8 @@ bool
  tree_versionable_function_p (tree fndecl)
  {

--- a/build/gcc8/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
+++ b/build/gcc8/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
@@ -4,9 +4,9 @@ Date: Tue, 4 Mar 2014 02:58:33 +0000
 Subject: [PATCH 07/12] strict-cc2: check that disabling function cloning
  prevents constant propagation eliding or changing arguments
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c gcc-8.1.0/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
---- gcc-8.1.0~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-8.1.0/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	2018-05-24 11:10:19.570048834 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
+--- a~/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c	1970-01-01 00:00:00
 @@ -0,0 +1,27 @@
 +/* { dg-do compile { target { ilp32 } } } */
 +/* { dg-options "-O2 -funit-at-a-time -fipa-sra -fno-clone-functions"  } */

--- a/build/gcc8/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
+++ b/build/gcc8/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
@@ -3,9 +3,9 @@ From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 22:11:03 +0000
 Subject: [PATCH 08/12] sol2: enable full __cxa_atexit support
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/sol2.h gcc-8.1.0/gcc/config/sol2.h
---- gcc-8.1.0~/gcc/config/sol2.h	2018-01-30 21:18:40.000000000 +0000
-+++ gcc-8.1.0/gcc/config/sol2.h	2018-05-24 11:10:28.740109324 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
 @@ -206,7 +206,7 @@ along with GCC; see the file COPYING3.
  				   shared|" PIE_SPEC ":crtbeginS.o%s; \
  				   :crtbegin.o%s}"
@@ -24,9 +24,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/sol2.h gcc-8.1.0/gcc/config
  #endif
  
  #undef  ENDFILE_SPEC
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libgcc/config.host gcc-8.1.0/libgcc/config.host
---- gcc-8.1.0~/libgcc/config.host	2018-04-06 20:04:17.000000000 +0000
-+++ gcc-8.1.0/libgcc/config.host	2018-05-24 11:10:28.740693416 +0000
+diff -wpruN '--exclude=*.orig' a~/libgcc/config.host a/libgcc/config.host
+--- a~/libgcc/config.host	1970-01-01 00:00:00
++++ a/libgcc/config.host	1970-01-01 00:00:00
 @@ -267,7 +267,7 @@ case ${host} in
  *-*-solaris2*)
    # Unless linker support and dl_iterate_phdr are present,

--- a/build/gcc8/patches/0009-symtab-disable-non-interposable-alias-generation-if-.patch
+++ b/build/gcc8/patches/0009-symtab-disable-non-interposable-alias-generation-if-.patch
@@ -4,10 +4,10 @@ Date: Sun, 24 Jan 2016 18:30:00 +0000
 Subject: [PATCH 09/12] symtab: disable non-interposable alias generation if
  function cloning is disabled
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/symtab.c gcc-8.1.0/gcc/symtab.c
---- gcc-8.1.0~/gcc/symtab.c	2018-04-26 20:05:09.000000000 +0000
-+++ gcc-8.1.0/gcc/symtab.c	2018-05-24 11:10:37.764222822 +0000
-@@ -1764,6 +1764,10 @@ symtab_node::noninterposable_alias (void
+diff -wpruN '--exclude=*.orig' a~/gcc/symtab.c a/gcc/symtab.c
+--- a~/gcc/symtab.c	1970-01-01 00:00:00
++++ a/gcc/symtab.c	1970-01-01 00:00:00
+@@ -1771,6 +1771,10 @@ symtab_node::noninterposable_alias (void
    tree new_decl;
    symtab_node *new_node = NULL;
  

--- a/build/gcc8/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
+++ b/build/gcc8/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
@@ -29,10 +29,10 @@ Originally implemented in:
         	ix86_expand_prologue, ix86_expand_epilogue): Handle -msave-args.
 
         git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/csl-sol210-3_4-branch@101443 138bc75d-0d04-0410-961f-82ee72b054a4
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/config/i386/i386.c
---- gcc-8.1.0~/gcc/config/i386/i386.c	2018-05-24 11:10:01.523151611 +0000
-+++ gcc-8.1.0/gcc/config/i386/i386.c	2018-05-24 11:10:46.984020638 +0000
-@@ -814,6 +814,8 @@ static unsigned int ix86_minimum_incomin
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
+@@ -817,6 +817,8 @@ static unsigned int ix86_minimum_incomin
  
  static enum calling_abi ix86_function_abi (const_tree);
  
@@ -41,7 +41,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  
  #ifndef SUBTARGET32_DEFAULT_CPU
  #define SUBTARGET32_DEFAULT_CPU "i386"
-@@ -4482,6 +4484,9 @@ ix86_option_override_internal (bool main
+@@ -4485,6 +4487,9 @@ ix86_option_override_internal (bool main
        &= ~((OPTION_MASK_ISA_BMI | OPTION_MASK_ISA_BMI2 | OPTION_MASK_ISA_TBM)
  	   & ~opts->x_ix86_isa_flags_explicit);
  
@@ -51,7 +51,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    /* Validate -mpreferred-stack-boundary= value or default it to
       PREFERRED_STACK_BOUNDARY_DEFAULT.  */
    ix86_preferred_stack_boundary = PREFERRED_STACK_BOUNDARY_DEFAULT;
-@@ -10741,7 +10746,7 @@ ix86_can_use_return_insn_p (void)
+@@ -10744,7 +10749,7 @@ ix86_can_use_return_insn_p (void)
  
    struct ix86_frame &frame = cfun->machine->frame;
    return (frame.stack_pointer_offset == UNITS_PER_WORD
@@ -60,7 +60,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  }
  
  /* Value should be nonzero if functions must have frame pointers.
-@@ -10765,6 +10770,9 @@ ix86_frame_pointer_required (void)
+@@ -10768,6 +10773,9 @@ ix86_frame_pointer_required (void)
    if (TARGET_32BIT_MS_ABI && cfun->calls_setjmp)
      return true;
  
@@ -70,7 +70,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    /* Win64 SEH, very large frames need a frame-pointer as maximum stack
       allocation is 4GB.  */
    if (TARGET_64BIT_MS_ABI && get_frame_size () > SEH_MAX_FRAME_SIZE)
-@@ -11673,6 +11681,7 @@ ix86_compute_frame_layout (void)
+@@ -11676,6 +11684,7 @@ ix86_compute_frame_layout (void)
  
    frame->nregs = ix86_nsaved_regs ();
    frame->nsseregs = ix86_nsaved_sseregs ();
@@ -78,7 +78,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  
    /* 64-bit MS ABI seem to require stack alignment to be always 16,
       except for function prologues, leaf functions and when the defult
-@@ -11735,7 +11744,8 @@ ix86_compute_frame_layout (void)
+@@ -11738,7 +11747,8 @@ ix86_compute_frame_layout (void)
      }
  
    frame->save_regs_using_mov
@@ -88,7 +88,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
         /* If static stack checking is enabled and done with probes,
  	  the registers need to be saved before allocating the frame.  */
         && flag_stack_check != STATIC_BUILTIN_STACK_CHECK);
-@@ -11755,6 +11765,13 @@ ix86_compute_frame_layout (void)
+@@ -11758,6 +11768,13 @@ ix86_compute_frame_layout (void)
    /* The traditional frame pointer location is at the top of the frame.  */
    frame->hard_frame_pointer_offset = offset;
  
@@ -102,7 +102,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    /* Register save area */
    offset += frame->nregs * UNITS_PER_WORD;
    frame->reg_save_offset = offset;
-@@ -11893,7 +11910,7 @@ ix86_compute_frame_layout (void)
+@@ -11896,7 +11913,7 @@ ix86_compute_frame_layout (void)
    /* Size prologue needs to allocate.  */
    to_allocate = offset - frame->sse_reg_save_offset;
  
@@ -111,7 +111,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
        || (TARGET_64BIT && to_allocate >= HOST_WIDE_INT_C (0x80000000))
        /* If stack clash probing needs a loop, then it needs a
  	 scratch register.  But the returned register is only guaranteed
-@@ -11912,7 +11929,11 @@ ix86_compute_frame_layout (void)
+@@ -11915,7 +11932,11 @@ ix86_compute_frame_layout (void)
      {
        frame->red_zone_size = to_allocate;
        if (frame->save_regs_using_mov)
@@ -123,7 +123,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
        if (frame->red_zone_size > RED_ZONE_SIZE - RED_ZONE_RESERVE)
  	frame->red_zone_size = RED_ZONE_SIZE - RED_ZONE_RESERVE;
      }
-@@ -11943,6 +11964,23 @@ ix86_compute_frame_layout (void)
+@@ -11946,6 +11967,23 @@ ix86_compute_frame_layout (void)
  	  frame->hard_frame_pointer_offset = frame->stack_pointer_offset - 128;
  	}
      }
@@ -147,7 +147,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  }
  
  /* This is semi-inlined memory_address_length, but simplified
-@@ -12159,6 +12197,24 @@ ix86_emit_save_regs (void)
+@@ -12162,6 +12200,24 @@ ix86_emit_save_regs (void)
    unsigned int regno;
    rtx_insn *insn;
  
@@ -172,7 +172,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    for (regno = FIRST_PSEUDO_REGISTER - 1; regno-- > 0; )
      if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
        {
-@@ -12245,9 +12301,30 @@ ix86_emit_save_reg_using_mov (machine_mo
+@@ -12248,9 +12304,30 @@ ix86_emit_save_reg_using_mov (machine_mo
  /* Emit code to save registers using MOV insns.
     First register is stored at CFA - CFA_OFFSET.  */
  static void
@@ -204,7 +204,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  
    for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
      if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
-@@ -13731,7 +13808,7 @@ ix86_expand_prologue (void)
+@@ -13734,7 +13811,7 @@ ix86_expand_prologue (void)
  	}
      }
  
@@ -213,7 +213,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    sse_registers_saved = (frame.nsseregs == 0);
    save_stub_call_needed = (m->call_ms2sysv);
    gcc_assert (sse_registers_saved || !save_stub_call_needed);
-@@ -13773,6 +13850,7 @@ ix86_expand_prologue (void)
+@@ -13776,6 +13853,7 @@ ix86_expand_prologue (void)
  	{
  	  ix86_emit_save_regs ();
  	  int_registers_saved = true;
@@ -221,7 +221,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  	  gcc_assert (m->fs.sp_offset == frame.reg_save_offset);
  	}
  
-@@ -13784,7 +13862,7 @@ ix86_expand_prologue (void)
+@@ -13787,7 +13865,7 @@ ix86_expand_prologue (void)
  	       && (! TARGET_STACK_PROBE
  		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
  	{
@@ -230,7 +230,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  	  int_registers_saved = true;
  	}
      }
-@@ -14073,7 +14151,7 @@ ix86_expand_prologue (void)
+@@ -14076,7 +14154,7 @@ ix86_expand_prologue (void)
      }
  
    if (!int_registers_saved)
@@ -239,7 +239,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    if (!sse_registers_saved)
      ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
    else if (save_stub_call_needed)
-@@ -14108,6 +14186,7 @@ ix86_expand_prologue (void)
+@@ -14111,6 +14189,7 @@ ix86_expand_prologue (void)
       relative to the value of the stack pointer at the end of the function
       prologue, and moving instructions that access redzone area via frame
       pointer inside push sequence violates this assumption.  */
@@ -247,7 +247,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    if (frame_pointer_needed && frame.red_zone_size)
      emit_insn (gen_memory_blockage ());
  
-@@ -14491,6 +14570,7 @@ ix86_expand_epilogue (int style)
+@@ -14494,6 +14573,7 @@ ix86_expand_epilogue (int style)
  
    /* See the comment about red zone and frame
       pointer usage in ix86_expand_prologue.  */
@@ -255,7 +255,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    if (frame_pointer_needed && frame.red_zone_size)
      emit_insn (gen_memory_blockage ());
  
-@@ -14722,6 +14802,36 @@ ix86_expand_epilogue (int style)
+@@ -14725,6 +14805,36 @@ ix86_expand_epilogue (int style)
        ix86_emit_restore_regs_using_pop ();
      }
  
@@ -292,7 +292,7 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
    /* If we used a stack pointer and haven't already got rid of it,
       then do so now.  */
    if (m->fs.fp_valid)
-@@ -15775,6 +15885,19 @@ ix86_cannot_force_const_mem (machine_mod
+@@ -15778,6 +15888,19 @@ ix86_cannot_force_const_mem (machine_mod
    return !ix86_legitimate_constant_p (mode, x);
  }
  
@@ -312,9 +312,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.c gcc-8.1.0/gcc/c
  /*  Nonzero if the symbol is marked as dllimport, or as stub-variable,
      otherwise zero.  */
  
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.h gcc-8.1.0/gcc/config/i386/i386.h
---- gcc-8.1.0~/gcc/config/i386/i386.h	2018-04-20 13:30:13.000000000 +0000
-+++ gcc-8.1.0/gcc/config/i386/i386.h	2018-05-24 11:10:46.984924305 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.h a/gcc/config/i386/i386.h
+--- a~/gcc/config/i386/i386.h	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.h	1970-01-01 00:00:00
 @@ -2419,6 +2419,11 @@ enum avx_u128_state
  
     saved frame pointer			if frame_pointer_needed
@@ -343,9 +343,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.h gcc-8.1.0/gcc/c
    HOST_WIDE_INT reg_save_offset;
    HOST_WIDE_INT stack_realign_allocate;
    HOST_WIDE_INT stack_realign_offset;
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.opt gcc-8.1.0/gcc/config/i386/i386.opt
---- gcc-8.1.0~/gcc/config/i386/i386.opt	2018-04-24 16:56:04.000000000 +0000
-+++ gcc-8.1.0/gcc/config/i386/i386.opt	2018-05-24 11:10:46.985315625 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.opt a/gcc/config/i386/i386.opt
+--- a~/gcc/config/i386/i386.opt	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.opt	1970-01-01 00:00:00
 @@ -509,6 +509,16 @@ mtls-direct-seg-refs
  Target Report Mask(TLS_DIRECT_SEG_REFS)
  Use direct references against %gs when accessing tls data.
@@ -363,10 +363,10 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/i386/i386.opt gcc-8.1.0/gcc
  mtune=
  Target RejectNegative Joined Var(ix86_tune_string)
  Schedule code for given CPU.
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/invoke.texi
---- gcc-8.1.0~/gcc/doc/invoke.texi	2018-05-24 11:10:10.597416961 +0000
-+++ gcc-8.1.0/gcc/doc/invoke.texi	2018-05-24 11:10:46.989890877 +0000
-@@ -14632,6 +14632,10 @@ dynamically linked.  This is the default
+diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
+--- a~/gcc/doc/invoke.texi	1970-01-01 00:00:00
++++ a/gcc/doc/invoke.texi	1970-01-01 00:00:00
+@@ -14640,6 +14640,10 @@ dynamically linked.  This is the default
  Generate code for the large code model.  This makes no assumptions about
  addresses and sizes of sections.  Programs can be statically linked only.
  
@@ -377,10 +377,10 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/doc/invoke.texi gcc-8.1.0/gcc/doc/
  @item -mstrict-align
  @opindex mstrict-align
  Avoid generating memory accesses that may not be aligned on a natural object
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/dwarf2out.c gcc-8.1.0/gcc/dwarf2out.c
---- gcc-8.1.0~/gcc/dwarf2out.c	2018-04-12 14:18:17.000000000 +0000
-+++ gcc-8.1.0/gcc/dwarf2out.c	2018-05-24 11:10:46.995505404 +0000
-@@ -23169,6 +23169,11 @@ gen_subprogram_die (tree decl, dw_die_re
+diff -wpruN '--exclude=*.orig' a~/gcc/dwarf2out.c a/gcc/dwarf2out.c
+--- a~/gcc/dwarf2out.c	1970-01-01 00:00:00
++++ a/gcc/dwarf2out.c	1970-01-01 00:00:00
+@@ -23183,6 +23183,11 @@ gen_subprogram_die (tree decl, dw_die_re
      /* Add the calling convention attribute if requested.  */
      add_calling_convention_attribute (subr_die, decl);
  
@@ -392,9 +392,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/dwarf2out.c gcc-8.1.0/gcc/dwarf2ou
    /* Output Dwarf info for all of the stuff within the body of the function
       (if it has one - it may be just a declaration).
  
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-args-mov.c gcc-8.1.0/gcc/testsuite/gcc.target/i386/msave-args-mov.c
---- gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-8.1.0/gcc/testsuite/gcc.target/i386/msave-args-mov.c	2018-05-24 11:10:46.995814160 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/msave-args-mov.c a/gcc/testsuite/gcc.target/i386/msave-args-mov.c
+--- a~/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/msave-args-mov.c	1970-01-01 00:00:00
 @@ -0,0 +1,26 @@
 +/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
 +/* { dg-options "-msave-args -mforce-save-regs-using-mov -save-temps" } */
@@ -422,9 +422,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-ar
 +/* { dg-final { scan-assembler "movq\t%rcx, -32\\(%rbp\\)" } } */
 +/* { dg-final { scan-assembler "movq\t%r8, -40\\(%rbp\\)" } } */
 +/* { dg-final { cleanup-saved-temps } } */
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-args-push.c gcc-8.1.0/gcc/testsuite/gcc.target/i386/msave-args-push.c
---- gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-8.1.0/gcc/testsuite/gcc.target/i386/msave-args-push.c	2018-05-24 11:10:46.995992700 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/testsuite/gcc.target/i386/msave-args-push.c a/gcc/testsuite/gcc.target/i386/msave-args-push.c
+--- a~/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00
++++ a/gcc/testsuite/gcc.target/i386/msave-args-push.c	1970-01-01 00:00:00
 @@ -0,0 +1,26 @@
 +/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
 +/* { dg-options "-msave-args -save-temps " } */
@@ -452,9 +452,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/testsuite/gcc.target/i386/msave-ar
 +/* { dg-final { scan-assembler "pushq\t%rcx" } } */
 +/* { dg-final { scan-assembler "pushq\t%r8" } } */
 +/* { dg-final { cleanup-saved-temps } } */
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/include/dwarf2.def gcc-8.1.0/include/dwarf2.def
---- gcc-8.1.0~/include/dwarf2.def	2018-02-09 02:22:11.000000000 +0000
-+++ gcc-8.1.0/include/dwarf2.def	2018-05-24 11:10:46.996280240 +0000
+diff -wpruN '--exclude=*.orig' a~/include/dwarf2.def a/include/dwarf2.def
+--- a~/include/dwarf2.def	1970-01-01 00:00:00
++++ a/include/dwarf2.def	1970-01-01 00:00:00
 @@ -459,6 +459,8 @@ DW_TAG (DW_AT_GNU_denominator, 0x2304)
  /* Biased integer extension.
     See https://gcc.gnu.org/wiki/DW_AT_GNU_bias .  */

--- a/build/gcc8/patches/0011-16-update-cmn_err-format-specifier.patch
+++ b/build/gcc8/patches/0011-16-update-cmn_err-format-specifier.patch
@@ -4,9 +4,9 @@ Date: Sat, 5 Nov 2016 05:26:47 +0300
 Subject: [PATCH 11/12] 16 update cmn_err format specifier Reviewed by: Richard
  Lowe <richlowe@richlowe.net> Reviewed by: Robert Mustacchi <rm@joyent.com>
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/sol2-c.c gcc-8.1.0/gcc/config/sol2-c.c
---- gcc-8.1.0~/gcc/config/sol2-c.c	2018-01-03 10:03:58.000000000 +0000
-+++ gcc-8.1.0/gcc/config/sol2-c.c	2018-05-24 11:10:56.152718367 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2-c.c a/gcc/config/sol2-c.c
+--- a~/gcc/config/sol2-c.c	1970-01-01 00:00:00
++++ a/gcc/config/sol2-c.c	1970-01-01 00:00:00
 @@ -40,7 +40,10 @@ static const format_length_info cmn_err_
  
  static const format_flag_spec cmn_err_flag_specs[] =

--- a/build/gcc8/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
+++ b/build/gcc8/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
@@ -5,9 +5,9 @@ Subject: [PATCH 12/12] 19 cmn_err %b conversion should accept 0 flag Reviewed
  by: Robert Mustacchi <rm@joyent.com> Reviewed by: Richard Lowe
  <richlowe@richlowe.net>
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/gcc/config/sol2-c.c gcc-8.1.0/gcc/config/sol2-c.c
---- gcc-8.1.0~/gcc/config/sol2-c.c	2018-05-24 11:10:56.152718367 +0000
-+++ gcc-8.1.0/gcc/config/sol2-c.c	2018-05-24 11:11:05.432090207 +0000
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2-c.c a/gcc/config/sol2-c.c
+--- a~/gcc/config/sol2-c.c	1970-01-01 00:00:00
++++ a/gcc/config/sol2-c.c	1970-01-01 00:00:00
 @@ -67,7 +67,7 @@ static const format_char_info cmn_err_ch
    { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
    { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },

--- a/build/gcc8/patches/1000-ld-flags.patch
+++ b/build/gcc8/patches/1000-ld-flags.patch
@@ -1,6 +1,7 @@
---- ./gcc/config/sol2.h.orig	2016-05-08 21:13:10.810423614 +0200
-+++ ./gcc/config/sol2.h	2016-05-08 21:16:55.681535743 +0200
-@@ -195,8 +195,8 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
+@@ -269,8 +269,8 @@ along with GCC; see the file COPYING3.
    "%{G:-G} \
     %{YP,*} \
     %{R*} \
@@ -11,7 +12,7 @@
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -208,8 +208,8 @@
+@@ -282,8 +282,8 @@ along with GCC; see the file COPYING3.
    "%{G:-G} \
     %{YP,*} \
     %{R*} \

--- a/build/gcc8/patches/1005-use-compare-debug.patch
+++ b/build/gcc8/patches/1005-use-compare-debug.patch
@@ -4,9 +4,9 @@ From oi-userland
 For some reason avx_*.o and sse_*.o contain a lot of debug info in
 a way that makes stage2/stage3 comparison fail.
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/Makefile.in gcc-8.1.0/Makefile.in
---- gcc-8.1.0~/Makefile.in	2017-11-28 10:35:37.000000000 +0000
-+++ gcc-8.1.0/Makefile.in	2018-05-24 11:11:42.228598543 +0000
+diff -wpruN '--exclude=*.orig' a~/Makefile.in a/Makefile.in
+--- a~/Makefile.in	1970-01-01 00:00:00
++++ a/Makefile.in	1970-01-01 00:00:00
 @@ -544,7 +544,7 @@ STAGEautoprofile_TFLAGS = $(STAGE2_TFLAG
  STAGEautofeedback_CFLAGS = $(STAGE3_CFLAGS)
  STAGEautofeedback_TFLAGS = $(STAGE3_TFLAGS)

--- a/build/gcc8/patches/libgo_runtime_proc.patch
+++ b/build/gcc8/patches/libgo_runtime_proc.patch
@@ -2,9 +2,9 @@ $NetBSD: patch-libgo_runtime_proc.c,v 1.1 2013/04/02 09:57:52 jperkin Exp $
 
 SunOS libelf does not support largefile.
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libgo/runtime/proc.c gcc-8.1.0/libgo/runtime/proc.c
---- gcc-8.1.0~/libgo/runtime/proc.c	2018-02-02 00:16:43.000000000 +0000
-+++ gcc-8.1.0/libgo/runtime/proc.c	2018-05-24 11:11:14.606064265 +0000
+diff -wpruN '--exclude=*.orig' a~/libgo/runtime/proc.c a/libgo/runtime/proc.c
+--- a~/libgo/runtime/proc.c	1970-01-01 00:00:00
++++ a/libgo/runtime/proc.c	1970-01-01 00:00:00
 @@ -12,6 +12,10 @@
  #include "config.h"
  

--- a/build/gcc8/patches/libstdc++-aligned_alloc.patch
+++ b/build/gcc8/patches/libstdc++-aligned_alloc.patch
@@ -1,9 +1,9 @@
 
 Ensure we can find SunOS std::aligned_alloc if using it.
 
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/include/c_global/cstdlib gcc-8.1.0/libstdc++-v3/include/c_global/cstdlib
---- gcc-8.1.0~/libstdc++-v3/include/c_global/cstdlib	2018-03-12 22:52:16.000000000 +0000
-+++ gcc-8.1.0/libstdc++-v3/include/c_global/cstdlib	2018-05-24 11:11:33.048640973 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/include/c_global/cstdlib a/libstdc++-v3/include/c_global/cstdlib
+--- a~/libstdc++-v3/include/c_global/cstdlib	1970-01-01 00:00:00
++++ a/libstdc++-v3/include/c_global/cstdlib	1970-01-01 00:00:00
 @@ -78,9 +78,6 @@ namespace std
  
  // Get rid of those macros defined in <stdlib.h> in lieu of real functions.
@@ -24,9 +24,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/include/c_global/cstdlib 
    using ::atexit;
  #if __cplusplus >= 201103L
  # ifdef _GLIBCXX_HAVE_AT_QUICK_EXIT
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/libsupc++/new_opa.cc gcc-8.1.0/libstdc++-v3/libsupc++/new_opa.cc
---- gcc-8.1.0~/libstdc++-v3/libsupc++/new_opa.cc	2018-01-03 10:03:58.000000000 +0000
-+++ gcc-8.1.0/libstdc++-v3/libsupc++/new_opa.cc	2018-05-24 11:11:33.048910287 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/libsupc++/new_opa.cc a/libstdc++-v3/libsupc++/new_opa.cc
+--- a~/libstdc++-v3/libsupc++/new_opa.cc	1970-01-01 00:00:00
++++ a/libstdc++-v3/libsupc++/new_opa.cc	1970-01-01 00:00:00
 @@ -31,6 +31,10 @@
  using std::new_handler;
  using std::bad_alloc;

--- a/build/gcc8/patches/never-omit-frame-pointer.patch
+++ b/build/gcc8/patches/never-omit-frame-pointer.patch
@@ -1,0 +1,31 @@
+diff -wpruN '--exclude=*.orig' a~/gcc/config/i386/i386.c a/gcc/config/i386/i386.c
+--- a~/gcc/config/i386/i386.c	1970-01-01 00:00:00
++++ a/gcc/config/i386/i386.c	1970-01-01 00:00:00
+@@ -4934,6 +4934,15 @@ ix86_option_override_internal (bool main
+       free (str);
+     }
+ 
++  /*
++   * We never want to omit the frame pointer, regardless of the optimisation
++   * level or options to gcc - we like stack traces too much and it is of
++   * questionable benefit anyway, even on i386.
++   */
++
++  flag_omit_frame_pointer = 0;
++  opts->x_flag_omit_frame_pointer = 0;
++
+   /* Save the initial options in case the user does function specific
+      options.  */
+   if (main_args_p)
+diff -wpruN '--exclude=*.orig' a~/gcc/opts.c a/gcc/opts.c
+--- a~/gcc/opts.c	1970-01-01 00:00:00
++++ a/gcc/opts.c	1970-01-01 00:00:00
+@@ -476,7 +476,7 @@ static const struct default_options defa
+     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_pta, NULL, 1 },
+     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_fssa_phiopt, NULL, 1 },
+     { OPT_LEVELS_1_PLUS, OPT_ftree_builtin_call_dce, NULL, 1 },
+-    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 1 },
++    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 0 },
+ 
+     /* -O2 optimizations.  */
+     { OPT_LEVELS_2_PLUS, OPT_finline_small_functions, NULL, 1 },

--- a/build/gcc8/patches/no-lrt.patch
+++ b/build/gcc8/patches/no-lrt.patch
@@ -1,6 +1,6 @@
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/acinclude.m4 gcc-8.1.0/libstdc++-v3/acinclude.m4
---- gcc-8.1.0~/libstdc++-v3/acinclude.m4	2017-11-21 06:22:13.000000000 +0000
-+++ gcc-8.1.0/libstdc++-v3/acinclude.m4	2018-05-24 11:11:23.704129435 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/acinclude.m4 a/libstdc++-v3/acinclude.m4
+--- a~/libstdc++-v3/acinclude.m4	1970-01-01 00:00:00
++++ a/libstdc++-v3/acinclude.m4	1970-01-01 00:00:00
 @@ -1434,7 +1434,7 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME]
          ac_has_nanosleep=yes
          ;;
@@ -10,9 +10,9 @@ diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/acinclude.m4 gcc-8.1.0/li
          ac_has_clock_monotonic=yes
          ac_has_clock_realtime=yes
          ac_has_nanosleep=yes
-diff -wpruN '--exclude=*.orig' gcc-8.1.0~/libstdc++-v3/configure gcc-8.1.0/libstdc++-v3/configure
---- gcc-8.1.0~/libstdc++-v3/configure	2018-04-24 16:45:26.000000000 +0000
-+++ gcc-8.1.0/libstdc++-v3/configure	2018-05-24 11:11:23.716474110 +0000
+diff -wpruN '--exclude=*.orig' a~/libstdc++-v3/configure a/libstdc++-v3/configure
+--- a~/libstdc++-v3/configure	1970-01-01 00:00:00
++++ a/libstdc++-v3/configure	1970-01-01 00:00:00
 @@ -20581,7 +20581,7 @@ $as_echo "$glibcxx_glibc217" >&6; }
          ac_has_nanosleep=yes
          ;;

--- a/build/gcc8/patches/series
+++ b/build/gcc8/patches/series
@@ -14,3 +14,4 @@ libstdc++-aligned_alloc.patch
 1005-use-compare-debug.patch
 0002-compare_tests-Use-nawk-on-OmniOS.patch
 1000-ld-flags.patch
+never-omit-frame-pointer.patch


### PR DESCRIPTION
gcc should accept and ignore -fomit-frame-pointer instead of omitting the frame pointer. This option has no positive benefits and causes the resulting binaries to be impossible to debug. Since many automated build systems apply this argument even when the end user has not consciously chosen to create an undebuggable binary, the sensible thing to do is to simply ignore the option.
gcc in SmartOS does (or certainly did) this.

This is particularly important when we move to GCC8 as that version includes frame pointer omission at -O1 or above.

A test using a binary that dumps core, before the change shows that the stack trace is missing detail when the frame pointer is omitted.

#### 32-bit -g
```
core 'core' of 27453:   ./c
 fea17775 strcpy   (1, 2, 3, 8050901) + 15
 08050f03 func2    (1, 2, 3, 0) + 17
 08050f20 func     (1, 2, 3, 8050f6f) + 17
 08050f45 main     (8044c3c, feb32348, 8044c78, 8050de8, 1, 8044c9c) + 1f
 08050de8 _start_crt (1, 8044c9c, fefd1c40, 0, 0, 0) + 97
 08050cba _start   (1, 8044db4, 0, 8044db8, 8044dc5, 8044de9) + 1a
```
#### 32-bit -fomit-frame-pointer
```
core 'core' of 27470:   ./c
 febc7775 strcpy   (803f40c, fece2348, 803f448, 8050de8, 1, 803f46c) + 15
 08050de8 _start_crt (1, 803f46c, fefd1c40, 0, 0, 0) + 97
 08050cba _start   (1, 803f584, 0, 803f588, 803f595, 803f5b9) + 1a
```
#### 32-bit -fno-omit-frame-pointer
```
core 'core' of 27487:   ./c
 fed57775 strcpy   (1, 2, 3, 8050901) + 15
 08050f03 func2    (1, 2, 3, 0) + 17
 08050f20 func     (1, 2, 3, 8050f6f) + 17
 08050f45 main     (804681c, fee72348, 8046858, 8050de8, 1, 804687c) + 1f
 08050de8 _start_crt (1, 804687c, fefd1c40, 0, 0, 0) + 97
 08050cba _start   (1, 8046994, 0, 8046998, 80469a5, 80469c9) + 1a
```

After this change, the stack trace is present for all cases (64-bit too)