### PR TITLE
Restore legacy libraries

### DIFF
--- a/build/libidn/build.sh
+++ b/build/libidn/build.sh
@@ -34,14 +34,20 @@ SUMMARY="The Internationalized Domains Library"
 DESC="IDN - The Internationalized Domains Library"
 
 CONFIGURE_OPTS="--disable-static"
-LIBTOOL_NOSTDLIB=libtool
-LIBTOOL_NOSTDLIB_EXTRAS=-lc
 
 init
-download_source $PROG $PROG $VER
-patch_source
 prep_build
-build
+
+# The library major version changed from 11 to 12 with 1.35. We need to
+# continue shipping the older version of the library to support anything
+# linked against it. This builds both versions in order.
+for VER in 1.34 $VER; do
+    BUILDDIR=$PROG-$VER
+    download_source $PROG $PROG $VER
+    patch_source
+    build
+done
+
 make_isa_stub
 make_package
 clean_up

--- a/build/net-snmp/build.sh
+++ b/build/net-snmp/build.sh
@@ -81,11 +81,25 @@ TESTSUITE_SED="
     /^gmake/d
 "
 
+install_legacy()
+{
+    # Include legacy API libraries (changed from .30 -> .35 in 5.8)
+    ver=30
+    for lib in snmp netsnmp netsnmpagent netsnmphelpers netsnmpmibs \
+      netsnmptrapd; do
+        logcmd cp /usr/lib/lib$lib.so.$ver $DESTDIR/usr/lib/ \
+            || logerr "$lib copy failed"
+        logcmd cp /usr/lib/amd64/lib$lib.so.$ver $DESTDIR/usr/lib/amd64/ \
+            || logerr "$lib copy failed"
+    done
+}
+
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+install_legacy
 run_testsuite test
 install_smf application/management net-snmp.xml svc-net-snmp
 strip_install


### PR DESCRIPTION
r151028 testing showed up this problem. A couple of packages have changed the major version of their libraries between r26 and now. We need to continue shipping the previous versions to support any software linked against them. I've also added a test for this to the pre-release testing sheet.

Two different approaches here - libidn is fairly simple so I'm building both old and new versions. Building an older version of libnetsnmp is harder (partly because it does not build with openssl 1.1 and partly because of the amount of patches we apply) so I'm copying the libraries from the live system.

```diff
--- Published library/libidn@1.35,5.11-151027.0
--- Comparing old package with new

+link path=usr/lib/amd64/libidn.so.11 target=libidn.so.11.6.18
+file path=usr/lib/amd64/libidn.so.11.6.18 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+link path=usr/lib/libidn.so.11 target=libidn.so.11.6.18
+file path=usr/lib/libidn.so.11.6.18 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=32

```
```diff
--- Published system/management/snmp/net-snmp@5.8,5.11-151027.0
--- Comparing old package with new

+file path=usr/lib/amd64/libnetsnmp.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/amd64/libnetsnmpagent.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/amd64/libnetsnmphelpers.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/amd64/libnetsnmpmibs.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/amd64/libnetsnmptrapd.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/amd64/libsnmp.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=64
+file path=usr/lib/libnetsnmp.so.30 owner=root group=bin mode=0755 elfarch=i386 \
+    elfbits=32
+file path=usr/lib/libnetsnmpagent.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=32
+file path=usr/lib/libnetsnmphelpers.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=32
+file path=usr/lib/libnetsnmpmibs.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=32
+file path=usr/lib/libnetsnmptrapd.so.30 owner=root group=bin mode=0755 \
+    elfarch=i386 elfbits=32
+file path=usr/lib/libsnmp.so.30 owner=root group=bin mode=0755 elfarch=i386 \
+    elfbits=32
```