### PR TITLE
with 9997, illumos builds now require idnkit

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -20,6 +20,8 @@ depend fmri=developer/versioning/mercurial type=require
 depend fmri=developer/versioning/git type=require
 depend fmri=developer/library/lint type=require
 depend fmri=library/glib2 type=require
+depend fmri=library/idnkit type=require
+depend fmri=library/idnkit/header-idnkit type=require
 depend fmri=library/libxml2 type=require
 depend fmri=library/libxslt type=require
 depend fmri=library/nspr/header-nspr type=require

--- a/build/meta/omnios-build-tools.p5m
+++ b/build/meta/omnios-build-tools.p5m
@@ -31,8 +31,6 @@ depend fmri=file/gnu-coreutils type=require
 depend fmri=library/expat type=require
 depend fmri=library/glib2 type=require
 depend fmri=library/gmp type=require
-depend fmri=library/idnkit type=require
-depend fmri=library/idnkit/header-idnkit type=require
 depend fmri=library/libffi type=require
 depend fmri=library/libidn type=require
 depend fmri=library/nspr/header-nspr type=require


### PR DESCRIPTION
with 9997, illumos builds now require idnkit
