### PR TITLE
python-35 and gcc7 are now required for building illumos (r151028)

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -8,6 +8,7 @@ depend fmri=developer/bmake type=require
 depend fmri=developer/build/make type=require
 depend fmri=developer/build/onbld type=require
 depend fmri=developer/gcc44 type=require
+depend fmri=developer/gcc7 type=require
 depend fmri=developer/sunstudio12.1 type=require
 depend fmri=developer/gnu-binutils type=require
 depend fmri=developer/illumos-closed type=require
@@ -36,3 +37,4 @@ depend fmri=system/header type=require
 depend fmri=system/management/snmp/net-snmp type=require
 depend fmri=text/gnu-gettext type=require
 depend fmri=pkg://omnios/runtime/python-27 type=require
+depend fmri=pkg://omnios/runtime/python-35 type=require


### PR DESCRIPTION
python-35 and gcc7 are now required for building illumos (r151028)
