### PR TITLE
Add automatic library ABI check when packaging

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1073,6 +1073,7 @@ make_package() {
     fi
     if [ -n "$DESTDIR" ]; then
         check_symlinks "$DESTDIR"
+        [ -z "$BATCH" ] && check_libabi "$DESTDIR" "$PKG"
         logmsg "--- Generating package manifest from $DESTDIR"
         logmsg "------ Running: $PKGSEND generate $DESTDIR > $P5M_INT"
         GENERATE_ARGS=
@@ -1858,9 +1859,76 @@ strip_install() {
 #############################################################################
 
 check_symlinks() {
-    logmsg "Checking for dangling symlinks"
+    logmsg "-- Checking for dangling symlinks"
     for link in `find "$1" -type l`; do
         readlink -e $link >/dev/null || logerr "Dangling symlink $link"
+    done
+}
+
+#############################################################################
+# Check for library ABI change
+#############################################################################
+
+extract_libabis() {
+    declare -Ag "$1"
+    local -n array="$1"
+    local src="$2"
+
+    while read file; do
+        lib=${file%.so.*}
+        abi=${file#*.so.}
+        array[$lib]+="$abi "
+    done < <(sed < "$src" '
+        # basename
+        s/.*\///
+        # Remove minor versions (e.g. .so.7.1.2 -> .so.7)
+        s/\(\.so\.[0-9][0-9]*\)\..*/\1/
+        ' | sort | uniq)
+}
+
+check_libabi() {
+    local destdir="$1"
+    local pkg="$2"
+
+    logmsg "-- Checking for library ABI changes"
+
+    # Build list of libraries and ABIs from this package on disk
+    logcmd -p find "$destdir" -type f -name lib\*.so.\* > $TMPDIR/libs.$$
+    extract_libabis cla__new $TMPDIR/libs.$$
+    logcmd rm -f $TMPDIR/libs.$$
+
+    [ ${#cla__new[@]} -gt 0 ] || return
+
+    # The package has at least one library
+
+    logmsg "--- Found libraries, fetching previous package contents"
+    pkgitems -g $IPS_REPO $pkg | nawk '
+            /^file path=.*\.so\./ {
+                sub(/path=/, "", $2)
+                print $2
+            }
+        ' > $TMPDIR/libs.$$
+    [ -s $TMPDIR/libs.$$ ] || logerr "Could not retrieve contents"
+    # In case the user chooses to continue after the previous error
+    [ -s $TMPDIR/libs.$$ ] || return
+    extract_libabis cla__prev $TMPDIR/libs.$$
+    rm -f $TMPDIR/libs.$$
+
+    # Compare
+    for k in "${!cla__new[@]}"; do
+        [ "${cla__new[$k]}" = "${cla__prev[$k]}" ] && continue
+        # The list of ABIs has changed. Make sure that all of the old versions
+        # are present in the new.
+        logmsg -n "--- $lib ABI change, ${cla__prev[$k]} -> ${cla__new[$k]}"
+        local prev new flag
+        for prev in ${cla__prev[$k]}; do
+            flag=0
+            for new in ${cla__new[$k]}; do
+                [ "$prev" = "$new" ] && flag=1
+            done
+            [ "$flag" -eq 1 ] && continue
+            logerr "--- $lib.so.$prev missing from new package"
+        done
     done
 }
 
@@ -1869,7 +1937,7 @@ check_symlinks() {
 #############################################################################
 
 clean_up() {
-    logmsg "Cleaning up"
+    logmsg "-- Cleaning up"
     if [ -z "$DONT_REMOVE_INSTALL_DIR" ]; then
         logmsg "--- Removing temporary install directory $DESTDIR"
         logcmd chmod -R u+w $DESTDIR > /dev/null 2>&1


### PR DESCRIPTION
When preparing for r151028, we noticed in testing that some libraries had undergone an ABI change and so software built under the previous OmniOS release may not run have run on the new if there was a dependency on the library with the old ABI.

This change adds an automated check to alert package builders when this occurs.

For example, if an old ABI library is no longer present, the build will now fail:
```
-- Checking for library ABI changes
--- Found libraries, fetching previous package contents
--- libreadline ABI change, 6 7  -> 7 8
--- libreadline.so.6 missing from new package
An Error occured in the build. Do you wish to continue anyway? (y/n)
```

when a new version is added, there's just a note

```
-- Checking for library ABI changes
--- Found libraries, fetching previous package contents
--- libreadline ABI change, 6 7  -> 6 7 8
--- libreadline ABI change, 6 7  -> 6 7 8
```