### PR TITLE
ntpsec: update to 1.1.2 & add smf exclusions

### DIFF
--- a/build/ntp/files/ntp.xml
+++ b/build/ntp/files/ntp.xml
@@ -69,6 +69,17 @@
 		<service_fmri value='svc:/network/routing-setup' />
 	</dependency>
 
+	<!-- vmtoolsd also adjusts the system time. Prevent ntp running
+	     at the same time. -->
+	<dependency
+		name='open-vm-tools'
+		grouping='exclude_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+		    value='svc:/system/virtualization/open-vm-tools:default' />
+	</dependency>
+
 <!--	<dependent
 	    name='ntp_multi-user'
 	    grouping='optional_all'
@@ -122,12 +133,12 @@
 	<instance name="default" enabled="false">
 		<property_group name='config' type='application' >
 			<!-- default property settings for ntpd(1M). -->
-		
+
 			<propval
 			    name='wait_for_sync'
 			    type='boolean'
 			    value='false' />
-		
+
 			<propval
 			    name='wait_for_sync_tries'
 			    type='integer'
@@ -142,43 +153,43 @@
 			    name='no_auth_required'
 			    type='boolean'
 			    value='false' />
-		
+
 			<propval
 			    name='verbose_logging'
 			    type='boolean'
 			    value='false' />
-	
+
 			<propval
 			    name='slew_always'
 			    type='boolean'
 			    value='false' />
-	
+
 			<propval
 			    name='always_allow_large_step'
 			    type='boolean'
 			    value='true' />
-	
+
 			<propval
 			    name='logfile'
 			    type='astring'
 			    value='/var/ntp/ntp.log' />
-		
+
 			<propval
 			    name='debuglevel'
 			    type='integer'
 			    value='0' />
-	
+
 			<propval
 			    name='mdnsregister'
 			    type='boolean'
 			    value='false' />
-	
+
 			<!-- to change properties -->
 			<propval
 			    name='value_authorization'
 			    type='astring'
 			    value='solaris.smf.value.ntp' />
-		
+
 		</property_group>
 	</instance>
 	<stability value='Unstable' />

--- a/build/ntpsec/build.sh
+++ b/build/ntpsec/build.sh
@@ -17,11 +17,11 @@
 . ../../lib/functions.sh
 
 PROG=ntpsec
-VER=1.1.1
+VER=1.1.2
 VERHUMAN=$VER
 PKG=service/network/ntpsec
-SUMMARY="A secure, hardened and improved Network Time Protocol implementation"
-DESC="$SUMMARY"
+SUMMARY="Network time services"
+DESC="A secure, hardened and improved Network Time Protocol implementation"
 
 BUILDARCH=64
 XFORM_ARGS="-D PVER=$PYTHONVER"
@@ -52,9 +52,9 @@ configure64() {
         --sysconfdir=/etc/inet \
         --refclock=all \
         --define=CONFIG_FILE=/etc/inet/ntp.conf \
-        --python=/usr/bin/python$PYTHONVER \
-        --pythondir=/usr/lib/python$PYTHONVER/vendor-packages \
-        --pythonarchdir=/usr/lib/python$PYTHONVER/vendor-packages \
+        --python=$PYTHON \
+        --pythondir=$PYTHONVENDOR \
+        --pythonarchdir=$PYTHONVENDOR \
         --nopyc \
         --nopyo \
         --nopycache \

--- a/build/ntpsec/files/ntpsec.xml
+++ b/build/ntpsec/files/ntpsec.xml
@@ -22,6 +22,7 @@
 
  Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
  Copyright 2016 Andrew Stormont <andyjstormont@gmail.com>
+ Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
  NOTE:  This service manifest is not editable; its contents will
  be overwritten by package or patch operations, including
@@ -76,6 +77,17 @@
 		<service_fmri value='file://localhost/etc/inet/ntp.conf' />
 	</dependency>
 
+	<!-- vmtoolsd also adjusts the system time. Prevent ntp running
+	     at the same time. -->
+	<dependency
+		name='open-vm-tools'
+		grouping='exclude_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+		    value='svc:/system/virtualization/open-vm-tools:default' />
+	</dependency>
+
 	<exec_method
 	    type='method'
     	    name='start'
@@ -121,12 +133,12 @@
 	<instance name="default" enabled="false">
 		<property_group name='config' type='application' >
 			<!-- default property settings for ntpd(1M). -->
-		
+
 			<propval
 			    name='wait_for_sync'
 			    type='boolean'
 			    value='false' />
-		
+
 			<propval
 			    name='wait_for_sync_tries'
 			    type='integer'
@@ -141,38 +153,38 @@
 			    name='verbose_logging'
 			    type='boolean'
 			    value='false' />
-	
+
 			<propval
 			    name='slew_always'
 			    type='boolean'
 			    value='false' />
-	
+
 			<propval
 			    name='always_allow_large_step'
 			    type='boolean'
 			    value='true' />
-	
+
 			<propval
 			    name='logfile'
 			    type='astring'
 			    value='/var/ntp/ntp.log' />
-		
+
 			<propval
 			    name='debuglevel'
 			    type='integer'
 			    value='0' />
-	
+
 			<propval
 			    name='mdnsregister'
 			    type='boolean'
 			    value='false' />
-	
+
 			<!-- to change properties -->
 			<propval
 			    name='value_authorization'
 			    type='astring'
 			    value='solaris.smf.value.ntp' />
-		
+
 		</property_group>
 	</instance>
 	<stability value='Unstable' />

--- a/build/ntpsec/testsuite.log
+++ b/build/ntpsec/testsuite.log
@@ -1,12 +1,26 @@
+BINARY      : test_agentx.py
+RETURN VALUE: 0
+
+*** stdout ***
+
+*** stderr ***
+.............................
+----------------------------------------------------------------------
+Ran 29 tests in 0.005s
+
+OK
+
+
+
 BINARY      : test_agentx_packet.py
 RETURN VALUE: 0
 
 *** stdout ***
 
 *** stderr ***
-.........................................
+........................................
 ----------------------------------------------------------------------
-Ran 41 tests in 0.008s
+Ran 40 tests in 0.008s
 
 OK
 
@@ -25,13 +39,29 @@ TEST(calendar, is_leapyear) PASS
 TEST(calendar, julian0) PASS
 TEST(calendar, days_per_year) PASS
 TEST(calendar, parse_to_unixtime) PASS
+TEST(calendar, PeriodicExtend1) PASS
+TEST(calendar, NtpToTime1) PASS
+TEST(calendar, NtpToNtp1) PASS
 TEST(calendar, DaySplitMerge) PASS
+TEST(calendar, DaysecToDate1) PASS
+TEST(calendar, SplitEraDays1) PASS
 TEST(calendar, SplitYearDays1) PASS
 TEST(calendar, SplitYearDays2) PASS
 TEST(calendar, RataDie1) PASS
+TEST(calendar, TimeToDate1) PASS
+TEST(calendar, DayJoin1) PASS
+TEST(calendar, DaysInYears1) PASS
+TEST(calendar, EdateToEradays1) PASS
+TEST(calendar, EtimeToSeconds1) PASS
+TEST(calendar, TmToRd1) PASS
 TEST(calendar, LeapYears1) PASS
 TEST(calendar, LeapYears2) PASS
 TEST(calendar, RoundTripDate) PASS
+TEST(calendar, DateToDaysec1) PASS
+TEST(calendar, TmToDaysec1) PASS
+TEST(calendar, DateToTime1) PASS
+TEST(calendar, Ntp64ToDate1) PASS
+TEST(calendar, NtpToDate1) PASS
 TEST(clocktime, CurrentYear) PASS
 TEST(clocktime, CurrentYearExplicit) PASS
 TEST(clocktime, CurrentYearFuzz) PASS
@@ -40,6 +70,9 @@ TEST(clocktime, PreviousYear) PASS
 TEST(clocktime, NextYear) PASS
 TEST(clocktime, NoReasonableConversion) PASS
 TEST(clocktime, AlwaysInLimit) PASS
+TEST(endian, Bit16) PASS
+TEST(endian, Bit32) PASS
+TEST(endian, Bit64) PASS
 TEST(decodenetnum, Services) PASS
 TEST(decodenetnum, IPv4AddressOnly) PASS
 TEST(decodenetnum, IPv4AddressWithPort) PASS
@@ -48,6 +81,9 @@ TEST(decodenetnum, IPv6AddressOnly) PASS
 TEST(decodenetnum, IPv6AddressWithPort) PASS
 TEST(decodenetnum, IllegalAddress) PASS
 TEST(decodenetnum, IllegalCharInPort) PASS
+TEST(dolfptoa, DoLfpToA) PASS
+TEST(dolfptoa, MfpToA) PASS
+TEST(dolfptoa, MfpToMs) PASS
 TEST(hextolfp, PositiveInteger) PASS
 TEST(hextolfp, NegativeInteger) PASS
 TEST(hextolfp, PositiveFraction) PASS
@@ -74,6 +110,9 @@ TEST(lfptostr, UnsignedInteger) PASS
 TEST(macencrypt, Encrypt) PASS
 TEST(macencrypt, DecryptValid) PASS
 TEST(macencrypt, DecryptInvalid) PASS
+TEST(macencrypt, CMAC_Encrypt) PASS
+TEST(macencrypt, DecryptValidCMAC) PASS
+TEST(macencrypt, DecryptInvalidCMAC) PASS
 TEST(macencrypt, IPv4AddressToRefId) PASS
 TEST(macencrypt, IPv6AddressToRefId) PASS
 TEST(msyslog, msnprintf) PASS
@@ -85,12 +124,12 @@ TEST(msyslog, format_errmsgHangingPercent) PASS
 TEST(msyslog, msnprintfNullTarget) PASS
 TEST(msyslog, msnprintfTruncate) PASS
 TEST(netof6, IPv6Address) PASS
-TEST(numtoa, Address) PASS
-TEST(numtoa, Netmask) PASS
+TEST(numtoa, RefidStr) PASS
 TEST(prettydate, ConstantDate) PASS
-TEST(recvbuff, Initialization) PASS
-TEST(recvbuff, GetAndFree) PASS
-TEST(recvbuff, GetAndFill) PASS
+TEST(prettydate, Rfc3339Date1) PASS
+TEST(prettydate, Rfc3339Time1) PASS
+TEST(random, random32) PASS
+TEST(random, random64) PASS
 TEST(refidsmear, Main) PASS
 TEST(socktoa, IPv4AddressWithPort) PASS
 TEST(socktoa, IPv6AddressWithPort) PASS
@@ -98,6 +137,10 @@ TEST(socktoa, ScopedIPv6AddressWithPort) PASS
 TEST(socktoa, HashEqual) PASS
 TEST(socktoa, HashNotEqual) PASS
 TEST(socktoa, IgnoreIPv6Fields) PASS
+TEST(statestr, ResMatchFlags) PASS
+TEST(statestr, ResAccessFlags) PASS
+TEST(statestr, KSTFlags) PASS
+TEST(statestr, StatusToA) PASS
 TEST(statestr, PeerRestart) PASS
 TEST(statestr, SysUnspecified) PASS
 TEST(statestr, ClockCodeExists) PASS
@@ -135,6 +178,13 @@ TEST(timespecops, test_FromLFPbittest) PASS
 TEST(timespecops, test_FromLFPrelPos) PASS
 TEST(timespecops, test_FromLFPrelNeg) PASS
 TEST(timespecops, test_LFProundtrip) PASS
+TEST(timespecops, test_FromLFPuBittest) PASS
+TEST(timespecops, test_FromLFPuRelPos) PASS
+TEST(timespecops, test_FromLFPuRelNeg) PASS
+TEST(timespecops, test_LFPuRoundtrip) PASS
+TEST(timespecops, DToTspec) PASS
+TEST(timespecops, LfpStampToTspec) PASS
+TEST(timespecops, TvalToTspec) PASS
 TEST(vi64ops, SetVUI64s_pos) PASS
 TEST(vi64ops, SetVUI64s_neg) PASS
 TEST(vi64ops, SetVUI64u) PASS
@@ -145,7 +195,7 @@ TEST(ymd2yd, LeapYearFebruary) PASS
 TEST(ymd2yd, LeapYearDecember) PASS
 
 -----------------------
-126 Tests 0 Failures 0 Ignored 
+162 Tests 0 Failures 0 Ignored 
 OK
 
 *** stderr ***
@@ -284,9 +334,12 @@ TEST(hackrestrict, AddingNewRestriction) PASS
 TEST(hackrestrict, TheMostFittingRestrictionIsMatched) PASS
 TEST(hackrestrict, DeletedRestrictionIsNotMatched) PASS
 TEST(hackrestrict, RestrictUnflagWorks) PASS
+TEST(recvbuff, Initialization) PASS
+TEST(recvbuff, GetAndFree) PASS
+TEST(recvbuff, GetAndFill) PASS
 
 -----------------------
-35 Tests 0 Failures 0 Ignored 
+38 Tests 0 Failures 0 Ignored 
 OK
 
 *** stderr ***
@@ -315,7 +368,7 @@ RETURN VALUE: 0
 *** stderr ***
 ..............
 ----------------------------------------------------------------------
-Ran 14 tests in 0.007s
+Ran 14 tests in 0.004s
 
 OK
 
@@ -325,11 +378,14 @@ BINARY      : test_util.py
 RETURN VALUE: 0
 
 *** stdout ***
+'"'
+'n'
+'\\'
 
 *** stderr ***
-.........................................
+..........................................
 ----------------------------------------------------------------------
-Ran 41 tests in 0.008s
+Ran 42 tests in 0.008s
 
 OK
 

--- a/build/open-vm-tools/files/open-vm-tools.xml
+++ b/build/open-vm-tools/files/open-vm-tools.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" ?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
 <!--
     CDDL HEADER START
 
@@ -18,39 +19,70 @@
     information: Portions Copyright [yyyy] [name of copyright owner]
 
     CDDL HEADER END
--->
 
-<!--
     Copyright (c) 2014 by Delphix.
     All rights reserved.
+    Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 -->
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+
 <service_bundle type="manifest" name="system/virtualization/open-vm-tools">
-    <service version="1" type="service" name="system/virtualization/open-vm-tools">
-        <create_default_instance enabled="true" />
 
-        <dependency restart_on="none" type="service" name="multi_user_dependency" grouping="require_all">
-            <service_fmri value="svc:/milestone/multi-user"/>
-        </dependency>
+<service
+	name="system/virtualization/open-vm-tools"
+	type="service"
+	version="1">
 
-        <exec_method timeout_seconds="60" type="method" name="start"
-            exec="/usr/bin/vmtoolsd &amp;"
-            />
-        <exec_method timeout_seconds="60" type="method" name="stop"
-            exec=":kill"/>
-        <exec_method timeout_seconds="60" type="method" name="refresh"
-            exec=":kill -1"/> <!-- SIGHUP -->
-        <template>
-            <common_name>
-                <loctext xml:lang="C">
-                    Open Virtual Machine Tools
-                </loctext>
-            </common_name>
-            <description>
-                <loctext xml:lang="C">
-                    The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under VMware hypervisor.
-                </loctext>
-            </description>
-        </template>
-    </service>
+	<create_default_instance enabled="true" />
+
+	<dependency
+		name="multi_user_dependency"
+		grouping="require_all"
+		restart_on="none"
+		type="service">
+		<service_fmri value="svc:/milestone/multi-user"/>
+	</dependency>
+
+	<!-- vmtoolsd adjusts the system time. Prevent ntp running
+	     at the same time. -->
+	<dependency
+		name='ntpd'
+		grouping='exclude_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+		    value='svc:/network/ntp:default' />
+	</dependency>
+
+	<exec_method
+		type="method"
+		name="start"
+		exec="/usr/bin/vmtoolsd &amp;"
+		timeout_seconds="60" />
+
+	<exec_method
+		type="method"
+		name="stop"
+		exec=":kill"
+		timeout_seconds="60" />
+
+	<exec_method
+		type="method"
+		name="refresh"
+		exec=":kill -1"
+		timeout_seconds="60" /> <!-- SIGHUP -->
+
+	<template>
+		<common_name>
+			<loctext xml:lang="C">
+			Open Virtual Machine Tools
+			</loctext>
+		</common_name>
+		<description>
+			<loctext xml:lang="C">
+			The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under VMware hypervisor.
+			</loctext>
+		</description>
+	</template>
+</service>
+
 </service_bundle>

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -64,7 +64,7 @@
 | runtime/python-35			| 3.5.6			| https://www.python.org/downloads/source/
 | security/sudo				| 1.8.24		| https://www.sudo.ws/
 | service/network/ntp			| 4.2.8p12		| http://www.ntp.org/downloads.html
-| service/network/ntpsec		| 1.1.1			| https://github.com/ntpsec/ntpsec/releases https://blog.ntpsec.org/
+| service/network/ntpsec		| 1.1.2			| https://github.com/ntpsec/ntpsec/releases https://blog.ntpsec.org/
 | service/network/smtp/dma		| 0.11			| https://github.com/corecode/dma/releases
 | shell/bash				| 4.4.18		| https://ftp.gnu.org/gnu/bash/
 | shell/bash-patchlvl			| 023			| https://ftp.gnu.org/gnu/bash/bash-4.4-patches


### PR DESCRIPTION
The second commit addresses https://github.com/omniti-labs/omnios-build/issues/94 by not allowing `open-vm-tools` and either `ntpd` to run concurrently.
