### PR TITLE
Allow $FLAVOR to contain spaces

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -85,9 +85,8 @@ process_opts() {
                 SKIP_TESTSUITE=1
                 ;;
             f)
-                FLAVOR=$OPTARG
-                OLDFLAVOR=$OPTARG # Used to see if the script overrides the
-                                   # flavor
+                FLAVOR="$OPTARG"
+                OLDFLAVOR="$OPTARG" # Used to see if the script overrides
                 ;;
             r)
                 PKGSRVR=$OPTARG


### PR DESCRIPTION
This allows multiple illumos packages to be built at once via, for instance:

```
cd build/illumos
./build.sh -f "SUNWcs system/kernel/platform"
```