### PR TITLE
 Support expensive package build throttle and more...

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -118,11 +118,6 @@ EOM
     exit
 }
 
-bail() {
-    echo $*
-    exit
-}
-
 # Dependencies are limited at the moment. The only thing that matters is
 # that kayak-kernel is built last. Build everything else in alphabetical
 # order.
@@ -273,21 +268,21 @@ build_manifest() {
     if [ -f root.tar.bz2 ]; then
         logmsg "File archive found. Extracting..."
         bzip2 -dc root.tar.bz2 | tar xf - \
-            || bail "Failed to extract root.tar.bz2"
+            || logerr "Failed to extract root.tar.bz2"
         logmsg "Publishing from $mf.final"
         logcmd pkgsend -s $PKGSRVR publish -d $PKGROOT $mf.final \
-            || bail "pkgsend failed"
+            || logerr "pkgsend failed"
         logcmd rm -rf $PKGROOT
     elif [ -d "$PKGROOT" ]; then
         # In case we just have a tree of files and not a tarball
         logmsg "Publishing from $mf.final"
         logcmd pkgsend -s $PKGSRVR publish -d $PKGROOT $mf.final \
-            || bail "pkgsend failed"
+            || logerr "pkgsend failed"
     else
         # Else we just have a manifest to import
         logmsg "Simple manifest to import... importing to $PKGSRVR"
         logcmd pkgsend -s $PKGSRVR publish $mf.final \
-            || bail "pkgsend failed"
+            || logerr "pkgsend failed"
     fi
     rm -f $mf.final
 }
@@ -299,7 +294,7 @@ build() {
         buildtgt="${targets[$1]}"
         logmsg "--- $1 -> $buildtgt"
     else
-        bail "Unknown package: $1"
+        logerr "Unknown package: $1"
     fi
     if is_built $buildtgt; then
         logmsg "--- Package $1 was already built."
@@ -307,7 +302,7 @@ build() {
         BUILD=${fulltargets[$buildtgt]}
         DIR="`dirname $BUILD`"
         SCRIPT="`basename $BUILD`"
-        pushd $DIR > /dev/null || bail "Cannot chdir to $DIR"
+        pushd $DIR > /dev/null || logerr "Cannot chdir to $DIR"
         PKGSRVR=$DEFAULT_PKGSRVR
         PKGPUBLISHER=$DEFAULT_PKGPUBLISHER
         PKGROOT=`pwd`/root

--- a/build/buildctl
+++ b/build/buildctl
@@ -103,8 +103,8 @@ $0
     list-built [grep pattern]      - show package build status
     licenses                       - audit licenses
     build <pkg>
-    build [-e] all
-    build [-e] parallel <threads>  - start/continue parallel build
+    build [-e|E] all
+    build [-e|E] parallel <num>    - start/continue parallel build
     build continue                 - continue interrupted build
     build from <pkg>               - build <pkg> then those after
     baseline [create [repo]]       - check or create pkg baseline
@@ -112,6 +112,7 @@ $0
 Options:
 
     -e                             - also build packages flagged as expensive
+    -E                             - force (re-)build of expensive packages
 
 EOM
 
@@ -182,6 +183,17 @@ record_expensive() {
         done
         record_built '# end of expensive packages'
     fi
+}
+
+# Remove all expensive packages from the built cache
+remove_expensive() {
+    [ -f "$BUILT_CACHE" ] || return
+    [ -n "$EXPENSIVE" ] || return
+    for pkg in $EXPENSIVE; do
+        cp $BUILT_CACHE $BUILT_CACHE.$$
+        egrep -v "^$pkg\$" $BUILT_CACHE.$$ > $BUILT_CACHE
+        rm -f $BUILT_CACHE.$$
+    done
 }
 
 clear_built() {
@@ -577,6 +589,12 @@ case "$1" in
         shift
         [ "$1" = "-e" ] && BUILD_EXPENSIVE=1 && shift
         [ "$1" = "-c" ] && USE_CCACHE=1 && shift
+        if [ "$1" = "-E" ]; then
+            # Force (re)build of expensive packages
+            remove_expensive
+            BUILD_EXPENSIVE=1
+            shift
+        fi
         tobuild="$@"
         [ -z "$tobuild" ] && tobuild=all
 

--- a/build/buildctl
+++ b/build/buildctl
@@ -216,7 +216,7 @@ record_built() {
         [ -p "$built_pipe" ] || logerr "Built cache pipe does not exist."
         for i in {1..10}; do
             echo "$*" >> $built_pipe
-            # EACCESS, pipe could be full
+            # SIGPIPE, pipe could be full
             [ $? -ne 141 ] && break
             logmsg -e "Built pipe is full, retrying..."
             sleep 1
@@ -445,16 +445,28 @@ wait_for_slot() {
             wait "${slots[$i]}"
             s=$?
             typeset job="${slottgt[$i]}"
-            if [ $s -ne 0 ]; then
-                logmsg -e "-- Job $i ($job) terminated with status $s"
-                note -e "***** BUILD ERROR ***** ($job/$s)"
-                return
-            else
-                logmsg -n "-- Job $i ($job) terminated normally"
-                slots[$i]=
-                nextslot=$i
-                return
-            fi
+            case $s in
+                0)  logmsg -n "-- Job $i ($job) terminated normally"
+                    slots[$i]=
+                    nextslot=$i
+                    return
+                    ;;
+                141)
+                    # Jobs sometimes terminate with 141 (SIGPIPE) but have
+                    # actually run to completion. We don't know why this
+                    # happens yet, but treat this as a successful run for now.
+                    # If the build or publication has not worked, the baseline
+                    # check will catch it.
+                    logmsg -n "-- Job $i ($job) terminated with SIGPIPE"
+                    slots[$i]=
+                    nextslot=$i
+                    return
+                    ;;
+                *)  logmsg -e "-- Job $i ($job) terminated with status $s"
+                    note -e "***** BUILD ERROR ***** ($job/$s)"
+                    return
+                    ;;
+            esac
         done
         # Print status summary each minute (approx.)
         [ `date +%S` -eq 0 ] && job_status

--- a/build/buildctl
+++ b/build/buildctl
@@ -10,6 +10,8 @@ declare -A targets
 declare -A fulltargets
 # list of licenses
 declare -A licenses
+# expensive package lookup table
+declare -A expensive
 
 add_target() {
     local pkg=$1
@@ -63,9 +65,17 @@ add_buildscripts() {
     done
 }
 
+add_expensive() {
+    typeset i=1
+    for pkg in $EXPENSIVE; do
+        expensive[$pkg]=$((i++))
+    done
+}
+
 add_targets() {
     add_manifests
     add_buildscripts
+    add_expensive
 }
 
 detect_licenses() {
@@ -242,6 +252,7 @@ stop_built_listener() {
 
 restore_built() {
     [ -f "$BUILT_CACHE" ] || record_expensive
+    touch "$BUILT_CACHE"
 
     for pkg in `grep -v '^#' "$BUILT_CACHE"`; do
         [ -n "${already_built[$pkg]}" ] || already_built+=([$pkg]=1)
@@ -419,9 +430,54 @@ job_status() {
     logmsg -h "######################################################"
 }
 
+nextslot=
+wait_for_slot() {
+    nextslot=
+    err=
+    while :; do
+        for i in `seq 0 $threads`; do
+            # Idle slot? Just return the slot number
+            [ -z "${slots[$i]}" ] && nextslot=$i && return
+            # Job finished?
+            kill -0 "${slots[$i]}" 2>/dev/null && continue
+
+            # Reap terminated job
+            wait "${slots[$i]}"
+            s=$?
+            typeset job="${slottgt[$i]}"
+            if [ $s -ne 0 ]; then
+                logmsg -e "-- Job $i ($job) terminated with status $s"
+                note -e "***** BUILD ERROR ***** ($job/$s)"
+                return
+            else
+                logmsg -n "-- Job $i ($job) terminated normally"
+                slots[$i]=
+                nextslot=$i
+                return
+            fi
+        done
+        # Print status summary each minute (approx.)
+        [ `date +%S` -eq 0 ] && job_status
+        sleep 1
+    done
+}
+
+count_expensive() {
+    typeset -i ne=0
+    for i in `seq 0 $threads`; do
+        [ -z "${slots[$i]}" ] && continue
+        p="${slottgt[$i]}"
+        # Expensive?
+        [ -n "${expensive[$p]}" ] || continue
+        ((ne++))
+    done
+    echo $ne
+}
+
 parallel_build() {
     threads=$1
-    # Lint is not thread-safe and skip test-suite in parallel build mode.
+    # pkglint is not thread-safe so skip it and the test-suite in parallel
+    # build mode.
     build_flags="-b -t -l"
     export BATCH=1  # So logerr() exits without prompting
     [ -n "$USE_CCACHE" ] && build_flags+=" -c"
@@ -430,7 +486,6 @@ parallel_build() {
 
     ((threads = threads - 1))
 
-    pkgcount=${#fulltargets[@]}
     pkgnum=0
 
     start_built_listener
@@ -441,12 +496,26 @@ parallel_build() {
     declare -A slottgt
     declare -A slotdesc
     declare -A slotstart
+    declare -a queue
 
+    [ -n "$ETHROTTLE" ] || ETHROTTLE=0
+
+    # Queue up the packages to build
     for tgt in `buildorder`; do
-        ((pkgnum = pkgnum + 1))
-
         # Defer this until last
         [ "$tgt" = "system/install/kayak-kernel" ] && continue
+        queue+=($tgt)
+    done
+    [ -z "$SKIP_KAYAK_KERNEL" ] && queue+=(system/install/kayak-kernel)
+
+    pkgcount=${#queue[@]}
+
+    while [ ${#queue[@]} -gt 0 ]; do
+        # Pop tgt off queue
+        tgt=${queue[0]}; queue=("${queue[@]:1}")
+        nextslot=
+
+        ((pkgnum++))
 
         # If this target belongs to the same script as an already running
         # job, skip it.
@@ -459,41 +528,62 @@ parallel_build() {
             fi
         done
 
-        logmsg "-- Waiting for spare job slot for $tgt"
-
-        err=
-        while :; do
-            for i in `seq 0 $threads`; do
-                # Idle slot?
-                if [ -z "${slots[$i]}" ] || \
-                  ! kill -0 "${slots[$i]}" 2>/dev/null; then
-                    # Reap terminated job
-                    if [ -n "${slots[$i]}" ]; then
-                        #logmsg "-- waiting for job $i (${slots[$i]})..."
-                        wait "${slots[$i]}"
-                        s=$?
-                        if [ $s -ne 0 ]; then
-                            logmsg -e "-- Job $i terminated with status $s"
-                            err="${slottgt[$i]}"
-                            note -e "***** BUILD ERROR ***** ($err)"
-                            break 3
-                        else
-                            logmsg "-- Job $i terminated normally"
-                        fi
-                    fi
-                    note -h "($pkgnum/$pkgcount) Building $tgt (slot $i)"
-                    logprefix="[$i] " build $tgt &
-                    slots[$i]=$!
-                    slottgt[$i]=$tgt
-                    slotdesc[$i]="`printf "(%3d/%d) %s" $pkgnum $pkgcount $tgt`"
-                    slotstart[$i]=`date +%s`
-                    break 2
+        # If this target is expensive and we want to throttle the number
+        # of parallel expensive jobs, then check that we are not running too
+        # many expensive jobs in parallel. If so, then the job is moved
+        # to later on in the queue unless it is already near the end in
+        # which case we just wait until the number of expensive jobs has
+        # dropped before proceeding.
+        if [ "$ETHROTTLE" -gt 0 -a -n "${expensive[$tgt]}" ]; then
+            # Count the number of running expensive targets
+            ne=`count_expensive`
+            if [ $ne -ge $ETHROTTLE ]; then
+                # Calculate the new queue position for this target.
+                # Currently just its position in the expensive array
+                # multipled by 10. If the queue is shorter than the new
+                # location, then the target is just appended.
+                newloc=${expensive[$tgt]}
+                ((newloc *= 10))
+                # Ensure that kayak-kernel remains last
+                if [ $((newloc + 1)) -ge ${#queue[@]} ]; then
+                    newloc=${#queue[@]}
+                    ((newloc -= 2))
                 fi
-            done
-            # Print status summary each minute (approx.)
-            [ `date +%S` -eq 0 ] && job_status
-            sleep 1
-        done
+                # If the new location is at the head of the queue or if
+                # the queue size is less than the number of expensive
+                # packages, then we are draining. Just pause until the
+                # number of expensive jobs has dropped low enough.
+                if [ $newloc -le 0 -o ${#queue[@]} -le ${#expensive[@]} ]; then
+                    logmsg -n "-- $tgt, waiting for number of jobs to drop"
+                    while [ `count_expensive` -gt $ETHROTTLE ]; do
+                        wait_for_slot
+                    done
+                    break
+                else
+                    logmsg -n "-- $tgt, relocating to $newloc/${#queue[@]}"
+                    _queue=("${queue[@]:0:newloc}")
+                    _queue+=($tgt)
+                    _queue+=("${queue[@]:newloc}")
+                    queue=("${_queue[@]}")
+                    # Next queue target
+                    ((pkgnum--))
+                    continue
+                fi
+            fi
+        fi
+
+        if [ -z "$nextslot" ]; then
+            logmsg "-- Waiting for spare job slot for $tgt"
+            wait_for_slot
+            [ -n "$nextslot" ] || break
+        fi
+
+        note -h "($pkgnum/$pkgcount) Building $tgt (slot $nextslot)"
+        logprefix="[$nextslot] " build $tgt &
+        slots[$nextslot]=$!
+        slottgt[$nextslot]=$tgt
+        slotdesc[$nextslot]="`printf "(%3d/%d) %s" $pkgnum $pkgcount $tgt`"
+        slotstart[$nextslot]=`date +%s`
     done
 
     if [ -n "$err" -a -z "$NOKILL_ON_ERROR" ]; then
@@ -512,19 +602,13 @@ parallel_build() {
                     wait "${slots[$i]}"
                     slots[$i]=
                 else
-                    ((running = running + 1))
+                    ((running++))
                 fi
             done
             [ "$running" -eq 0 ] && break
             [ `date +%S` -eq 0 ] && job_status "(draining) "
             sleep 1
         done
-    fi
-
-    if [ -z "$err" -a -z "$SKIP_KAYAK_KERNEL" ]; then
-        # Build this one last
-        note -h "($pkgcount/$pkgcount) Building system/install/kayak-kernel"
-        build system/install/kayak-kernel
     fi
 
     if [ -n "$err" ]; then

--- a/build/gcc44/build.sh
+++ b/build/gcc44/build.sh
@@ -85,6 +85,14 @@ CONFIGURE_OPTS="
 LDFLAGS32="-R/opt/gcc-${VER}/lib"
 export LD_OPTIONS="-zignore -zcombreloc -Bdirect -i"
 
+# If the selected compiler is the same version as the one we're building
+# then the three-stage bootstrap is unecessary and some build time can be
+# saved.
+[ -z "$FORCE_BOOTSTRAP" ] \
+    && [ "`gcc -v 2>&1 | nawk '/^gcc version/ { print $3 }'`" = "$VER" ] \
+    && CONFIGURE_OPTS+=" --disable-bootstrap" \
+    && logmsg "--- disabling bootstrap"
+
 init
 download_source gcc44 ${PROG}-gcc-4.4.4-${ILLUMOSVER}
 patch_source

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -168,20 +168,21 @@ logcmd() {
 
 c_highlight="`tput setaf 2`"
 c_error="`tput setaf 1`"
+c_note="`tput setaf 6`"
 c_reset="`tput sgr0`"
 logmsg() {
     typeset highlight=0
     [ "$1" = "-h" ] && shift && highlight=1
     [ "$1" = "-e" ] && shift && highlight=2
+    [ "$1" = "-n" ] && shift && highlight=3
 
     echo "$logprefix$@" >> $LOGFILE
-    if [ $highlight -eq 1 ]; then
-        echo "$c_highlight$logprefix$@$c_reset"
-    elif [ $highlight -eq 2 ]; then
-        echo "$c_error$logprefix$@$c_reset"
-    else
-        echo "$logprefix$@"
-    fi
+    case $highlight in
+        1) echo "$c_highlight$logprefix$@$c_reset" ;;
+        2) echo "$c_error$logprefix$@$c_reset" ;;
+        3) echo "$c_note$logprefix$@$c_reset" ;;
+        *) echo "$logprefix$@" ;;
+    esac
 }
 
 logerr() {

--- a/lib/site.sh.template
+++ b/lib/site.sh.template
@@ -59,6 +59,9 @@
 #	runtime/java
 #"
 
+# Throttle the number of expensive packages that can be built in parallel
+#ETHROTTLE=3
+
 # To always use the ccache engine to speed up re-compilation
 #USE_CCACHE=1
 


### PR DESCRIPTION
These changes are a set of improvements to the build system to make it more robust and to provide an option to throttle the load a bit and smooth out packages which are expensive to build - meaning that they require a lot of CPU time or disk activity to complete.

To manage system load, it may be preferable to limit the number of these that can be built at
any time. The algorithm used here is pretty crude, it just shunts the expensive package further down
the queue of packages to be built so that smaller packages can be built while we wait for the number of
running expensive builds to fall.

By default, no packages are flagged _expensive_ so build behaviour will not change unless the `lib/site.sh`
file is modified, for example:

```
EXPENSIVE="
        developer/sunstudio12.1
        developer/gcc44
        developer/gcc44/libgmp-gcc44
        developer/gcc44/libmpc-gcc44
        developer/gcc44/libmpfr-gcc44
        developer/gcc5
        developer/gcc7
        developer/gcc8
        developer/java/jdk
        runtime/java
"

ETHROTTLE=3
```

With this configuration in place, here is selected output from a full parallel (6 threads) build, with expensive packages enabled (and some additional debug lines which have since been removed):
(This is not new but a reminder that once some expensive packages have been defined they are not built unless the -e option is provided)

```
% omni bo -e parallel 6

... after a while ...

***
*** (21/235) Building developer/gcc44/libmpc-gcc44 (slot 5)
***
-- developer/gcc44/libmpfr-gcc44 is expensive, checking running jobs
-- 3 expensive job(s) running, defer developer/gcc44/libmpfr-gcc44
-- developer/gcc44/libmpfr-gcc44, relocating to 50/213
-- developer/gcc5, relocating to 60/213
-- developer/gcc7, relocating to 70/206
-- developer/gcc8, relocating to 80/206

######################################################
-- Job status --
    [0]      328 - (   48s) ( 30/235) developer/illumos-closed
    [1]     6762 - (   83s) ( 20/235) developer/gcc44/libgmp-gcc44
    [2]    21035 - (   60s) ( 29/235) developer/gnu-binutils
    [3]     4228 - (   88s) ( 19/235) developer/gcc44
    [4]      722 - (  150s) (  9/235) database/sqlite-3
    [5]     7123 - (   82s) ( 21/235) developer/gcc44/libmpc-gcc44
######################################################

-- developer/java/jdk is expensive, checking running jobs
-- 3 expensive job(s) running, defer developer/java/jdk
-- developer/java/jdk, relocating to 90/203

######################################################
-- Job status --
    [0]      782 - (   21s) ( 32/235) developer/lexer/flex
    [1]     6762 - (  143s) ( 20/235) developer/gcc44/libgmp-gcc44
    [2]    21035 - (  120s) ( 29/235) developer/gnu-binutils
    [3]     4228 - (  148s) ( 19/235) developer/gcc44
    [4]      722 - (  210s) (  9/235) database/sqlite-3
    [5]     7123 - (  142s) ( 21/235) developer/gcc44/libmpc-gcc44
######################################################


[5] Done.
[5] Time: developer/gcc44/libmpc-gcc44 - 259
-- Job 5 terminated normally

-- developer/sunstudio12.1 is expensive, checking running jobs
-- Waiting for spare job slot for developer/sunstudio12.1

***
*** (39/235) Building developer/sunstudio12.1 (slot 4)
***

######################################################
-- Job status --
    [0]     9885 - (   98s) ( 37/235) developer/parser/bison
    [1]     6762 - (  443s) ( 20/235) developer/gcc44/libgmp-gcc44
    [2]    21035 - (  420s) ( 29/235) developer/gnu-binutils
    [3]     4228 - (  448s) ( 19/235) developer/gcc44
    [4]    26371 - (    3s) ( 39/235) developer/sunstudio12.1
    [5]    25143 - (    6s) ( 38/235) developer/pkg-config
######################################################


A bit later...


######################################################
-- Job status --
    [0]    17808 - (  182s) ( 63/235) library/libidn
    [1]     2137 - (    2s) ( 74/235) library/pcre
    [2]     1448 - (  370s) ( 58/235) library/gmp
    [3]     9620 - (   54s) ( 71/235) library/nghttp2
    [4]     4615 - (   56s) ( 70/235) library/ncurses
    [5]    23411 - (   46s) ( 72/235) library/nspr
######################################################

...

***
*** (79/235) Building developer/gcc5 (slot 2)
***

######################################################
-- Job status --
    [0]    20954 - (   13s) ( 82/235) library/python-2/coverage-27
    [1]     2137 - (  122s) ( 74/235) library/pcre
    [2]    14306 - (   38s) ( 79/235) developer/gcc5
    [3]    21086 - (   11s) ( 83/235) library/python-2/cryptography-27
    [4]     4615 - (  176s) ( 70/235) library/ncurses
    [5]    23411 - (  166s) ( 72/235) library/nspr
######################################################

... gcc 7 comes in too after another 10 packages have gone by ...

######################################################
-- Job status --
    [0]    26623 - (  108s) ( 97/235) developer/gcc7
    [1]     2137 - (  362s) ( 74/235) library/pcre
    [2]    14306 - (  278s) ( 79/235) developer/gcc5
    [3]    28654 - (   16s) (103/235) library/python-2/pycparser-27
    [4]     4615 - (  416s) ( 70/235) library/ncurses
    [5]    23411 - (  406s) ( 72/235) library/nspr
######################################################

... and gcc 8 after that ...

######################################################
-- Job status --
    [0]    26623 - (  168s) ( 97/235) developer/gcc7
    [1]     2137 - (  422s) ( 74/235) library/pcre
    [2]    14306 - (  338s) ( 79/235) developer/gcc5
    [3]    29667 - (    5s) (108/235) developer/gcc8
    [4]     4615 - (  476s) ( 70/235) library/ncurses
    [5]    23411 - (  466s) ( 72/235) library/nspr
######################################################

... but at least the JDK build will not start until one of these has finished ...

... it comes around for a second time but, due to too many jobs running,
... gets shunted 90 places down the queue again...

-- developer/java/jdk is expensive, checking running jobs
-- 3 expensive job(s) running, defer developer/java/jdk
-- developer/java/jdk, relocating to 90/113

... both gccs finished ...

######################################################
-- Job status --
    [0]     1461 - (  412s) (168/235) security/sudo
    [1]     2828 - (  124s) (175/235) shell/zsh
    [2]    14858 - (   98s) (178/235) system/install/kayak
    [3]     7115 - (  116s) (176/235) system/bhyve/firmware
    [4]    18886 - ( 3008s) (146/235) library/security/openssl
    [5]     6227 - (  212s) (172/235) shell/bash
######################################################

... and the build completes successfully in due course ...
```
