### PR TITLE
Return explicit success status

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -459,10 +459,17 @@ fi
 
 logmsg "===== Build started at `date` ====="
 
+build_end() {
+    rv=$?
+    if [ -n "$PKG" -a -n "$build_start" ]; then
+        logmsg Time: $PKG - $((`date +%s` - build_start))
+        build_start=
+    fi
+    exit $rv
+}
+
 build_start=`date +%s`
-trap '[ -n "$build_start" ] && \
-    logmsg Time: $PKG - $((`date +%s` - build_start)) && \
-    build_start=' EXIT
+trap 'build_end' EXIT
 
 #############################################################################
 # Libtool -nostdlib hacking
@@ -1137,7 +1144,9 @@ make_package() {
     fi
     logmsg "--- Published $FMRI"
 
-     [ -z "$BATCH" -a -z "$SKIP_PKG_DIFF" ] && diff_package $FMRI
+    [ -z "$BATCH" -a -z "$SKIP_PKG_DIFF" ] && diff_package $FMRI
+
+    return 0
 }
 
 # Create a list of the items contained within a package in a format suitable
@@ -1761,6 +1770,7 @@ clean_up() {
             logerr "Failed to remove temporary manifest and transform files"
         logmsg "Done."
     fi
+    return 0
 }
 
 #############################################################################


### PR DESCRIPTION
Fix problem with some packages appearing to fail during a parallel build, despite actually building and publishing correctly. This is caused by the overall build script exiting with a non-zero code. It seems to be a problem in bash where exit codes are not consistently passed up from subroutines. I tested in other shells and the results were always consistent but in bash I got about an 80/20% split in behaviour.

Regardless, explicitly returning 0 on successful completion of the package build and cleanup functions resolves the problem as far as my testing shows.