### PR TITLE
gcc7 is now required for illumos builds

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -8,6 +8,7 @@ depend fmri=developer/bmake type=require
 depend fmri=developer/build/make type=require
 depend fmri=developer/build/onbld type=require
 depend fmri=developer/gcc44 type=require
+depend fmri=developer/gcc7 type=require
 depend fmri=developer/sunstudio12.1 type=require
 depend fmri=developer/gnu-binutils type=require
 depend fmri=developer/illumos-closed type=require


### PR DESCRIPTION
gcc7 is now required for illumos builds
