### PR TITLE
libpciaccess: PCI access utility library

### DIFF
--- a/build/libpciaccess/build.sh
+++ b/build/libpciaccess/build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END }}}
+#
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Use is subject to license terms.
+#
+# Load support functions
+. ../../lib/functions.sh
+
+PROG=libpciaccess
+VER=0.14
+VERHUMAN=$VER
+PKG=library/libpciaccess
+SUMMARY="PCI access utility library from X.org"
+DESC="The pciaccess library wraps platform-dependent PCI access methods in a convenient library."
+
+BUILD_DEPENDS_IPS="autoconf automake"
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_isa_stub
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker


### PR DESCRIPTION
The pciaccess library wraps platform-dependent PCI access methods in a convenient library. For exmaple it's required to build gfx-drm and the kernel module.