### PR TITLE
Skip dashrev lock for release/name

### DIFF
--- a/build/jeos/build-userland.sh
+++ b/build/jeos/build-userland.sh
@@ -44,8 +44,9 @@ add_constraints()
             logerr "Bad package line, $pkg $ver"
         fi
         [ -z "$dash" ] && dash=0
+        [ "$dash" = "-" ] && dash= || dash=".$dash"
         echo "depend facet.version-lock.$pkg=true"\
-            "fmri=$pkg@$ver,5.11-@RELVER@.$dash type=incorporate" \
+            "fmri=$pkg@$ver,5.11-@RELVER@$dash type=incorporate" \
             >> $cmf
     done
 }

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -95,7 +95,7 @@ network/rsync				3.1
 network/service/isc-dhcp		4.4
 network/test/iperf			3
 network/test/netperf			2.7
-release/name				0.5.11
+release/name				0.5.11	-
 release/notices				0.5.11
 runtime/java				1.7.0
 runtime/perl-64				5.28


### PR DESCRIPTION
The `release/name` package has a dash-revision which reflects the release suffix. `omnios-userland` needs to allow any dash revision rather than just 0