### PR TITLE
screen: use ncurses (r151022)

### DIFF
--- a/build/screen/build.sh
+++ b/build/screen/build.sh
@@ -22,6 +22,7 @@
 #
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
 # Load support functions
@@ -37,13 +38,12 @@ DESC="$SUMMARY"
 TAR=gtar
 
 BUILDARCH=32
-CONFIGURE_OPTS_32="$CONFIGURE_OPTS_32 --bindir=/usr/bin --with-sys-screenrc=/etc/screenrc --enable-colors256 LDFLAGS=-lxnet"
-gnu_cleanup() {
-    logcmd rm $DESTDIR/usr/bin/screen
-    logcmd mv $DESTDIR/usr/bin/screen-${VER} $DESTDIR/usr/bin/screen
-    logcmd mv $DESTDIR/usr/man $DESTDIR/usr/share/
-    logcmd mv $DESTDIR/usr/info $DESTDIR/usr/share/
-}
+CONFIGURE_OPTS+="
+	--bindir=/usr/bin
+	--with-sys-screenrc=/etc/screenrc
+	--enable-colors256
+	LDFLAGS=-lxnet
+"
 
 save_function make_install make_install_orig
 make_install() {
@@ -60,8 +60,6 @@ download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
-gnu_cleanup
 strip_install
-make_isa_stub
 make_package
 clean_up

--- a/build/screen/local.mog
+++ b/build/screen/local.mog
@@ -21,7 +21,13 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
 #
+
+<transform link path=usr/bin/screen -> drop>
+<transform file path=usr/bin/screen-.* -> set path usr/bin/screen>
+<transform file dir link path=usr/man -> edit path usr/man usr/share/man>
+
 <transform file path=etc/screenrc$ -> set preserve renamenew>
 license COPYING license=GPLv2

--- a/build/screen/patches/Makefile.in.patch
+++ b/build/screen/patches/Makefile.in.patch
@@ -1,7 +1,8 @@
---- Makefile.in.orig	Wed Jan  7 15:18:56 2009
-+++ Makefile.in	Wed Jan  7 15:19:26 2009
-@@ -15,7 +15,7 @@
- exec_prefix = @exec_prefix@
+diff -pruN '--exclude=*.orig' screen-4.6.1~/Makefile.in screen-4.6.1/Makefile.in
+--- screen-4.6.1~/Makefile.in	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/Makefile.in	2017-10-18 10:04:34.021872031 +0000
+@@ -17,7 +17,7 @@ datarootdir = @datarootdir@
+ datadir = @datadir@
  
  # don't forget to change mandir and infodir in doc/Makefile.
 -bindir  = $(exec_prefix)/bin

--- a/build/screen/patches/ncurses.patch
+++ b/build/screen/patches/ncurses.patch
@@ -1,0 +1,46 @@
+This patch makes configure check for ncurses before curses so that screen
+can take advantage of the latest terminal type information from our
+ncurses package.
+
+diff -pruN '--exclude=*.orig' screen-4.6.1~/configure screen-4.6.1/configure
+--- screen-4.6.1~/configure	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/configure	2017-10-18 10:04:34.096877437 +0000
+@@ -4825,7 +4825,7 @@ if ac_fn_c_try_link "$LINENO"; then :
+ 
+ else
+   olibs="$LIBS"
+-LIBS="-lcurses $olibs"
++LIBS="-lncurses $olibs"
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking libcurses..." >&5
+ $as_echo "$as_me: checking libcurses..." >&6;}
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -4916,7 +4916,7 @@ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+ 
+ else
+-  LIBS="-lncurses $olibs"
++  LIBS="-lcurses $olibs"
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking libncurses..." >&5
+ $as_echo "$as_me: checking libncurses..." >&6;}
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+diff -pruN '--exclude=*.orig' screen-4.6.1~/configure.ac screen-4.6.1/configure.ac
+--- screen-4.6.1~/configure.ac	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/configure.ac	2017-10-18 10:04:34.097268379 +0000
+@@ -631,7 +631,7 @@ dnl
+ AC_CHECKING(for tgetent)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+ olibs="$LIBS"
+-LIBS="-lcurses $olibs"
++LIBS="-lncurses $olibs"
+ AC_CHECKING(libcurses)
+ AC_TRY_LINK(,[
+ #ifdef __hpux
+@@ -652,7 +652,7 @@ AC_TRY_LINK(,tgetent((char *)0, (char *)
+ LIBS="-ltinfow $olibs"
+ AC_CHECKING(libtinfow)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+-LIBS="-lncurses $olibs"
++LIBS="-lcurses $olibs"
+ AC_CHECKING(libncurses)
+ AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+ LIBS="-ltinfo $olibs"

--- a/build/screen/patches/series
+++ b/build/screen/patches/series
@@ -1,2 +1,3 @@
-Makefile.in.patch -p0
-xnet-hack.patch -p1
+Makefile.in.patch
+xnet-hack.patch
+ncurses.patch

--- a/build/screen/patches/xnet-hack.patch
+++ b/build/screen/patches/xnet-hack.patch
@@ -1,7 +1,8 @@
-diff -ru screen-4.2.1-orig/socket.c screen-4.2.1/socket.c
---- screen-4.2.1-orig/socket.c	Sat Apr 26 12:22:43 2014
-+++ screen-4.2.1/socket.c	Wed Aug 13 17:39:58 2014
-@@ -31,7 +31,9 @@
+diff -pruN '--exclude=*.orig' screen-4.6.1~/socket.c screen-4.6.1/socket.c
+--- screen-4.6.1~/socket.c	2017-07-10 19:26:25.000000000 +0000
++++ screen-4.6.1/socket.c	2017-10-18 10:04:34.059604565 +0000
+@@ -33,7 +33,9 @@
+ #include <sys/types.h>
  #include <sys/stat.h>
  #include <fcntl.h>
  #if !defined(NAMEDPIPE)


### PR DESCRIPTION
We changed screen to use ncurses in October 2017 but did not backport it to r151022.
Now an r151022 user has reported that screen is not working with xterm256-color