### PR TITLE
Studio is still required to build gate lint libraries

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -15,6 +15,7 @@ depend fmri=developer/java/jdk type=require
 depend fmri=developer/lexer/flex type=require
 depend fmri=developer/object-file type=require
 depend fmri=developer/parser/bison type=require
+depend fmri=developer/sunstudio12.1 type=require
 depend fmri=developer/versioning/mercurial type=require
 depend fmri=developer/versioning/git type=require
 depend fmri=developer/library/lint type=require


### PR DESCRIPTION
Studio is still required to build gate lint libraries
