### PR TITLE
Set dashrev for release/name

### DIFF
--- a/build/release/build.sh
+++ b/build/release/build.sh
@@ -37,6 +37,8 @@ if [[ "$RELEASE" = *[a-z] ]]; then
     done
 fi
 
+DASHREV=$RELREV
+
 XFORM_ARGS="
     -DRELEASE=$RELEASE -DRELNUM=$RELNUM -DRELDATE=$RELDATE -DRELREV=$RELREV
 "


### PR DESCRIPTION
This will result in versions for release/name of the form
```
pkg://omnios/release/name@0.5.11-151028.28:20180905T084129Z
```
which would correspond to `r151028ab`