### PR TITLE
Change the gcc startfile spec to match what we had in gcc7

### DIFF
--- a/build/gcc8/patches/series
+++ b/build/gcc8/patches/series
@@ -14,3 +14,4 @@ libstdc++-aligned_alloc.patch
 0002-compare_tests-Use-nawk-on-OmniOS.patch
 1000-ld-flags.patch
 never-omit-frame-pointer.patch
+standards.patch

--- a/build/gcc8/patches/standards.patch
+++ b/build/gcc8/patches/standards.patch
@@ -1,0 +1,41 @@
+From d5e28d05a9f21a927da854f112928fe6ee88cd60 Mon Sep 17 00:00:00 2001
+From: Richard Lowe <richlowe@richlowe.net>
+Date: Wed, 27 Jan 2016 16:49:07 -0500
+Subject: [PATCH] sol2: Use appropriate values objects for the various C and
+ C++ standards
+
+I'm reasonable confident of the C cases, less confident of the C++
+cases.
+
+This is on the basis that c99 and greater implies XPG6 (and vice versa), as the
+manual pages and headers say/enforce.  It is possible that C11 should
+imply xpg7 if and when we support that.
+
+C99 and greater get strict ansi.
+
+C otherwise gets transitional ansi (and no UNIX standard)
+
+C++ gets strict ansi, other than in C++98.  And gets no UNIX standards
+objects at all.
+diff -wpruN '--exclude=*.orig' a~/gcc/config/sol2.h a/gcc/config/sol2.h
+--- a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
+@@ -196,10 +196,14 @@ along with GCC; see the file COPYING3.
+    first in ld.so.1's search path), we only link the values-*.o files into
+    executable programs.  */
+ #undef STARTFILE_ARCH_SPEC
+-#define STARTFILE_ARCH_SPEC \
+-  "%{!shared:%{!symbolic: \
+-     %{ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; :values-Xa.o%s} \
+-     %{std=c90|std=gnu90:values-xpg4.o%s; :values-xpg6.o%s}}}"
++#define STARTFILE_ARCH_SPEC "%{std=c1x|std=gnu1x:values-Xc.o%s values-xpg6.o%s; \
++			       std=c11|std=gnu11:values-Xc.o%s values-xpg6.o%s; \
++			       std=c99|std=gnu99:values-Xc.o%s values-xpg6.o%s; \
++			       std=c9x|std=gnu9x:values-Xc.o%s values-xpg6.o%s; \
++			       std=c++0x|std=gnu++0x:values-Xc.o%s; \
++			       std=c++11|std=gnu++11:values-Xc.o%s; \
++			       std=c++03|std=gnu++03:values-Xc.o%s; \
++			       :values-Xa.o%s}"
+ 
+ #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
+ #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \


### PR DESCRIPTION
We originally dropped the startfile arch patch in gcc8 (https://github.com/illumos/gcc/commit/d5e28d05a9f21a927da854f112928fe6ee88cd60 ) as the problem has been fixed upstream for gcc8.
However, without this patch we are seeing some pty-related test failures in packages such as `zsh`  - possibly because the upstream fix only links _values-xpg6.o_ into executable programs - see https://github.com/gcc-mirror/gcc/blob/master/gcc/config/sol2.h#L199

With this additional patch applied to the compiler, the `zsh` test suite passes.