### PR TITLE
glib2: temporarily disable pthread_setname_np() (r151028)

### DIFF
--- a/build/glib/patches/series
+++ b/build/glib/patches/series
@@ -2,3 +2,4 @@ threadlib.patch
 zignore.patch
 gobject.h.patch
 mntent.patch
+setname.patch

--- a/build/glib/patches/setname.patch
+++ b/build/glib/patches/setname.patch
@@ -1,0 +1,48 @@
+Temporarily disable the detection of pthread_setname_np() and
+pthread_getname_np(). These are present in OmniOS as of r151028 but if
+glib2 uses those symbols then it becomes impossible to build stock
+illumos-gate on OmniOS. Once illumos 8158 is integrated, this patch
+can be removed.
+
+diff -wpruN glib-2.58.1~/configure glib-2.58.1/configure
+--- glib-2.58.1~/configure	2018-10-11 17:39:40.074510944 +0000
++++ glib-2.58.1/configure	2018-10-11 18:08:06.728112453 +0000
+@@ -27237,7 +27237,7 @@ $as_echo_n "checking for pthread_setname
+ int
+ main ()
+ {
+-pthread_setname_np(pthread_self(), "example")
++pthread_setname_np_DISABLED(pthread_self(), "example")
+   ;
+   return 0;
+ }
+@@ -27262,7 +27262,7 @@ $as_echo_n "checking for pthread_getname
+ int
+ main ()
+ {
+-char name[16]; pthread_getname_np(pthread_self(), name, 16);
++char name[16]; pthread_getname_np_DISABLED(pthread_self(), name, 16);
+   ;
+   return 0;
+ }
+diff -wpruN glib-2.58.1~/configure.ac glib-2.58.1/configure.ac
+--- glib-2.58.1~/configure.ac	2018-10-11 17:39:33.279686186 +0000
++++ glib-2.58.1/configure.ac	2018-10-11 18:08:25.891855165 +0000
+@@ -2150,7 +2150,7 @@ AS_IF([ test x"$have_threads" = xposix],
+         AC_LINK_IFELSE(
+             [AC_LANG_PROGRAM(
+                 [#include <pthread.h>],
+-                [pthread_setname_np(pthread_self(), "example")])],
++                [pthread_setname_np_DISABLED(pthread_self(), "example")])],
+             [AC_MSG_RESULT(yes)
+              AC_DEFINE(HAVE_PTHREAD_SETNAME_NP_WITH_TID,1,
+                 [Have function pthread_setname_np(pthread_t, const char*)])],
+@@ -2159,7 +2159,7 @@ AS_IF([ test x"$have_threads" = xposix],
+         AC_LINK_IFELSE(
+             [AC_LANG_PROGRAM(
+                 [#include <pthread.h>],
+-                [[char name[16]; pthread_getname_np(pthread_self(), name, 16);]])],
++                [[char name[16]; pthread_getname_np_DISABLED(pthread_self(), name, 16);]])],
+             [AC_MSG_RESULT(yes)
+              AC_DEFINE(HAVE_PTHREAD_GETNAME_NP,1,
+                 [Have function pthread_getname_np(pthread_t, name, len)])],


### PR DESCRIPTION
Backport for #1061 