### PR TITLE
Require gfortran-runtime for building OmniOS

### DIFF
--- a/build/gcc-runtime/build-runtimef.sh
+++ b/build/gcc-runtime/build-runtimef.sh
@@ -23,6 +23,10 @@ VERHUMAN=$VER
 SUMMARY="GNU fortran runtime dependencies"
 DESC="$SUMMARY"
 
+# As we copy libraries from the live system, the package must already be
+# installed.
+BUILD_DEPENDS_IPS+=" $PKG"
+
 init
 prep_build
 shopt -s extglob

--- a/build/meta/omnios-build-tools.p5m
+++ b/build/meta/omnios-build-tools.p5m
@@ -51,10 +51,10 @@ depend fmri=runtime/python-35 type=require
 depend fmri=service/network/tftp type=require
 depend fmri=system/header/header-audio type=require
 depend fmri=system/library type=require
+depend fmri=system/library/gfortran-runtime type=require
 depend fmri=system/library/math type=require
 depend fmri=system/pciutils/pci.ids type=require
 depend fmri=system/zones/internal type=require
 depend fmri=text/gnu-sed type=require
 depend fmri=text/intltool type=require
 depend fmri=web/ca-bundle type=require
-


### PR DESCRIPTION
Require gfortran-runtime for building OmniOS
