### PR TITLE
Add developer/object-file dependency to python

### DIFF
--- a/build/python27/build.sh
+++ b/build/python27/build.sh
@@ -44,6 +44,7 @@ RUN_DEPENDS_IPS="
     library/security/openssl
     library/zlib
     system/library/gcc-runtime
+    developer/object-file
 "
 XFORM_ARGS="-D PYTHONVER=$PYTHONVER"
 

--- a/build/python35/build.sh
+++ b/build/python35/build.sh
@@ -35,6 +35,7 @@ RUN_DEPENDS_IPS="
     library/security/openssl
     library/zlib
     system/library/gcc-runtime
+    developer/object-file
 "
 XFORM_ARGS="-D PYTHONVER=$MVER"
 


### PR DESCRIPTION
The python ctypes module expects to find `/usr/ccs/bin/dump` in order to extract information from shared libraries at runtime. One particular usage of this is in the `uuid` module which is used often for IPS package operations (where a temporary UUID is required, such as when running `pkgrepo`).
`/usr/ccs/bin/dump` is part of `developer/object-file` and without the latter package installed pkg operations requiring a uuid can hang for up to 2 minutes.

The best way to fix this seems to be adding `developer/object-file` as a dependency for python, since it is. This will effectively make the package part of the base OmniOS installation image (since python is) but it is small:
```
% pkgmgr list r151028 --dst -l object-file
PKG                                      FLAGS    FILES        SIZE        COMP
developer/object-file                      s         78    3.44 MiB    1.21 MiB
```