### PR TITLE
Replace ntp with ntpsec in default image

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -275,7 +275,7 @@ service/file-system/nfs				0.5.11	require
 service/file-system/smb				0.5.11	require
 service/hal					0.5.11	require
 service/network/network-clients			0.5.11	require
-service/network/ntp				4.2.8	optional
+service/network/ntpsec				1.1	optional
 service/network/smtp/dma			0.11	require		F
 service/picl					0.5.11	require
 service/resource-pools				0.5.11	require


### PR DESCRIPTION
Although it can be subsequently removed, we ship `ntp` in our default installation images. This should be replaced by the newer and better maintained `ntpsec`.