### PR TITLE
 Explicitly specify compiler for pkg5 build

### DIFF
--- a/build/pkg/build.sh
+++ b/build/pkg/build.sh
@@ -31,8 +31,6 @@
 # list to use later when showing package differences.
 PKG=package/pkg
 PKGLIST=$PKG
-PKG=package/pkg-35
-PKGLIST+=" $PKG"
 PKG=system/zones/brand/ipkg
 PKGLIST+=" $PKG"
 PKG=system/zones/brand/lipkg
@@ -75,9 +73,10 @@ build() {
     pushd $TMPDIR/$BUILDDIR/pkg/src > /dev/null || logerr "Cannot chdir"
     logmsg "--- toplevel build"
     logcmd make clean
-    logcmd make CODE_WS=$TMPDIR/$BUILDDIR/pkg || logerr "make failed"
+    logcmd make CC=$GCC CODE_WS=$TMPDIR/$BUILDDIR/pkg || logerr "make failed"
     logmsg "--- proto install"
-    logcmd make install CODE_WS=$TMPDIR/$BUILDDIR/pkg || logerr "install failed"
+    logcmd make install CC=$GCC CODE_WS=$TMPDIR/$BUILDDIR/pkg \
+        || logerr "install failed"
     popd > /dev/null
 }
 
@@ -86,9 +85,11 @@ package() {
     logmsg "--- packaging"
     logcmd make clean
     logcmd make \
+        CC=$GCC \
         CODE_WS=$TMPDIR/$BUILDDIR/pkg \
         BUILDNUM=$BUILDNUM || logerr "pkg make failed"
     logcmd make publish-pkgs \
+        CC=$GCC \
         CODE_WS=$TMPDIR/$BUILDDIR/pkg \
         BUILDNUM=$BUILDNUM \
         PKGSEND_OPTS="" \

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -354,7 +354,9 @@ set_gccver() {
     GCCVER="$1"
     [ -z "$2" ] && logmsg "-- Setting GCC version to $GCCVER"
     GCCPATH="/opt/gcc-$GCCVER"
-    [ -x "$GCCPATH/bin/gcc" ] || logerr "Unknown compiler version $GCCVER"
+    GCC="$GCCPATH/bin/gcc"
+    GXX="$GCCPATH/bin/g++"
+    [ -x "$GCC" ] || logerr "Unknown compiler version $GCCVER"
     PATH="$GCCPATH/bin:$BASEPATH"
     for cmd in gcc g++; do
         [ -h $TMPDIR/tools/$cmd ] && rm -f $TMPDIR/tools/$cmd
@@ -364,7 +366,7 @@ set_gccver() {
         [ -x $CCACHE_PATH/ccache ] || logerr "Ccache is not installed"
         PATH="$CCACHE_PATH:$PATH"
     fi
-    export GCCVER GCCPATH PATH
+    export GCC GXX GCCVER GCCPATH PATH
 }
 
 set_gccver $DEFAULT_GCC_VER -q


### PR DESCRIPTION
At present, pkg5 is partially built with gcc4 and partially with gcc8. Change the build script to explicitly pass the desired compiler version.

NB: The test suite currently needs to be run with gcc4 due to tests that do not expect the compiler to create binaries with a runpath including /usr/lib/gcc/8 - this still needs resolving.