### PR TITLE
ncurses: add underline for sun-color

### DIFF
--- a/build/ncurses/patches/extra-newline.patch
+++ b/build/ncurses/patches/extra-newline.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/configure a/configure
 --- a~/configure	1970-01-01 00:00:00
 +++ a/configure	1970-01-01 00:00:00
-@@ -26612,6 +26612,10 @@ TMPSED=\${TMPDIR:-/tmp}/headers.sed\$\$
+@@ -26929,6 +26929,10 @@ TMPSED=\${TMPDIR:-/tmp}/headers.sed\$\$
  echo installing \$SRC in \$DST
  CF_EOF
  

--- a/build/ncurses/patches/series
+++ b/build/ncurses/patches/series
@@ -1,2 +1,3 @@
 extra-newline.patch
 xterm-no-rep.patch
+sun-color.patch

--- a/build/ncurses/patches/sun-color.patch
+++ b/build/ncurses/patches/sun-color.patch
@@ -1,0 +1,27 @@
+
+Updates to illumos-gate in February 2019 added support for underline
+to sun-color.
+
+See: https://www.illumos.org/issues/10359
+
+diff -wpruN '--exclude=*.orig' a~/misc/terminfo.src a/misc/terminfo.src
+--- a~/misc/terminfo.src	1970-01-01 00:00:00
++++ a/misc/terminfo.src	1970-01-01 00:00:00
+@@ -7525,7 +7525,7 @@ sun-type4|Sun Workstation console with t
+ #	cbt=\E[Z
+ #	dim=\E[2m
+ #	blink=\E[5m
+-# It supports bold, but not underline -TD (2009-09-19)
++# It supports bold, -TD (2009-09-19)
+ sun-color|Sun Microsystems Workstation console with color support (IA systems),
+ 	colors#8, ncv#3, pairs#64,
+ 	bold=\E[1m, cub=\E[%p1%dD, cud=\E[%p1%dB, cuf=\E[%p1%dC,
+@@ -7536,7 +7536,7 @@ sun-color|Sun Microsystems Workstation c
+ 	setf=\E[3%?%p1%{1}%=%t4%e%p1%{3}%=%t6%e%p1%{4}%=%t1%e%p1%{6}
+ 	     %=%t3%e%p1%d%;m,
+ 	sgr=\E[0%?%p6%t;1%;%?%p1%p3%|%t;7%;m, sgr0=\E[m,
+-	smso=\E[7m, use=sun,
++	smso=\E[7m, smul=\E[4m, rmul=\E[24m, use=sun,
+ 
+ #### Iris consoles
+ #

--- a/build/ncurses/patches/xterm-no-rep.patch
+++ b/build/ncurses/patches/xterm-no-rep.patch
@@ -10,7 +10,7 @@ See also http://invisible-island.net/ncurses/ncurses.faq.html#xterm_generic
 diff -wpruN '--exclude=*.orig' a~/misc/terminfo.src a/misc/terminfo.src
 --- a~/misc/terminfo.src	1970-01-01 00:00:00
 +++ a/misc/terminfo.src	1970-01-01 00:00:00
-@@ -4332,7 +4332,7 @@ xterm-xfree86|xterm terminal emulator (X
+@@ -4338,7 +4338,7 @@ xterm-xfree86|xterm terminal emulator (X
  xterm-new|modern xterm terminal emulator,
  	npc,
  	indn=\E[%p1%dS, kb2=\EOE, kcbt=\E[Z, kent=\EOM,


### PR DESCRIPTION
Replicating a terminfo change from upstream gate.
Since sun-color is not just illumos, this is not going to be upstreamed, and it only applies to illumos after the support was integrated so is not eligible for backport.