### PR TITLE
iso-codes: update to 4.1

### DIFF
--- a/build/iso-codes/build.sh
+++ b/build/iso-codes/build.sh
@@ -27,7 +27,7 @@
 . ../../lib/functions.sh
 
 PROG=iso-codes
-VER=4.0
+VER=4.1
 VERHUMAN=$VER
 PKG=data/iso-codes
 SUMMARY="ISO code lists and translations"
@@ -36,15 +36,6 @@ DESC+="(e.g. country, language, language scripts, and currency names)"
 
 BUILD_DEPENDS_IPS="data/iso-codes"
 
-install_xml() {
-    # As of iso-code 4.0, the .xml files are no longer included. We continue
-    # to ship them for now, but they will no longer be updated.
-    # The XML files include a header pointing users at the JSON ones.
-    logcmd mkdir -p $DESTDIR/usr/share/xml || logerr "mkdir"
-    logcmd rsync -avr /usr/share/xml/iso-codes/ \
-        $DESTDIR/usr/share/xml/iso-codes/ || logerr "rsync"
-}
-
 set_arch 32
 
 init
@@ -52,7 +43,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-install_xml
 make_package
 clean_up
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -8,7 +8,7 @@
 | compress/unzip			| 6.0			| https://sourceforge.net/projects/infozip/files/UnZip%206.x%20%28latest%29/ https://www.cvedetails.com/vulnerability-list/vendor_id-816/product_id-1395/Info-zip-Unzip.html
 | compress/xz				| 5.2.4			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/ http://www.info-zip.org/Zip.html
-| data/iso-codes			| 4.0			| https://salsa.debian.org/iso-codes-team/iso-codes/tags
+| data/iso-codes			| 4.1			| https://salsa.debian.org/iso-codes-team/iso-codes/tags
 | database/sqlite-3			| 3240000		| https://www.sqlite.org/download.html
 | developer/acpi/compiler		| 20180810		| https://www.acpica.org/downloads/
 | developer/bmake			| 20180512		| http://ftp.netbsd.org/pub/NetBSD/misc/sjg/ http://www.crufty.net/ftp/pub/sjg/


### PR DESCRIPTION
From the release notes:

```
* The XML files have been re-added, because too many
  other programs still rely on those files.
  ***********************************************************
  ** If you're maintaining a program which uses XML files, **
  ** please switch to the JSON data files.                 **
  ***********************************************************
```

So, I've reverted our local XML file preservation.