### PR TITLE
Change default gcc version to 8

### DIFF
--- a/build/acpica/build.sh
+++ b/build/acpica/build.sh
@@ -25,6 +25,10 @@ DESC="$SUMMARY"
 
 BUILDARCH=32
 
+# This package does not yet build with gcc8. It is set to be removed once
+# the ACPI updates are imported from illumos-gate so use gcc 7 for now.
+set_gccver 7
+
 extract_licence() {
     # Horrible - need to extract the licence from a source file.
     # We choose the BSD licence

--- a/build/gcc-runtime/build-runtime++.sh
+++ b/build/gcc-runtime/build-runtime++.sh
@@ -15,6 +15,7 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../lib/functions.sh
+. common.sh
 
 PKG=system/library/g++-runtime
 PROG=libstdc++
@@ -84,17 +85,17 @@ for v in `seq 5 $VER`; do
         # And now link in the main .so version for the current gcc
 
         logcmd ln -sf $maj usr/lib/$lib.so
-        logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$maj usr/lib/$maj
+        logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$maj usr/lib/$maj
         logcmd ln -sf $maj usr/lib/$ISAPART64/$lib.so
-        logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$maj \
+        logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$maj \
             usr/lib/$ISAPART64/$maj
     done
 done
 
 # And special-case libssl.so.0.0.0
 lib=libssp.so.0.0.0
-logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$lib usr/lib/$lib
-logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$lib \
+logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$lib usr/lib/$lib
+logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$lib \
     usr/lib/$ISAPART64/$lib
 
 # Copy in legacy versions in case old code is linked against them

--- a/build/gcc-runtime/build-runtime.sh
+++ b/build/gcc-runtime/build-runtime.sh
@@ -15,6 +15,7 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../lib/functions.sh
+. common.sh
 
 PKG=system/library/gcc-runtime
 PROG=libgcc_s
@@ -88,16 +89,16 @@ done
 
 # Unversioned links
 for lib in $libs; do
-    logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$lib.so usr/lib/$lib.so
-    logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$lib.so \
+    logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$lib.so usr/lib/$lib.so
+    logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$lib.so \
         usr/lib/amd64/$lib.so
 done
 
 # Special handling for libgcc.so.1
 full=libgcc_s.so.1
 lib=libgcc_s
-logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$full usr/lib/$full
-logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$full \
+logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$full usr/lib/$full
+logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$full \
     usr/lib/$ISAPART64/$full
 logcmd ln -sf $full usr/lib/$lib.so
 logcmd ln -sf $full usr/lib/$ISAPART64/$lib.so

--- a/build/gcc-runtime/build-runtimef.sh
+++ b/build/gcc-runtime/build-runtimef.sh
@@ -15,6 +15,7 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/functions.sh
+. common.sh
 
 PKG=system/library/gfortran-runtime
 PROG=gfortran
@@ -88,15 +89,15 @@ done
 
 # Unversioned links
 for lib in $libs; do
-    logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$lib.so usr/lib/$lib.so
-    logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$lib.so \
+    logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$lib.so usr/lib/$lib.so
+    logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$lib.so \
         usr/lib/amd64/$lib.so
 done
 
 # And special-case libquadmath.so.0.0.0
 lib=libquadmath.so.0.0.0
-logcmd ln -sf ../gcc/$DEFAULT_GCC_VER/lib/$lib usr/lib/$lib
-logcmd ln -sf ../../gcc/$DEFAULT_GCC_VER/lib/$ISAPART64/$lib \
+logcmd ln -sf ../gcc/$SHARED_GCC_VER/lib/$lib usr/lib/$lib
+logcmd ln -sf ../../gcc/$SHARED_GCC_VER/lib/$ISAPART64/$lib \
     usr/lib/$ISAPART64/$lib
 
 popd >/dev/null

--- a/build/gcc-runtime/common.sh
+++ b/build/gcc-runtime/common.sh
@@ -1,0 +1,11 @@
+
+# Any binaries compiled before we separated out the lib directories for each
+# major gcc version will load libraries from /usr/lib.
+# Even though there was not supposed to be an ABI change, experience has
+# shown that binaries built with older GCC versions experience problems
+# when loading the runtimes from gcc8. For that reason, retain version 7
+# libraries in /usr/lib. Anything built more recently will use
+# version-specific paths.
+
+SHARED_GCC_VER=7
+

--- a/build/nasm/build.sh
+++ b/build/nasm/build.sh
@@ -25,6 +25,11 @@ SUMMARY="The Netwide Assembler"
 DESC="$SUMMARY"
 
 set_arch 32
+# This package does not yet build with gcc8.
+# ./include/nasmlib.h:194:1: error: 'pure' attribute on function returning
+#     'void' [-Werror=attributes]
+# void pure_func seg_init(void);
+set_gccver 7
 
 init
 download_source $PROG $PROG $VER

--- a/build/openssh/build.sh
+++ b/build/openssh/build.sh
@@ -34,11 +34,6 @@ SUMMARY="OpenSSH Client and utilities"
 DESC="OpenSSH Secure Shell protocol Client and associated Utilities"
 
 set_arch 64
-# OpenSSH enables spectre mitigations during build if the compiler
-# supports them. Our gcc 7 does, but they don't work and produce crashing
-# binaries. Since we want the mitigations in something like openssh, we
-# use gcc 8.
-set_gccver 8
 
 CONFIGURE_OPTS_64+="
     --sysconfdir=/etc/ssh

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -192,7 +192,7 @@ CC=gcc
 CXX=g++
 
 # Specify default versions for building packages
-DEFAULT_GCC_VER=7
+DEFAULT_GCC_VER=8
 PYTHON2VER=2.7
 PYTHON3VER=3.5
 DEFAULT_PYTHON_VER=$PYTHON2VER


### PR DESCRIPTION
Two packages fail to build with gcc8 and so have been left on gcc7:

`acpica` - which will be removed soon anyway once illumos-gate has the new ACPI support integrated;
`nasm` - needs further investigation.