### PR TITLE
Stop gcc linking with -lpthread

### DIFF
--- a/build/gcc7/patches/no-lpthread.patch
+++ b/build/gcc7/patches/no-lpthread.patch
@@ -1,0 +1,17 @@
+Prevent gcc from linking with libpthread if -pthread[s] is passed as an option.
+libpthread is a filter in illumos; all functionality has been migrated to libc.
+
+Some build systems such as meson/ninja pass this option; glib2 now requires
+meson/ninja to build. Since glib2 is linked with hald in gate, the spurious
+libpthread causes build warnings.
+
++++ a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
+@@ -157,7 +157,6 @@
+ #undef LIB_SPEC
+ #define LIB_SPEC \
+   "%{!symbolic:\
+-     %{pthreads|pthread:-lpthread} \
+      %{p|pg:-ldl} -lc}"
+ 
+ #ifndef CROSS_DIRECTORY_STRUCTURE

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -14,3 +14,4 @@
 0016-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
 0017-libgcc-unwind.map-should-be-v2-style.patch
 ld-flags.patch
+no-lpthread.patch

--- a/build/gcc8/patches/no-lpthread.patch
+++ b/build/gcc8/patches/no-lpthread.patch
@@ -1,0 +1,17 @@
+Prevent gcc from linking with libpthread if -pthread[s] is passed as an option.
+libpthread is a filter in illumos; all functionality has been migrated to libc.
+
+Some build systems such as meson/ninja pass this option; glib2 now requires
+meson/ninja to build. Since glib2 is linked with hald in gate, the spurious
+libpthread causes build warnings.
+
++++ a~/gcc/config/sol2.h	1970-01-01 00:00:00
++++ a/gcc/config/sol2.h	1970-01-01 00:00:00
+@@ -157,7 +157,6 @@
+ #undef LIB_SPEC
+ #define LIB_SPEC \
+   "%{!symbolic:\
+-     %{pthreads|pthread:-lpthread} \
+      %{p|pg:-ldl} -lc}"
+ 
+ #ifndef CROSS_DIRECTORY_STRUCTURE

--- a/build/gcc8/patches/series
+++ b/build/gcc8/patches/series
@@ -14,3 +14,4 @@
 0016-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
 0017-libgcc-unwind.map-should-be-v2-style.patch
 ld-flags.patch
+no-lpthread.patch


### PR DESCRIPTION
Prevent gcc from linking with libpthread if -pthread[s] is passed as an option.
libpthread is a filter in illumos; all functionality has been migrated to libc.

Some build systems such as meson/ninja pass this option; glib2 now requires
meson/ninja to build. Since glib2 is linked with hald in gate, the spurious
libpthread causes build warnings.

```
bloody% gcc -pthread -o test test.c
bloody% ldd test
        libpthread.so.1 =>       /lib/libpthread.so.1
        libc.so.1 =>     /lib/libc.so.1
        libm.so.2 =>     /lib/libm.so.2
bloody% gcc -dumpspecs
*lib:
%{!symbolic:     %{pthreads|pthread:-lpthread}      %{p|pg:-ldl} -lc}

bloody% pfexec pkg update gcc7
bloody% gcc -pthread -o test test.c
bloody% ldd test
        libc.so.1 =>     /lib/libc.so.1
        libm.so.2 =>     /lib/libm.so.2
bloody% gcc -dumpspecs
*lib:
%{!symbolic:     %{p|pg:-ldl} -lc}
```
(also tested with gcc8)