### PR TITLE
Create link to temporary working area in build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build.log
 build.log.*
+tmp
 tmp.repo/
 *.p5m.final

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -636,6 +636,9 @@ prep_build() {
         [ -d $TMPDIR/$BUILDDIR ] && logcmd rm -rf $TMPDIR/$BUILDDIR
         logcmd mkdir -p $TMPDIR/$BUILDDIR
     fi
+
+    # Create symbolic link to build area in source
+    logcmd ln -sf $TMPDIR $SRCDIR/tmp
 }
 
 #############################################################################


### PR DESCRIPTION
For example:

```
% pwd
/data/omnios-build/omniosorg/bloody/omnios/build/nghttp2
% ls
build.sh*   local.mog
% ./build.sh
...
% ls tmp
library_nghttp2_pkg/           nghttp2-1.32.1.tar.xz
nghttp2-1.32.1/                nghttp2-1.32.1.tar.xz.sha256
% ls -l
total 55
-rw-r--r--   1 af       other       116K Sep  2 10:07 build.log
-rwxr-xr-x   1 af       other      1.57K Sep  2 09:59 build.sh*
-rw-r--r--   1 af       other        363 Jul 11 13:51 local.mog
lrwxrwxrwx   1 af       other         57 Sep  2 10:06 tmp -> /data/omnios-build/omniosorg/bloody/_build/nghttp2-1.32.1/
```