### PR TITLE
Entire should not include dashrevs

### DIFF
--- a/build/entire/build-entire.sh
+++ b/build/entire/build-entire.sh
@@ -56,7 +56,7 @@ add_constraints()
             if [[ "$flags" = *S* ]]; then
                 echo " variant.opensolaris.imagetype=full\\c"
             fi
-            echo " fmri=pkg://@PKGPUBLISHER@/$pkg@$ver,5.11-@PVER@ type=$typ"
+            echo " fmri=pkg://@PKGPUBLISHER@/$pkg@$ver,5.11-@RELVER@ type=$typ"
         ) >> $cmf
     done
 }


### PR DESCRIPTION
This changes lines in entire from:

```diff
-depend fmri=pkg://omnios/text/gnu-patch@2.7,5.11-151029.0 type=require
+depend fmri=pkg://omnios/text/gnu-patch@2.7,5.11-151029 type=require
```

before this change, all lines in entire had a dashrev of 0, implying a minimum version. Removing the dashrev entirely achieves the same result and is better for some of the other processes such as optional package install during zone creation.

```
bloody% pkg contents -m entire | grep gnu-patch
depend fmri=pkg://omnios/text/gnu-patch@2.7,5.11-151029 type=require

bloody% pfexec pkg uninstall gnu-patch
Creating Plan (Solver setup): /
pkg uninstall: Unable to remove 'text/gnu-patch@2.7.6-151029.0' due to the following packages that depend on it:
  entire@11-151029.0
```