### PR TITLE
gcc8 - use newer no-clone-functions patch

### DIFF
--- a/build/gcc8/patches/0006-allow-the-global-disabling-of-function-cloning.patch
+++ b/build/gcc8/patches/0006-allow-the-global-disabling-of-function-cloning.patch
@@ -1,7 +1,7 @@
-From bb799405ca0a1bf7284bb050ec4c91f91d11abe1 Mon Sep 17 00:00:00 2001
+From 458d6bc81262364726bdc39953c940098ac59c12 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sun, 30 Sep 2012 16:44:14 -0400
-Subject: [PATCH 06/12] allow the global disabling of function cloning
+Subject: [PATCH] allow the global disabling of function cloning
 
 Optimizations which clone functions to create call-specific implementations
 which may be better optimized also dissociate these functions from their
@@ -11,7 +11,25 @@ having the actual source symbol name).
 
 This allows any function cloning to be disabled, and makes any such
 optimization ineffective, and our source safe for debuggers everywhere.
-
+diff -wpruN '--exclude=*.orig' a~/gcc/attribs.c a/gcc/attribs.c
+--- a~/gcc/attribs.c	1970-01-01 00:00:00
++++ a/gcc/attribs.c	1970-01-01 00:00:00
+@@ -541,6 +541,15 @@ decl_attributes (tree *node, tree attrib
+ 	attributes = tree_cons (get_identifier ("no_icf"),  NULL, attributes);
+     }
+ 
++  /* If the user passed -fno-clone-functions, all functions should be treated
++     as "noclone" */
++  if (TREE_CODE (*node) == FUNCTION_DECL
++      && !flag_clone_functions)
++    {
++      if (lookup_attribute ("noclone", attributes) == NULL)
++	attributes = tree_cons (get_identifier ("noclone"),  NULL, attributes);
++    }
++
+   targetm.insert_attributes (*node, &attributes);
+ 
+   /* Note that attributes on the same declaration are not necessarily
 diff -wpruN '--exclude=*.orig' a~/gcc/common.opt a/gcc/common.opt
 --- a~/gcc/common.opt	1970-01-01 00:00:00
 +++ a/gcc/common.opt	1970-01-01 00:00:00
@@ -55,20 +73,3 @@ diff -wpruN '--exclude=*.orig' a~/gcc/doc/invoke.texi a/gcc/doc/invoke.texi
  @item -fipa-ra
  @opindex fipa-ra
  Use caller save registers for allocation if those registers are not used by
-diff -wpruN '--exclude=*.orig' a~/gcc/tree-inline.c a/gcc/tree-inline.c
---- a~/gcc/tree-inline.c	1970-01-01 00:00:00
-+++ a/gcc/tree-inline.c	1970-01-01 00:00:00
-@@ -3523,6 +3523,13 @@ copy_forbidden (struct function *fun)
-   if (fun->cannot_be_copied_set)
-     return reason;
- 
-+  if (!flag_clone_functions)
-+    {
-+      reason = G_("function %q+F can never be copied "
-+		  "due to -fno-clone-functions");
-+      goto fail;
-+    }
-+
-   /* We cannot copy a function that receives a non-local goto
-      because we cannot remap the destination label used in the
-      function that is performing the non-local goto.  */


### PR DESCRIPTION
gcc8 - use newer no-clone-functions patch
