### PR TITLE
Remove SHA2 hashes from manifests when comparing

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1213,6 +1213,7 @@ pkgitems() {
         s/^file [^ ]+/file/
         s/ chash=[^ ]+//
         s/ elfhash=[^ ]+//
+        s/ pkg.content-hash=[^ ]+//g
         # Remove file sizes
         s/ pkg.[c]?size=[0-9]+//g
         # Remove timestamps


### PR DESCRIPTION
Remove SHA2 hashes from manifests when comparing
