### PR TITLE
Python module updates.

### DIFF
--- a/build/python27/cheroot/build.sh
+++ b/build/python27/cheroot/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-2/cheroot-27
 PROG=cheroot
-VER=6.4.0
+VER=6.5.2
 SUMMARY="cheroot - Highly-optimized, pure-python HTTP server"
 DESC="$SUMMARY"
 

--- a/build/python27/cherrypy/build.sh
+++ b/build/python27/cherrypy/build.sh
@@ -28,6 +28,7 @@
 
 PKG=library/python-2/cherrypy-27
 PROG=CherryPy
+# CherryPy 17 is the last version with Python2 support.
 VER=17.3.0
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"

--- a/build/python35/cheroot/build.sh
+++ b/build/python35/cheroot/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cheroot-35
 PROG=cheroot
-VER=6.4.0
+VER=6.5.2
 SUMMARY="cheroot - Highly-optimized, pure-python HTTP server"
 DESC="$SUMMARY"
 

--- a/build/python35/cherrypy/build.sh
+++ b/build/python35/cherrypy/build.sh
@@ -19,7 +19,7 @@
 
 PKG=library/python-3/cherrypy-35
 PROG=CherryPy
-VER=17.3.0
+VER=18.0.1
 SUMMARY="cherrypy - A Minimalist Python Web Framework"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -101,12 +101,13 @@
 | library/python-2/jaraco.classes-27	| 1.5			| https://pypi.org/project/jaraco.classes
 | library/python-2/functools32-27	| 3.2.3-2		| https://pypi.org/project/functools32
 | library/python-2/enum-27		| 1.1.6			| https://pypi.org/project/enum34
+| library/python-2/cherrypy-27		| 17.3.0		| https://pypi.org/project/jsonrpclib
 | library/python-2/jsonrpclib-27	| 0.1.7			| https://pypi.org/project/jsonrpclib
 | library/python-3/functools_lru_cache-35	| 1.5		| https://pypi.org/project/backports.functools_lru_cache/
 | library/python-3/asn1crypto-35	| 0.24.0		| https://pypi.org/project/asn1crypto
 | library/python-3/cffi-35		| 1.11.5		| https://pypi.org/project/cffi
-| library/python-3/cheroot-35		| 6.4.0			| https://pypi.org/project/cheroot
-| library/python-3/cherrypy-35		| 17.3.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
+| library/python-3/cheroot-35		| 6.5.2			| https://pypi.org/project/cheroot
+| library/python-3/cherrypy-35		| 18.0.1		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/contextlib2-35	| 0.5.5			| https://pypi.org/project/contextlib2
 | library/python-3/coverage-35		| 4.5.1			| https://pypi.org/project/coverage
 | library/python-3/cryptography-35	| 2.3.1			| https://pypi.org/project/cryptography

--- a/tools/test
+++ b/tools/test
@@ -294,6 +294,8 @@ check_python()
 		[[ $i = library/python-3/* ]] || continue
 		# The python-3 version of jsonrpclib is different
 		[ $i = library/python-3/jsonrpclib-35 ] && continue
+		# Cherrypy >= 18 is not compatible with python2
+		[ $i = library/python-3/cherrypy-35 ] && continue
 		j="`echo $i | sed '
 			s/python-3/python-2/
 			s/-35/-27/


### PR DESCRIPTION
Note that cherrypy >= 18 only supports python3 so the python2 module version remains at 17.