### PR TITLE
Add missing pkg-35 dependency to illumos-tools (r151028)

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -40,3 +40,4 @@ depend fmri=system/management/snmp/net-snmp type=require
 depend fmri=text/gnu-gettext type=require
 depend fmri=pkg://omnios/runtime/python-27 type=require
 depend fmri=pkg://omnios/runtime/python-35 type=require
+depend fmri=pkg://omnios/package/pkg-35 type=require


### PR DESCRIPTION
Add missing pkg-35 dependency to illumos-tools (r151028)
