### PR TITLE
Add symlink to final package directory

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -668,7 +668,7 @@ prep_build() {
         logcmd chmod -R u+w $DESTDIR > /dev/null 2>&1
         logcmd rm -rf $DESTDIR || \
             logerr "Failed to remove old temporary install dir"
-        mkdir -p $DESTDIR || \
+        logcmd mkdir -p $DESTDIR || \
             logerr "Failed to create temporary install dir"
     fi
 
@@ -684,6 +684,9 @@ prep_build() {
     # Create symbolic links to build area
     [ -h $SRCDIR/tmp/build ] && rm -f $SRCDIR/tmp/build
     logcmd ln -sf $BUILDDIR $SRCDIR/tmp/build
+    # ... and to DESTDIR
+    [ -h $SRCDIR/tmp/pkg ] && rm -f $SRCDIR/tmp/pkg
+    logcmd ln -sf $DESTDIR $SRCDIR/tmp/pkg
 }
 
 #############################################################################


### PR DESCRIPTION
This is a convenience link for package maintainers.

The link is created with an absolute path unlike the others since DESTDIR is under DTMPDIR and there is no guarantee that TMPDIR = DTMPDIR.

```
build:omnios.bloody:pkg% ls -l build/readline/tmp/
lrwxrwxrwx   1 af       other         12 Jan  9 12:08 build -> readline-7.0/
drwxr-xr-x   3 af       other          3 Jan  9 12:08 library_readline_pkg/
lrwxrwxrwx   1 af       other         76 Jan  9 12:08 pkg -> /data/omnios-build/omniosorg/bloody/_build/readline-7.0/library_readline_pkg/
drwxr-xr-x   6 af       other         88 Jan  9 12:09 readline-7.0/
```