### PR TITLE
illumos builds now require python-35

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -35,4 +35,5 @@ depend fmri=system/library/mozilla-nss/header-nss type=require
 depend fmri=system/header type=require
 depend fmri=system/management/snmp/net-snmp type=require
 depend fmri=text/gnu-gettext type=require
-depend fmri=pkg://omnios/runtime/python-27 type=require
+depend fmri=runtime/python-27 type=require
+depend fmri=runtime/python-35 type=require

--- a/build/meta/omnios-build-tools.p5m
+++ b/build/meta/omnios-build-tools.p5m
@@ -46,8 +46,6 @@ depend fmri=runtime/java type=require
 depend fmri=runtime/perl type=require
 depend fmri=runtime/perl-64 type=require
 depend fmri=runtime/perl/manual type=require
-depend fmri=runtime/python-27 type=require
-depend fmri=runtime/python-35 type=require
 depend fmri=service/network/tftp type=require
 depend fmri=system/header/header-audio type=require
 depend fmri=system/library type=require


### PR DESCRIPTION
illumos builds now require python-35
