### PR TITLE
Move bind to 64-bit, add comment clarifying library status, drop python modules.

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -31,9 +31,13 @@ VER=9.11.5
 VERHUMAN=$VER
 PKG=network/dns/bind
 SUMMARY="BIND DNS tools"
-DESC="$SUMMARY"
+DESC="Client utilities for DNS lookups"
 
-set_arch 32
+# This package ships private shared libraries in $PREFIX/lib/dns that are only
+# provided for use by the client utilities. We can therefore build everything
+# as 64-bit only and avoid shipping the include files, python modules and
+# library man pages (see local.mog)
+set_arch 64
 
 CONFIGURE_OPTS="
     --libdir=$PREFIX/lib/dns
@@ -43,12 +47,12 @@ CONFIGURE_OPTS="
     --with-openssl
     --enable-threads=yes
     --enable-devpoll=yes
-    --disable-openssl-version-check
     --enable-fixed-rrset
     --disable-getifaddrs
     --with-pkcs11
     --enable-shared
     --disable-static
+    --without-python
 "
 
 init
@@ -56,7 +60,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-python_vendor_relocate
 VER=${VER//-P/.}
 VER=${VER//-W/.}
 make_package


### PR DESCRIPTION
The first commit in the build.sh history is this:

```
commit 3b48761d8f2ee0331b0acae003baf11af93f7b30
Author: Eric Sproul <esproul@omniti.com>
Date:   Mon Mar 12 17:34:40 2012 +0000

    tid18365 network/dns/bind (BIND utilities). 
   Since the shared libs are not the exported versions and are used only in
   support of the client binaries, we just build 32-bit.
```

I've added an explanatory comment to the build.sh about this and moved to 64-bit. We have never shipped the include files so the libraries - in their private location - should not be depended on by anything.
Also, since everything apart from the client utilities is private here, dropped the python modules entirely.