### PR TITLE
sccs: update to 5.08

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -30,7 +30,7 @@ developer/sunstudio12.1			12.1
 developer/swig				3.0
 developer/versioning/git		2
 developer/versioning/mercurial		4
-developer/versioning/sccs		0.5.11
+developer/versioning/sccs		5
 driver/tuntap				1.3
 driver/virtualization/kvm		1.0
 editor/vim				8

--- a/build/sccs/build.sh
+++ b/build/sccs/build.sh
@@ -1,70 +1,46 @@
 #!/usr/bin/bash
 #
-# {{{ CDDL HEADER START
+# {{{ CDDL HEADER
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License, Version 1.0 only
-# (the "License").  You may not use this file except in compliance
-# with the License.
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END }}}
-#
-# Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-# Use is subject to license terms.
 
 . ../../lib/functions.sh
 
 PROG=sccs
-VER=0.5.11
+VER=5.08
 PKG=developer/versioning/sccs
 SUMMARY="Source Code Control System (SCCS)"
-DESC="$SUMMARY"
+DESC="The POSIX standard Source Code Control System (SCCS)"
 
-BUILD_DEPENDS_IPS="sunstudio12.1 compatibility/ucb"
-RUN_DEPENDS_IPS="system/library/math"
+set_arch 32
+MAKE=dmake
+NO_PARALLEL_MAKE=1
 
-build() {
-    logmsg "Building and installing ($1)"
-    pushd $TMPDIR/$1/usr/src > /dev/null || logerr "can't enter build harness"
-    logcmd env STUDIOBIN=$SUNSTUDIO_BIN DESTDIR=$DESTDIR ./build \
-        || logerr "make/install ($1) failed"
-    popd > /dev/null
-}
+HARDLINK_TARGETS="
+    usr/bin/cdc
+    usr/bin/sact
+"
 
-move_and_links() {
-    logmsg "Shifting binaries and setting up links"
-    logcmd mkdir -p $DESTDIR/usr/bin
-    logcmd mv $DESTDIR/usr/ccs/bin/help $DESTDIR/usr/bin/sccshelp \
-        || logerr "help move failed"
-    pushd $DESTDIR/usr/ccs/bin > /dev/null || logerr "Cannot chdir"
-    for cmd in *; do
-        [ -x "$cmd" ] || continue
-        logcmd mv $cmd ../../bin/ || logerr "Cannot relocate /usr/ccs/bin/$cmd"
-        logcmd ln -s ../../bin/$cmd $cmd || logerr "Link $cmd failed"
-    done
-    logcmd ln -s ../../bin/sccshelp sccshelp || logerr "sccshelp link"
-    logcmd ln -s ../../bin/sccshelp help || logerr "sccshelp link2"
-    popd > /dev/null
-}
+# sccs uses the schily build environment so neither the clean nor configure
+# step are required.
+make_clean() { :; }
+configure32() { :; }
 
 init
 prep_build
-BUILDDIR=devpro-sccs-20061219
-download_source devpro devpro-sccs src-20061219
-build devpro-sccs-20061219
-move_and_links
+download_source $PROG $PROG $VER
+patch_source
+build
 make_package
 clean_up
 

--- a/build/sccs/local.mog
+++ b/build/sccs/local.mog
@@ -1,29 +1,44 @@
 #
-# CDDL HEADER START
+# {{{ CDDL HEADER
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License, Version 1.0 only
-# (the "License").  You may not use this file except in compliance
-# with the License.
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
-#
-#
-# Copyright 2015 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Use is subject to license terms.
-#
-<transform dir path=usr/xpg4.* -> drop>
-<transform file path=usr/xpg4/bin/.* -> drop>
-<transform link path=usr/xpg4/bin/.* -> drop>
-license usr/src/OPENSOLARIS.LICENSE license=CDDL
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+license CDDL.Schily.txt license=CDDL
+license GPL-2.0.txt license=GPLv2
+
+<transform path=usr/include -> drop>
+<transform path=usr/lib/(?!help) -> drop>
+<transform path=usr/share/man/man3 -> drop>
+#<transform path=usr/xpg4 -> drop>
+
+dir group=bin mode=0755 owner=root path=usr/ccs
+dir group=bin mode=0755 owner=root path=usr/ccs/bin
+
+# We do not want such a generic command as 'help' in /usr/bin but it should
+# still exist in /usr/ccs/bin. Move help -> sccshelp and setup symlinks
+# appropriately.
+<transform file path=usr/bin/help$ -> edit path help sccshelp>
+link path=usr/ccs/bin/help target=sccshelp
+<transform file path=usr/share/man/man1/help.1$ -> edit path help sccshelp>
+
+# Drop diff binaries and libraries
+<transform file path=usr/bin/b?diff$ -> drop>
+<transform file path=usr/lib/diffh -> drop>
+<transform file path=usr/share/man/man1/b?diff.1$ -> drop>
+<transform file path=usr/share/man/man1/patch.1$ -> drop>
+
+# Compatibility links from old make package
+#  - symlink all binaries to /usr/ccs/bin/
+<transform file link hardlink path=usr/bin/(.*) -> emit \
+    link path=usr/ccs/bin/%<1> target=../../bin/%<1> >
+

--- a/build/sccs/patches/03.Defaults.sunos5.patch
+++ b/build/sccs/patches/03.Defaults.sunos5.patch
@@ -1,0 +1,29 @@
+diff -wpruN '--exclude=*.orig' a~/DEFAULTS/Defaults.sunos5 a/DEFAULTS/Defaults.sunos5
+--- a~/DEFAULTS/Defaults.sunos5	1970-01-01 00:00:00
++++ a/DEFAULTS/Defaults.sunos5	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@
+ # Compiler stuff
+ #
+ ###########################################################################
+-DEFCCOM=	cc
++DEFCCOM=	gcc
+ #DEFCCOM=	gcc
+ 
+ ###########################################################################
+@@ -32,14 +32,14 @@ DEFINCDIRS=	$(SRCROOT)/include
+ DEFOSINCDIRS=
+ LDPATH=		-L/opt/schily/lib
+ #RUNPATH=	-R$(INS_BASE)/lib -R/opt/schily/lib -R$(OLIBSDIR)
+-RUNPATH=	-R$(INS_BASE)/lib -R/opt/schily/lib
++#RUNPATH=	-R$(INS_BASE)/lib
+ 
+ ###########################################################################
+ #
+ # Installation config stuff
+ #
+ ###########################################################################
+-INS_BASE=	/opt/schily
++INS_BASE=	/usr
+ INS_KBASE=	/
+ INS_RBASE=	/
+ #

--- a/build/sccs/patches/04.remove_ccs.patch
+++ b/build/sccs/patches/04.remove_ccs.patch
@@ -1,0 +1,1370 @@
+/usr/ccs/ path is deprecated and should be used only for compatibility
+
+diff -wpruN '--exclude=*.orig' a~/patch/patch_sym.mk a/patch/patch_sym.mk
+--- a~/patch/patch_sym.mk	1970-01-01 00:00:00
++++ a/patch/patch_sym.mk	1970-01-01 00:00:00
+@@ -6,7 +6,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ _EXEEXT=	$(EXEEXT)
+ 
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		sccspatch
+ ORIG=		spatch
+ PSYMLINKS=	$(DEST_DIR)$(INS_BASE)/$(INSDIR)/$(TARGET)$(_EXEEXT)
+@@ -15,4 +15,4 @@
+ 
+ $(PSYMLINKS):	$(DEST_DIR)$(INS_BASE)/bin/$(ORIG)$(_EXEEXT)
+ 	$(MKDIR) -p $(DEST_DIR)$(INS_BASE)/$(INSDIR)
+-	@echo "	==> INSTALLING symlink \"$@\""; $(RM) $(RM_FORCE) $@; $(SYMLINK) ../../bin/$(ORIG)$(_EXEEXT) $@
++	@echo "	==> INSTALLING symlink \"$@\""; $(RM) $(RM_FORCE) $@; $(SYMLINK) ../bin/$(ORIG)$(_EXEEXT) $@
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-admin.1 a/sccs/man/sccs-admin.1
+--- a~/sccs/man/sccs-admin.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-admin.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-admin, admin \- create and administ
+ .SH SYNOPSIS
+ .LP
+ .LP
+-.B /usr/ccs/bin/admin
++.B /usr/bin/admin
+ .RB [ -bhknoz ]
+ .RB [ -a\c
+ .IR " username " | " groupid" ]...
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-cdc.1 a/sccs/man/sccs-cdc.1
+--- a~/sccs/man/sccs-cdc.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-cdc.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-cdc, cdc \- change the delta commen
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/cdc \c
++.B "/usr/bin/cdc \c
+ .BI -r "sid \c"
+ .RB [ -m\c
+ .IR mr-list "] \c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-comb.1 a/sccs/man/sccs-comb.1
+--- a~/sccs/man/sccs-comb.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-comb.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-comb, comb \- combine SCCS deltas
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/comb \c
++.B "/usr/bin/comb \c
+ .RB [ -os "] \c
+ .RB [ -c\c
+ .IR sid-list "] \c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-delta.1 a/sccs/man/sccs-delta.1
+--- a~/sccs/man/sccs-delta.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-delta.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-delta, delta \- make a delta to an
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B /usr/ccs/bin/delta \c
++.B /usr/bin/delta \c
+ .RB [ -dfhnopsz "] \c
+ .RB [ "-g \c
+ .I sid-list \c
+@@ -627,7 +627,7 @@ See
+ for descriptions of the following attributes:
+ .sp
+ 
+-.SS /usr/ccs/bin/delta
++.SS /usr/bin/delta
+ 
+ .LP
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-get.1 a/sccs/man/sccs-get.1
+--- a~/sccs/man/sccs-get.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-get.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@
+ sccs-get, get \- retrieve a version of an SCCS file
+ .SH SYNOPSIS
+ .LP
+-.B /usr/ccs/bin/get
++.B /usr/bin/get
+ .RB [ -beFgkmnopst ]
+ .RB [ -l
+ [p]]
+@@ -654,7 +654,7 @@ Prints the
+ .B get
+ version number string and exists.
+ 
+-.SS /usr/ccs/bin/get
++.SS /usr/bin/get
+ 
+ .br
+ .ne 3
+@@ -759,7 +759,7 @@ in the list.
+ .TP
+ .BI -r sid
+ Same as for
+-.B /usr/ccs/bin/get
++.B /usr/bin/get
+ except that
+ .B SID
+ is mandatory.
+@@ -771,18 +771,18 @@ is mandatory.
+ .TP
+ .BI -x sid-list
+ Same as for
+-.B /usr/ccs/bin/get
++.B /usr/bin/get
+ except that
+ .B sid-list
+ is mandatory.
+ 
+ .SH OUTPUT
+ 
+-.SS /usr/ccs/bin/get
++.SS /usr/bin/get
+ 
+ .LP
+ The output format for
+-.B /usr/ccs/bin/get
++.B /usr/bin/get
+ is as follows:
+ 
+ .LP
+@@ -1237,7 +1237,7 @@ See
+ for descriptions of the following attributes:
+ .sp
+ 
+-.SS /usr/ccs/bin/get
++.SS /usr/bin/get
+ 
+ .LP
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-help.1 a/sccs/man/sccs-help.1
+--- a~/sccs/man/sccs-help.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-help.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-help, help \- ask for help regardin
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B /usr/ccs/bin/help \c
++.B /usr/bin/help \c
+ .RI [ argument ]...
+ .fi
+ 
+@@ -68,7 +68,7 @@ responds with an explanation of the mess
+ 
+ .LP
+ When all else fails, try
+-.RB ` "/usr/ccs/bin/help  stuck" '.
++.RB ` "/usr/bin/help  stuck" '.
+ 
+ .SH ENVIRONMENT VARIABLES
+ .sp
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-prs.1 a/sccs/man/sccs-prs.1
+--- a~/sccs/man/sccs-prs.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-prs.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-prs, prs \- display selected portio
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/prs \c
++.B "/usr/bin/prs \c
+ .RB [ -ael "] \c
+ .RB [ -c\c
+ .IR date-time "] \c
+@@ -358,7 +358,7 @@ The following command:
+ .nf
+ example% \c
+ .B
+-/usr/ccs/bin/prs -e -d":I:\et:P:" program.c
++/usr/bin/prs -e -d":I:\et:P:" program.c
+ .fi
+ .in -2
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-prt.1 a/sccs/man/sccs-prt.1
+--- a~/sccs/man/sccs-prt.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-prt.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-prt, prt \- display delta table inf
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/prt \c
++.B "/usr/bin/prt \c
+ .RB [ -abdefistu "] \c
+ .RB [ -c\c
+ .IR date-time "] \c
+@@ -409,7 +409,7 @@ Examples of
+ The following command:
+ 
+ .LP
+-.B "example% /usr/ccs/bin/prt -y program.c
++.B "example% /usr/bin/prt -y program.c
+ 
+ .LP
+ produces a one-line display of the delta table entry for the
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-rcs2sccs.1 a/sccs/man/sccs-rcs2sccs.1
+--- a~/sccs/man/sccs-rcs2sccs.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-rcs2sccs.1	1970-01-01 00:00:00
+@@ -31,7 +31,7 @@
+ sccs-rcs2sccs, rcs2sccs \- convert RCS files into SCCS files
+ .SH SYNOPSIS
+ .LP
+-.B /usr/ccs/bin/rcs2sccs
++.B /usr/bin/rcs2sccs
+ .RB [ \-rm ]
+ .RB [ \-V6 ]
+ .RI [ file... ]
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-rmdel.1 a/sccs/man/sccs-rmdel.1
+--- a~/sccs/man/sccs-rmdel.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-rmdel.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-rmdel, rmdel \- remove a delta from
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/rmdel \c
++.B "/usr/bin/rmdel \c
+ .RB [ -d "] \c
+ .BI -r "sid \c
+ .RB [ -q\c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-sact.1 a/sccs/man/sccs-sact.1
+--- a~/sccs/man/sccs-sact.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-sact.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-sact, sact \- show editing activity
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/sact \c
++.B "/usr/bin/sact \c
+ .RB [ \-s "] \c
+ .IR s.filename...
+ .fi
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-sccsdiff.1 a/sccs/man/sccs-sccsdiff.1
+--- a~/sccs/man/sccs-sccsdiff.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-sccsdiff.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-sccsdiff, sccsdiff \- compare two v
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/sccsdiff \c
++.B "/usr/bin/sccsdiff \c
+ .RB [ -p "] \c
+ .BI -r "sid \c
+ .BI -r "sid \c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-unget.1 a/sccs/man/sccs-unget.1
+--- a~/sccs/man/sccs-unget.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-unget.1	1970-01-01 00:00:00
+@@ -37,7 +37,7 @@ sccs-unget, unget \- undo a previous get
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.B "/usr/ccs/bin/unget \c
++.B "/usr/bin/unget \c
+ .RB [ -ns "] \c
+ .RB [ -q\c
+ .RI [ nsedelim "]] \c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs-val.1 a/sccs/man/sccs-val.1
+--- a~/sccs/man/sccs-val.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs-val.1	1970-01-01 00:00:00
+@@ -37,11 +37,11 @@ sccs-val, val \- validate an SCCS file
+ .SH SYNOPSIS
+ .LP
+ .nf
+-.BR /usr/ccs/bin/val " -
++.BR /usr/bin/val " -
+ .fi
+ .LP
+ .nf
+-.B /usr/ccs/bin/val \c
++.B /usr/bin/val \c
+ .RB [ -T "] [" -s\c
+ .RB "] [" "-m \c
+ .I name\c
+diff -wpruN '--exclude=*.orig' a~/sccs/man/sccs.1 a/sccs/man/sccs.1
+--- a~/sccs/man/sccs.1	1970-01-01 00:00:00
++++ a/sccs/man/sccs.1	1970-01-01 00:00:00
+@@ -602,7 +602,7 @@ is described below.
+ Many of the following
+ .B sccs
+ subcommands invoke programs that reside in
+-.BR /usr/ccs/bin .
++.BR /usr/bin .
+ Many of these subcommands accept additional arguments that are
+ documented in the reference page for the utility program the
+ subcommand invokes.
+@@ -1884,7 +1884,7 @@ to:
+ 
+ .in +2
+ .nf
+-.B "/usr/ccs/bin/get   /usr/src/include/SCCS/s.stdio.h
++.B "/usr/bin/get   /usr/src/include/SCCS/s.stdio.h
+ .fi
+ .in -2
+ 
+@@ -1904,7 +1904,7 @@ becomes:
+ 
+ .in +2
+ .nf
+-.B "/usr/ccs/bin/get   include/private/s.stdio.h
++.B "/usr/bin/get   include/private/s.stdio.h
+ .fi
+ .in -2
+ 
+@@ -1951,7 +1951,7 @@ To retrieve a file from another director
+ 
+ .in +2
+ .nf
+-.RB example% " sccs get /usr/src/sccs/cc.c
++.RB example% " sccs get /usr/src/scc.c
+ .fi
+ .in -2
+ 
+@@ -1960,7 +1960,7 @@ or:
+ 
+ .in +2
+ .nf
+-.RB example% " sccs -p/usr/src/sccs/ get cc.c
++.RB example% " sccs -p/usr/src/s get cc.c
+ .fi
+ .in -2
+ 
+@@ -2234,7 +2234,7 @@ followed by the host name
+ .br
+ .ne 3
+ .TP
+-.B /usr/ccs/bin/*
++.B /usr/bin/*
+ .B SCCS
+ utility programs
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/admin.c a/sccs/sccs/cmd/src/admin.c
+--- a~/sccs/sccs/cmd/src/admin.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/admin.c	1970-01-01 00:00:00
+@@ -111,7 +111,7 @@ static char	*z;			/* for validation prog
+ static char	had_flag[NFLAGS];	/* -f seen list			*/
+ static char	rm_flag[NFLAGS];	/* -d seen list			*/
+ #if	defined(PROTOTYPES) && defined(INS_BASE)
+-static char	Valpgmp[]	=	NOGETTEXT(INS_BASE "/ccs/bin/" "val");
++static char	Valpgmp[]	=	NOGETTEXT(INS_BASE "/bin/" "val");
+ #endif
+ static char	Valpgm[]	=	NOGETTEXT("val");
+ static int	fexists;		/* Current file exists		*/
+@@ -179,10 +179,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/admin.mk a/sccs/sccs/cmd/src/admin.mk
+--- a~/sccs/sccs/cmd/src/admin.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/admin.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		admin
+ CPPOPTS +=	-DSUN5_0
+ CPPOPTS +=	-DUSE_LARGEFILES
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/bdiff.c a/sccs/sccs/cmd/src/bdiff.c
+--- a~/sccs/sccs/cmd/src/bdiff.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/bdiff.c	1970-01-01 00:00:00
+@@ -89,7 +89,7 @@ static char Error[128];
+ static int seglim;	/* limit of size of file segment to be generated */
+ 
+ #if	defined(PROTOTYPES) && defined(INS_BASE)
+-static char diffp[]  =  INS_BASE "/ccs/bin/" "diff";
++static char diffp[]  =  INS_BASE "/bin/" "diff";
+ #endif
+ static char diff[]  =  "/usr/bin/diff";
+ static char tempskel[] = "/tmp/bdXXXXXX"; /* used to generate temp file names */
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/bdiff.mk a/sccs/sccs/cmd/src/bdiff.mk
+--- a~/sccs/sccs/cmd/src/bdiff.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/bdiff.mk	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		bdiff
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/comb.c a/sccs/sccs/cmd/src/comb.c
+--- a~/sccs/sccs/cmd/src/comb.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/comb.c	1970-01-01 00:00:00
+@@ -90,10 +90,10 @@ register char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+@@ -292,7 +292,7 @@ char *file;
+ 	rdp = gpkt.p_idel;
+ 	Do_prs = 0;
+ #if defined(INS_BASE)
+-	fprintf(iop,"PATH=%s/ccs/bin:$PATH\n", INS_BASE);
++	fprintf(iop,"PATH=%s/bin:$PATH\n", INS_BASE);
+ 	fprintf(iop,"export PATH\n");
+ #endif
+ 	fprintf(iop,"trap \"rm -f COMB$$ comb$$ s.COMB$$; exit 2\" 1 2 3 15\n");
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/comb.mk a/sccs/sccs/cmd/src/comb.mk
+--- a~/sccs/sccs/cmd/src/comb.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/comb.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		comb
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/delta.c a/sccs/sccs/cmd/src/delta.c
+--- a~/sccs/sccs/cmd/src/delta.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/delta.c	1970-01-01 00:00:00
+@@ -69,17 +69,17 @@ static off_t	size_of_file;
+ static off_t	Szqfile;
+ static off_t	Checksum_offset;
+ #ifdef	PROTOTYPES
+-static char	BDiffpgm[]  =   NOGETTEXT(INS_BASE "/ccs/bin/" "bdiff");
++static char	BDiffpgm[]  =   NOGETTEXT(INS_BASE "/bin/" "bdiff");
+ #else
+ /*
+  * XXX If you are using a K&R compiler and like to install to a path
+- * XXX different from "/usr/ccs/bin/", you need to edit this string.
++ * XXX different from "/usr/bin/", you need to edit this string.
+  */
+-static char	BDiffpgm[]  =   NOGETTEXT("/usr/ccs/bin/bdiff");
++static char	BDiffpgm[]  =   NOGETTEXT("/usr/bin/bdiff");
+ #endif
+ static char	BDiffpgm2[]  =   NOGETTEXT("bdiff");
+ #if	defined(PROTOTYPES) && defined(INS_BASE)
+-static char	Diffpgmp[]  =   NOGETTEXT(INS_BASE "/ccs/bin/" "diff");
++static char	Diffpgmp[]  =   NOGETTEXT(INS_BASE "/bin/" "diff");
+ #endif
+ static char	Diffpgm[]   =   NOGETTEXT("/usr/bin/diff");
+ static char	Diffpgm2[]   =   NOGETTEXT("/bin/diff");
+@@ -144,10 +144,10 @@ register char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/delta.mk a/sccs/sccs/cmd/src/delta.mk
+--- a~/sccs/sccs/cmd/src/delta.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/delta.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		delta
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/diff.h a/sccs/sccs/cmd/src/diff.h
+--- a~/sccs/sccs/cmd/src/diff.h	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/diff.h	1970-01-01 00:00:00
+@@ -188,11 +188,11 @@ char pr[] = "/usr/bin/pr";
+ 
+ #if	defined(INS_BASE)
+ #ifdef __STDC__
+-char diff[] = INS_BASE "/ccs/bin/diff";
+-char diffh[] = INS_BASE "/ccs/lib/diffh";
++char diff[] = INS_BASE "/bin/diff";
++char diffh[] = INS_BASE "/lib/diffh";
+ #else
+-char diff[] = "/usr/ccs//bin/diff";
+-char diffh[] = "/usr/ccs/lib/diffh";
++char diff[] = "/usr//bin/diff";
++char diffh[] = "/usr/lib/diffh";
+ #endif
+ #else
+ char diff[] = "/usr/bin/diff";
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/diff.mk a/sccs/sccs/cmd/src/diff.mk
+--- a~/sccs/sccs/cmd/src/diff.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/diff.mk	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		diff
+ #SYMLINKS=	../../bin/sccs
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/diffh.mk a/sccs/sccs/cmd/src/diffh.mk
+--- a~/sccs/sccs/cmd/src/diffh.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/diffh.mk	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib
++INSDIR=		lib
+ TARGET=		diffh
+ #SYMLINKS=	../../bin/sccs
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/get.c a/sccs/sccs/cmd/src/get.c
+--- a~/sccs/sccs/cmd/src/get.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/get.c	1970-01-01 00:00:00
+@@ -55,13 +55,13 @@
+ #define	DATELEN	12
+ 
+ #if defined(__STDC__) || defined(PROTOTYPES)
+-#define	INCPATH		INS_BASE "/ccs/include"	/* place to find binaries */
++#define	INCPATH		INS_BASE "/include"	/* place to find binaries */
+ #else
+ /*
+  * XXX With a K&R compiler, you need to edit the following string in case
+  * XXX you like to change the install path.
+  */
+-#define	INCPATH		"/usr/ccs/include"	/* place to find binaries */
++#define	INCPATH		"/usr/include"	/* place to find binaries */
+ #endif
+ 
+ 
+@@ -134,10 +134,10 @@ register char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/get.mk a/sccs/sccs/cmd/src/get.mk
+--- a~/sccs/sccs/cmd/src/get.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/get.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		get
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/help.c a/sccs/sccs/cmd/src/help.c
+--- a~/sccs/sccs/cmd/src/help.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/help.c	1970-01-01 00:00:00
+@@ -45,9 +45,9 @@
+ #include	<i18n.h>
+ 
+ #ifdef	PROTOTYPES
+-static unsigned char Ohelpcmd[] = NOGETTEXT(INS_BASE "/ccs/lib/help/lib/help2");
++static unsigned char Ohelpcmd[] = NOGETTEXT(INS_BASE "/lib/help/lib/help2");
+ #else
+-static unsigned char Ohelpcmd[] = NOGETTEXT("/usr/ccs/lib/help/lib/help2");
++static unsigned char Ohelpcmd[] = NOGETTEXT("/usr/lib/help/lib/help2");
+ #endif
+ 
+ int main __PR((int argc, char **argv));
+@@ -70,10 +70,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/help.mk a/sccs/sccs/cmd/src/help.mk
+--- a~/sccs/sccs/cmd/src/help.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/help.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		help
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/help2.c a/sccs/sccs/cmd/src/help2.c
+--- a~/sccs/sccs/cmd/src/help2.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/help2.c	1970-01-01 00:00:00
+@@ -60,21 +60,21 @@
+  *
+  *	The file to be searched is determined from the argument. If the
+  *	argument does not contain numerics, the search
+- *	will be attempted on '/usr/ccs/lib/help/cmds', with the search key
++ *	will be attempted on '/usr/lib/help/cmds', with the search key
+  *	being the whole argument. This is used for SCCS command help.
+  *
+  *	If the argument begins with non-numerics but contains
+- *	numerics (e.g, zz32) the file /usr/ccs/lib/help/helploc
++ *	numerics (e.g, zz32) the file /usr/lib/help/helploc
+  *	will be checked for a file corresponding to the non numeric prefix,
+  *	That file will then be seached for the mesage. If
+- *	/usr/ccs/lib/help/helploc
++ *	/usr/lib/help/helploc
+  *	does not exist or the prefix is not found there the search will
+- *	be attempted on '/usr/ccs/lib/help/<non-numeric prefix>',
+- *	(e.g., /usr/ccs/lib/help/zz), with the search key
++ *	be attempted on '/usr/lib/help/<non-numeric prefix>',
++ *	(e.g., /usr/lib/help/zz), with the search key
+  *	being <remainder of arg>, (e.g., 32).
+  *	If the argument is all numeric, or if the file as
+  *	determined above does not exist, the search will be attempted on
+- *	'/usr/ccs/lib/help/default' with the search key being
++ *	'/usr/lib/help/default' with the search key being
+  *	the entire argument.
+  *	In no case will more than one search per argument be performed.
+  *
+@@ -115,7 +115,7 @@ main(argc, argv)
+ #else
+ 	char *default_locale = NOGETTEXT("C"); /* Default English. */
+ #endif
+-	char *helpdir = NOGETTEXT("/ccs/lib/help/locale/");
++	char *helpdir = NOGETTEXT("/lib/help/locale/");
+ 	char help_dir[200]; /* Directory to search for help text. */
+ 	char *locale = NULL; /* User's locale. */
+ 
+@@ -146,10 +146,10 @@ main(argc, argv)
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	    NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	    NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	    NOGETTEXT("/usr/ccs/lib/locale/"));
++	    NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/help2.mk a/sccs/sccs/cmd/src/help2.mk
+--- a~/sccs/sccs/cmd/src/help2.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/help2.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/lib/help/lib
++INSDIR=		lib/help/lib
+ TARGET=		help2
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/prs.c a/sccs/sccs/cmd/src/prs.c
+--- a~/sccs/sccs/cmd/src/prs.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/prs.c	1970-01-01 00:00:00
+@@ -76,7 +76,7 @@
+ # include	<schily/sysexits.h>
+ 
+ #if	defined(PROTOTYPES) && defined(INS_BASE)
+-static char	Getpgmp[]   =   NOGETTEXT(INS_BASE "/ccs/bin/" "get");
++static char	Getpgmp[]   =   NOGETTEXT(INS_BASE "/bin/" "get");
+ #endif
+ static char	Getpgm[]   =   NOGETTEXT("get");
+ static char defline[] = NOGETTEXT(":Dt:\t:DL:\nMRs:\n:MR:COMMENTS:\n:C:");
+@@ -167,10 +167,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/prs.mk a/sccs/sccs/cmd/src/prs.mk
+--- a~/sccs/sccs/cmd/src/prs.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/prs.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		prs
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/prt.c a/sccs/sccs/cmd/src/prt.c
+--- a~/sccs/sccs/cmd/src/prt.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/prt.c	1970-01-01 00:00:00
+@@ -148,10 +148,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/prt.mk a/sccs/sccs/cmd/src/prt.mk
+--- a~/sccs/sccs/cmd/src/prt.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/prt.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		prt
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/rcs2sccs.mk a/sccs/sccs/cmd/src/rcs2sccs.mk
+--- a~/sccs/sccs/cmd/src/rcs2sccs.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/rcs2sccs.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ INSMODE=	0755
+ TARGET=		rcs2sccs
+ SCRFILE=	rcs2sccs.sh
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/rcs2sccs.sh a/sccs/sccs/cmd/src/rcs2sccs.sh
+--- a~/sccs/sccs/cmd/src/rcs2sccs.sh	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/rcs2sccs.sh	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@
+ # Id: rcs2sccs,v 1.12 90/10/04 20:52:23 kenc Exp Locker: kenc
+ 
+ ############################################################
+-PATH=INS_BASE/ccs/bin:$PATH:/usr/ccs/bin
++PATH=INS_BASE/bin:$PATH:/usr/bin
+ ############################################################
+ ex_code=0
+ do_v6=""
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/rmchg.c a/sccs/sccs/cmd/src/rmchg.c
+--- a~/sccs/sccs/cmd/src/rmchg.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/rmchg.c	1970-01-01 00:00:00
+@@ -131,10 +131,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/rmchg.mk a/sccs/sccs/cmd/src/rmchg.mk
+--- a~/sccs/sccs/cmd/src/rmchg.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/rmchg.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		rmchg
+ HARDLINKS=	rmdel cdc
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccs.c a/sccs/sccs/cmd/src/sccs.c
+--- a~/sccs/sccs/cmd/src/sccs.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccs.c	1970-01-01 00:00:00
+@@ -187,9 +187,9 @@ static	int	didvfork;
+ #endif
+ #else
+ #if defined(__STDC__) || defined(PROTOTYPES)
+-#define	PROGPATH(name)	"/usr/ccs/bin/"	#name /* place to find binaries */
++#define	PROGPATH(name)	"/usr/bin/"	#name /* place to find binaries */
+ #else
+-#define	PROGPATH(name) "/usr/ccs/bin/name"	/* place to find binaries */
++#define	PROGPATH(name) "/usr/bin/name"	/* place to find binaries */
+ #endif
+ #endif /* V6 */
+ #else
+@@ -201,9 +201,9 @@ static	int	didvfork;
+ #endif
+ #else
+ #if defined(__STDC__) || defined(PROTOTYPES)
+-#define	PROGPATH(name)	"/usr/ccs/bin/"	#name /* place to find binaries */
++#define	PROGPATH(name)	"/usr/bin/"	#name /* place to find binaries */
+ #else
+-#define	PROGPATH(name) "/usr/ccs/bin/name"	/* place to find binaries */
++#define	PROGPATH(name) "/usr/bin/name"	/* place to find binaries */
+ #endif
+ #endif /* XPG4 */
+ #endif /* DESTDIR */
+@@ -212,13 +212,13 @@ static	int	didvfork;
+ #undef	PROGPATH
+ 
+ #if defined(__STDC__) || defined(PROTOTYPES)
+-#define	PROGPATH(name)	INS_BASE "/ccs/bin/" #name /* place to find binaries */
++#define	PROGPATH(name)	INS_BASE "/bin/" #name /* place to find binaries */
+ #else
+ /*
+  * XXX With a K&R compiler, you need to edit the following string in case
+  * XXX you like to change the install path.
+  */
+-#define	PROGPATH(name) "/usr/ccs/bin/name"	/* place to find binaries */
++#define	PROGPATH(name) "/usr/bin/name"	/* place to find binaries */
+ #endif
+ #endif	/* defined(INS_BASE) && !defined(XPG4) */
+ 
+@@ -429,15 +429,15 @@ extern char	*getenv();
+ # endif /* V6 */
+ 
+ #ifdef XPG4
+-/*static char path[] = NOGETTEXT("PATH=/usr/xpg4/bin:/usr/ccs/bin:/usr/bin");*/
++/*static char path[] = NOGETTEXT("PATH=/usr/xpg4/bin:/usr/bin:/usr/bin");*/
+ #ifdef	PROTOTYPES
+-static char path[] = NOGETTEXT("PATH=" INS_BASE "/xpg4/bin:" INS_BASE "/ccs/bin:/usr/bin");
++static char path[] = NOGETTEXT("PATH=" INS_BASE "/xpg4/bin:" INS_BASE "/bin:/usr/bin");
+ #else
+ /*
+  * XXX With a K&R compiler, you need to edit the following string in case
+  * XXX you like to change the install path.
+  */
+-static char path[] = NOGETTEXT("PATH=/usr/xpg4/bin:/usr/ccs/bin:/usr/bin");
++static char path[] = NOGETTEXT("PATH=/usr/xpg4/bin:/usr/bin:/usr/bin");
+ #endif
+ #endif
+ 
+@@ -499,10 +499,10 @@ main(argc, argv)
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+@@ -3380,7 +3380,7 @@ readncache()
+ 	FILE	*nfp;
+ 
+ 	strlcpy(nbuf, setrhome, sizeof (nbuf));
+-	strlcat(nbuf, "/.sccs/ncache", sizeof (nbuf));
++	strlcat(nbuf, "/.sncache", sizeof (nbuf));
+ 	nfp = fopen(nbuf, "rb");
+ 	if (nfp == NULL) {
+ 		return (-1);
+@@ -3477,7 +3477,7 @@ addcmd(nfiles, argv)
+ 		qsort((void *)anames, anum, sizeof (char *), addcmp);
+ 
+ 		strlcpy(nbuf, setrhome, sizeof (nbuf));
+-		strlcat(nbuf, "/.sccs/ncache", sizeof (nbuf));
++		strlcat(nbuf, "/.sncache", sizeof (nbuf));
+ 		nfp = xfcreat(nbuf, 0666);
+ 		for (i = 0; i < anum; i++) {
+ 			fputs(anames[i], nfp);
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccs.mk a/sccs/sccs/cmd/src/sccs.mk
+--- a~/sccs/sccs/cmd/src/sccs.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccs.mk	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		sccs
+ #SYMLINKS=	../../bin/sccs
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccs_sym.mk a/sccs/sccs/cmd/src/sccs_sym.mk
+--- a~/sccs/sccs/cmd/src/sccs_sym.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccs_sym.mk	1970-01-01 00:00:00
+@@ -12,6 +12,6 @@ PSYMLINKS=	$(DEST_DIR)$(INS_BASE)/$(INSD
+ 
+ install: $(PSYMLINKS)
+ 
+-$(PSYMLINKS):	$(DEST_DIR)$(INS_BASE)/ccs/bin/$(TARGET)$(_EXEEXT)
++$(PSYMLINKS):	$(DEST_DIR)$(INS_BASE)/bin/$(TARGET)$(_EXEEXT)
+ 	$(MKDIR) -p $(DEST_DIR)$(INS_BASE)/$(INSDIR)
+-	@echo "	==> INSTALLING symlink \"$@\""; $(RM) $(RM_FORCE) $@; $(SYMLINK) ../ccs/bin/$(TARGET)$(_EXEEXT) $@
++	@echo "	==> INSTALLING symlink \"$@\""; $(RM) $(RM_FORCE) $@; $(SYMLINK) ../bin/$(TARGET)$(_EXEEXT) $@
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccscvt.c a/sccs/sccs/cmd/src/sccscvt.c
+--- a~/sccs/sccs/cmd/src/sccscvt.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccscvt.c	1970-01-01 00:00:00
+@@ -88,10 +88,10 @@ main(ac, av)
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	    NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	    NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	    NOGETTEXT("/usr/ccs/lib/locale/"));
++	    NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccscvt.mk a/sccs/sccs/cmd/src/sccscvt.mk
+--- a~/sccs/sccs/cmd/src/sccscvt.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccscvt.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		sccscvt
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccsdiff.mk a/sccs/sccs/cmd/src/sccsdiff.mk
+--- a~/sccs/sccs/cmd/src/sccsdiff.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccsdiff.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ INSMODE=	0755
+ TARGET=		sccsdiff
+ SCRFILE=	sccsdiff.sh
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccsdiff.sh a/sccs/sccs/cmd/src/sccsdiff.sh
+--- a~/sccs/sccs/cmd/src/sccsdiff.sh	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccsdiff.sh	1970-01-01 00:00:00
+@@ -36,7 +36,7 @@
+ # if running under control of the NSE (-q option given), will look for
+ # get in the directtory from which it was run (if -q, $0 will be full pathname)
+ #
+-PATH=INS_BASE/ccs/bin:$PATH:/usr/ccs/bin
++PATH=INS_BASE/bin:$PATH:/usr/bin
+ 
+ trap "rm -f /tmp/get[abc]$$;exit 1" 1 2 3 15
+ umask 077
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccslog.c a/sccs/sccs/cmd/src/sccslog.c
+--- a~/sccs/sccs/cmd/src/sccslog.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccslog.c	1970-01-01 00:00:00
+@@ -137,7 +137,7 @@ static	char	*lastuser = NULL;
+ 
+ 		if (home == NULL)
+ 			home = ".";
+-		js_snprintf(nbuf, sizeof (nbuf), "%s/.sccs/usermap", home);
++		js_snprintf(nbuf, sizeof (nbuf), "%s/.susermap", home);
+ 		f = fopen(nbuf, "r");
+ 		if (f == NULL) {
+ 			cannot = 1;
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/sccslog.mk a/sccs/sccs/cmd/src/sccslog.mk
+--- a~/sccs/sccs/cmd/src/sccslog.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/sccslog.mk	1970-01-01 00:00:00
+@@ -5,7 +5,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		sccslog
+ CPPOPTS +=	-DUSE_LARGEFILES
+ CPPOPTS +=	-DSCHILY_PRINT
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/unget.c a/sccs/sccs/cmd/src/unget.c
+--- a~/sccs/sccs/cmd/src/unget.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/unget.c	1970-01-01 00:00:00
+@@ -108,10 +108,10 @@ char *argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/unget.mk a/sccs/sccs/cmd/src/unget.mk
+--- a~/sccs/sccs/cmd/src/unget.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/unget.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		unget
+ HARDLINKS=	sact
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/val.c a/sccs/sccs/cmd/src/val.c
+--- a~/sccs/sccs/cmd/src/val.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/val.c	1970-01-01 00:00:00
+@@ -144,10 +144,10 @@ char	*argv[];
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/val.mk a/sccs/sccs/cmd/src/val.mk
+--- a~/sccs/sccs/cmd/src/val.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/val.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		val
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/vc.mk a/sccs/sccs/cmd/src/vc.mk
+--- a~/sccs/sccs/cmd/src/vc.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/vc.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		vc
+ 
+ CPPOPTS +=	-DSUN5_0
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/what.c a/sccs/sccs/cmd/src/what.c
+--- a~/sccs/sccs/cmd/src/what.c	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/what.c	1970-01-01 00:00:00
+@@ -82,10 +82,10 @@ register char **argv;
+ 	 */
+ #ifdef	PROTOTYPES
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT(INS_BASE "/ccs/lib/locale/"));
++	   NOGETTEXT(INS_BASE "/lib/locale/"));
+ #else
+ 	(void) bindtextdomain(NOGETTEXT("SUNW_SPRO_SCCS"),
+-	   NOGETTEXT("/usr/ccs/lib/locale/"));
++	   NOGETTEXT("/usr/lib/locale/"));
+ #endif
+ 	
+ 	(void) textdomain(NOGETTEXT("SUNW_SPRO_SCCS"));
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/cmd/src/what.mk a/sccs/sccs/cmd/src/what.mk
+--- a~/sccs/sccs/cmd/src/what.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/cmd/src/what.mk	1970-01-01 00:00:00
+@@ -8,7 +8,7 @@ include		$(SRCROOT)/$(RULESDIR)/rules.to
+ ###########################################################################
+ 
+ #INSDIR=	sccs
+-INSDIR=		ccs/bin
++INSDIR=		bin
+ TARGET=		what
+ #SYMLINKS=	../bin/what
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/ad.mk a/sccs/sccs/help.d/ad.mk
+--- a~/sccs/sccs/help.d/ad.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/ad.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		ad
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/bd.mk a/sccs/sccs/help.d/bd.mk
+--- a~/sccs/sccs/help.d/bd.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/bd.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		bd
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/cb.mk a/sccs/sccs/help.d/cb.mk
+--- a~/sccs/sccs/help.d/cb.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/cb.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		cb
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/cm.mk a/sccs/sccs/help.d/cm.mk
+--- a~/sccs/sccs/help.d/cm.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/cm.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		cm
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/cmds.mk a/sccs/sccs/help.d/cmds.mk
+--- a~/sccs/sccs/help.d/cmds.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/cmds.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		cmds
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/co.mk a/sccs/sccs/help.d/co.mk
+--- a~/sccs/sccs/help.d/co.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/co.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		co
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/de.mk a/sccs/sccs/help.d/de.mk
+--- a~/sccs/sccs/help.d/de.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/de.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		de
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/default.mk a/sccs/sccs/help.d/default.mk
+--- a~/sccs/sccs/help.d/default.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/default.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		default
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/ge.mk a/sccs/sccs/help.d/ge.mk
+--- a~/sccs/sccs/help.d/ge.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/ge.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		ge
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/he.mk a/sccs/sccs/help.d/he.mk
+--- a~/sccs/sccs/help.d/he.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/he.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		he
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/pr.mk a/sccs/sccs/help.d/pr.mk
+--- a~/sccs/sccs/help.d/pr.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/pr.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		pr
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/prs.mk a/sccs/sccs/help.d/prs.mk
+--- a~/sccs/sccs/help.d/prs.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/prs.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		prs
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/rc.mk a/sccs/sccs/help.d/rc.mk
+--- a~/sccs/sccs/help.d/rc.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/rc.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		rc
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/un.mk a/sccs/sccs/help.d/un.mk
+--- a~/sccs/sccs/help.d/un.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/un.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		un
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/ut.mk a/sccs/sccs/help.d/ut.mk
+--- a~/sccs/sccs/help.d/ut.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/ut.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		ut
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/va.mk a/sccs/sccs/help.d/va.mk
+--- a~/sccs/sccs/help.d/va.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/va.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		va
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/help.d/vc.mk a/sccs/sccs/help.d/vc.mk
+--- a~/sccs/sccs/help.d/vc.mk	1970-01-01 00:00:00
++++ a/sccs/sccs/help.d/vc.mk	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib/help/locale/C
++INSDIR=		lib/help/locale/C
+ TARGET=		vc
+ #XMK_FILE=	Makefile.man
+ 
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/lib/cassi/src/Makefile a/sccs/sccs/lib/cassi/src/Makefile
+--- a~/sccs/sccs/lib/cassi/src/Makefile	1970-01-01 00:00:00
++++ a/sccs/sccs/lib/cassi/src/Makefile	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib
++INSDIR=		lib
+ TARGETLIB=	cassi
+ CPPOPTS +=	-DSUN5_0
+ CPPOPTS +=	-DUSE_LARGEFILES
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/lib/comobj/src/Makefile a/sccs/sccs/lib/comobj/src/Makefile
+--- a~/sccs/sccs/lib/comobj/src/Makefile	1970-01-01 00:00:00
++++ a/sccs/sccs/lib/comobj/src/Makefile	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib
++INSDIR=		lib
+ TARGETLIB=	comobj
+ CPPOPTS +=	-DSUN5_0
+ CPPOPTS +=	-DUSE_LARGEFILES
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/lib/comobj/src/help.c a/sccs/sccs/lib/comobj/src/help.c
+--- a~/sccs/sccs/lib/comobj/src/help.c	1970-01-01 00:00:00
++++ a/sccs/sccs/lib/comobj/src/help.c	1970-01-01 00:00:00
+@@ -56,21 +56,21 @@
+  *
+  *	The file to be searched is determined from the argument. If the
+  *	argument does not contain numerics, the search
+- *	will be attempted on '/usr/ccs/lib/help/cmds', with the search key
++ *	will be attempted on '/usr/lib/help/cmds', with the search key
+  *	being the whole argument. This is used for SCCS command help.
+  *
+  *	If the argument begins with non-numerics but contains
+- *	numerics (e.g, zz32) the file /usr/ccs/lib/help/helploc
++ *	numerics (e.g, zz32) the file /usr/lib/help/helploc
+  *	will be checked for a file corresponding to the non numeric prefix,
+  *	That file will then be seached for the mesage. If
+- *	/usr/ccs/lib/help/helploc
++ *	/usr/lib/help/helploc
+  *	does not exist or the prefix is not found there the search will
+- *	be attempted on '/usr/ccs/lib/help/<non-numeric prefix>',
+- *	(e.g., /usr/ccs/lib/help/zz), with the search key
++ *	be attempted on '/usr/lib/help/<non-numeric prefix>',
++ *	(e.g., /usr/lib/help/zz), with the search key
+  *	being <remainder of arg>, (e.g., 32).
+  *	If the argument is all numeric, or if the file as
+  *	determined above does not exist, the search will be attempted on
+- *	'/usr/ccs/lib/help/default' with the search key being
++ *	'/usr/lib/help/default' with the search key being
+  *	the entire argument.
+  *	In no case will more than one search per argument be performed.
+  *
+@@ -92,7 +92,7 @@
+  *	Comments are ignored.
+  */
+ 
+-#define	HELPLOC		"/ccs/lib/help/helploc"
++#define	HELPLOC		"/lib/help/helploc"
+ #define	DEFAULT_LOCALE	"C"			/* Default English. */
+ 
+ static int	findprt __PR((FILE *f, char *p, char *locale));
+@@ -179,7 +179,7 @@ findprt(f, p, locale)
+ 	char	hfile[max(8192, PATH_MAX+1)];
+ 	FILE	*iop;
+ 	char	*dftfile = NOGETTEXT("/default");
+-	char	*helpdir = NOGETTEXT("/ccs/lib/help/locale/");
++	char	*helpdir = NOGETTEXT("/lib/help/locale/");
+ 	char	help_dir[max(8192, PATH_MAX+1)]; /* Directory to search for. */
+ 
+ 	if ((int) size(p) > 50)
+diff -wpruN '--exclude=*.orig' a~/sccs/sccs/lib/mpwlib/src/Makefile a/sccs/sccs/lib/mpwlib/src/Makefile
+--- a~/sccs/sccs/lib/mpwlib/src/Makefile	1970-01-01 00:00:00
++++ a/sccs/sccs/lib/mpwlib/src/Makefile	1970-01-01 00:00:00
+@@ -7,7 +7,7 @@ RULESDIR=	RULES
+ include		$(SRCROOT)/$(RULESDIR)/rules.top
+ ###########################################################################
+ 
+-INSDIR=		ccs/lib
++INSDIR=		lib
+ TARGETLIB=	mpw
+ CPPOPTS +=	-DSUN5_0
+ CPPOPTS +=	-DUSE_LARGEFILES

--- a/build/sccs/patches/series
+++ b/build/sccs/patches/series
@@ -1,0 +1,2 @@
+03.Defaults.sunos5.patch
+04.remove_ccs.patch

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -27,6 +27,7 @@
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.20.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
 | developer/versioning/mercurial	| 4.8.1			| https://www.mercurial-scm.org/release/?M=D
+| developer/versioning/sccs		| 5.08			| https://sourceforge.net/projects/sccs/files/
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.1			| http://ftp.vim.org/pub/vim/unix
 | file/gnu-coreutils			| 8.30			| https://git.savannah.gnu.org/cgit/coreutils.git/refs/tags

--- a/tools/test
+++ b/tools/test
@@ -98,7 +98,6 @@ add_target()
 			*perl/manual:*)		return ;;
 			*illumos-closed:*)	return ;;
 			*kvm:*)			return ;;
-			*/sccs:*)		return ;;
 			*illumos-gate*)		return ;;
 			*/omnios-userland:*)	return ;;
 			*/iconv/*)		return ;;
@@ -206,7 +205,6 @@ check_constraints()
 		[ -n "${targets[$pkg]}" ] && bver=${targets[$pkg]} || bver=
 		case $pkg in
 			*/kvm)				continue ;;
-			*/sccs)				continue ;;
 			*/sunstudio12.1)		continue ;;
 			release/*)			continue ;;
 			*gcc-?-runtime)			continue ;;


### PR DESCRIPTION
Move from the legacy devpro sccs to Schily sccs.
The main motivation is to drop the last dependency on sunstudio for building OmniOS.