### PR TITLE
Following 9978, remove lint libraries

### DIFF
--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -33,8 +33,6 @@ SUMMARY="XML C parser and toolkit"
 DESC="Portable XML parser and toolkit library"
 
 RUN_DEPENDS_IPS="compress/xz library/zlib"
-# For lint library creation
-BUILD_DEPENDS_IPS="developer/sunstudio12.1"
 
 XFORM_ARGS="-D VER=$VER"
 
@@ -48,7 +46,6 @@ patch_source
 prep_build
 build
 run_testsuite check
-make_lintlibs xml2 /usr/lib /usr/include/libxml2 "libxml/*.h"
 make_isa_stub
 make_package local.mog final.mog
 clean_up

--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -35,8 +35,6 @@ SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "
 DESC+="and general purpose cryptographic library"
 
-BUILD_DEPENDS_IPS+=" developer/sunstudio12.1"
-
 # Generic options for both 32 and 64bit variants
 base_OPENSSL_CONFIG_OPTS="shared threads zlib enable-ssl2 enable-ssl3"
 base_LDFLAGS="-shared -Wl,-z,text,-z,aslr,-z,ignore"
@@ -129,8 +127,8 @@ version_files() {
     logcmd mkdir -p usr/ssl/lib usr/ssl/lib/amd64
     logcmd mv usr/lib/pkgconfig usr/ssl/lib/pkgconfig
     logcmd mv usr/lib/amd64/pkgconfig usr/ssl/lib/amd64/pkgconfig
-    logcmd mv lib/llib* lib/lib*.a usr/ssl/lib
-    logcmd mv lib/amd64/llib* lib/amd64/lib*.a usr/ssl/lib/amd64
+    logcmd mv lib/lib*.a usr/ssl/lib
+    logcmd mv lib/amd64/lib*.a usr/ssl/lib/amd64
 
     logcmd rm -f lib/lib{crypto,ssl}.so
     logcmd rm -f lib/amd64/lib{crypto,ssl}.so
@@ -175,8 +173,6 @@ if [ -z "$FLAVOR" -o "$FLAVOR" = "1.1" ]; then
     (cd $DESTDIR; gpatch -p1 < $SRCDIR/$PATCHDIR/post/opensslconf.dualarch)
     run_testsuite
     move_libs
-    make_lintlibs crypto /lib /usr/include "openssl/!(asn1_mac|ssl*|*tls*).h"
-    make_lintlibs ssl /lib /usr/include "openssl/{ssl,*tls}*.h"
 fi
 
 ######################################################################
@@ -215,8 +211,6 @@ if [ -z "$FLAVOR" -o "$FLAVOR" = "1.0" ]; then
     (cd $DESTDIR; gpatch -p1 < $SRCDIR/$PATCHDIR/post/opensslconf.dualarch)
     run_testsuite test "" testsuite.1.0.log
     move_libs
-    make_lintlibs crypto /lib /usr/include "openssl/!(ssl*|*tls*).h"
-    make_lintlibs ssl /lib /usr/include "openssl/{ssl,*tls}*.h"
 
     PKG=$oPKG ##IGNORE##
     PKGE=$oPKGE

--- a/build/openssl/local.mog
+++ b/build/openssl/local.mog
@@ -72,16 +72,6 @@ link path=usr/lib/amd64/libcrypto.so.1.1 target=../../../lib/amd64/libcrypto.so.
     link path=lib/amd64/%<2> target=../../%(path) \
     mediator=openssl mediator-version=%<1> >
 
-# lint libraries
-
-<transform file path=usr/ssl-([^/]+)/lib/(llib.*) -> emit \
-    link path=lib/%<2> target=../%(path) \
-    mediator=openssl mediator-version=%<1> >
-
-<transform file path=usr/ssl-([^/]+)/lib/amd64/(llib.*) -> emit \
-    link path=lib/amd64/%<2> target=../../%(path) \
-    mediator=openssl mediator-version=%<1> >
-
 # pkgconfig
 
 <transform file path=usr/ssl-([^/]+)/lib/pkgconfig/(.*) -> emit \

--- a/build/trousers/build.sh
+++ b/build/trousers/build.sh
@@ -33,9 +33,6 @@ PKG=library/security/trousers
 SUMMARY="trousers - TCG Software Stack - software for accessing a TPM device"
 DESC="$SUMMARY"
 
-# For lint lib creation
-BUILD_DEPENDS_IPS="developer/sunstudio12.1"
-
 LIBS="-lbsm -lnsl -lsocket -lgen -lscf -lresolv"
 
 CONFIGURE_OPTS+="
@@ -62,7 +59,6 @@ patch_source
 fix_headers
 prep_build
 build
-make_lintlibs tspi /usr/lib /usr/include "{tss,trousers}/*.h"
 make_isa_stub
 install_smf application/security tcsd.xml tcsd
 make_package

--- a/build/zlib/build.sh
+++ b/build/zlib/build.sh
@@ -24,7 +24,6 @@ SUMMARY="$PROG - A massively spiffy yet delicately unobtrusive compression libra
 DESC="$SUMMARY"
 
 DEPENDS_IPS="system/library/gcc-runtime"
-BUILD_DEPENDS_IPS="$DEPENDS_IPS developer/sunstudio12.1"
 
 CFLAGS+=" -DNO_VIZ"
 
@@ -80,7 +79,6 @@ patch_source
 prep_build
 build
 run_testsuite
-make_lintlibs z /usr/lib /usr/include
 make_isa_stub
 install_license
 move_libs

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -433,7 +433,6 @@ BasicRequirements() {
     [ -x $GCCPATH/bin/gcc ] || needed+=" developer/gcc$GCCVER"
     [ -x /usr/bin/ar ] || needed+=" developer/object-file"
     [ -x /usr/bin/ld ] || needed+=" developer/linker"
-    [ -f /usr/lib/crt1.o ] || needed+=" developer/library/lint"
     [ -x /usr/bin/gmake ] || needed+=" developer/build/gnu-make"
     [ -f /usr/include/sys/types.h ] || needed+=" system/header"
     [ -f /usr/include/math.h ] || needed+=" system/library/math"
@@ -1514,41 +1513,6 @@ make_install_in() {
     logmsg "------ make install in $1"
     logcmd $MAKE -C $1 DESTDIR=${DESTDIR} install || \
         logerr "------ Make install in $1 failed"
-}
-
-make_lintlibs() {
-    logmsg "Making lint libraries"
-
-    LINTLIB=$1
-    LINTLIBDIR=$2
-    LINTINCDIR=$3
-    LINTINCFILES=$4
-
-    [ -z "$LINTLIB" ] && logerr "not lint library specified"
-    [ -z $"LINTINCFILES" ] && LINTINCFILES="*.h"
-
-    cat <<EOF > ${DTMPDIR}/${PKGD}_llib-l${LINTLIB}
-/* LINTLIBRARY */
-/* PROTOLIB1 */
-#include <sys/types.h>
-#undef _LARGEFILE_SOURCE
-EOF
-    pushd ${DESTDIR}${LINTINCDIR} > /dev/null
-    sh -c "eval /usr/gnu/bin/ls -U ${LINTINCFILES}" | \
-        sed -e 's/\(.*\)/#include <\1>/' >> ${DTMPDIR}/${PKGD}_llib-l${LINTLIB}
-    popd > /dev/null
-
-    pushd ${DESTDIR}${LINTLIBDIR} > /dev/null
-    logcmd /opt/sunstudio12.1/bin/lint -nsvx -I${DESTDIR}${LINTINCDIR} \
-        -o ${LINTLIB} ${DTMPDIR}/${PKGD}_llib-l${LINTLIB} || \
-        logerr "failed to generate 32bit lint library ${LINTLIB}"
-    popd > /dev/null
-
-    pushd ${DESTDIR}${LINTLIBDIR}/amd64 > /dev/null
-    logcmd /opt/sunstudio12.1/bin/lint -nsvx -I${DESTDIR}${LINTINCDIR} -m64 \
-        -o ${LINTLIB} ${DTMPDIR}/${PKGD}_llib-l${LINTLIB} || \
-        logerr "failed to generate 64bit lint library ${LINTLIB}"
-    popd > /dev/null
 }
 
 build() {


### PR DESCRIPTION

https://illumos.org/issues/9978 removed the requirement to run lint against illumos-gate, and we mirrored the same change to illumos-omnios builds.

See also https://illumos.org/issues/10011