### PR TITLE
hg: update to 5.0

### DIFF
--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -29,7 +29,7 @@ developer/macro/gnu-m4			1.4.18
 developer/parser/bison			3.3
 developer/swig				3.0
 developer/versioning/git		2
-developer/versioning/mercurial		4
+developer/versioning/mercurial		5
 developer/versioning/sccs		5
 driver/tuntap				1.3
 driver/virtualization/kvm		1.0

--- a/build/mercurial/build.sh
+++ b/build/mercurial/build.sh
@@ -27,10 +27,15 @@
 . ../../lib/functions.sh
 
 PROG=mercurial
-VER=4.9.1
+VER=5.0
 PKG=developer/versioning/mercurial
 SUMMARY="Mercurial source control management"
 DESC="Free, distributed source control management tool"
+
+# Mercurial currently has beta support for Python 3 and use of Python 2.7 is
+# recommended for the best experience.
+# See https://www.mercurial-scm.org/wiki/Python3 for more on Mercurial's
+# Python 3 support.
 
 set_python_version $PYTHON2VER
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -23,7 +23,7 @@
 | developer/parser/bison		| 3.3.2			| https://git.savannah.gnu.org/cgit/bison.git/refs/tags https://ftp.gnu.org/gnu/bison/
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
 | developer/versioning/git		| 2.21.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
-| developer/versioning/mercurial	| 4.9.1			| https://www.mercurial-scm.org/release/?M=D https://www.mercurial-scm.org/wiki/WhatsNew
+| developer/versioning/mercurial	| 5.0			| https://www.mercurial-scm.org/release/?M=D https://www.mercurial-scm.org/wiki/WhatsNew
 | developer/versioning/sccs		| 5.09			| https://sourceforge.net/projects/sccs/files/
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases
 | editor/vim				| 8.1			| http://ftp.vim.org/pub/vim/unix


### PR DESCRIPTION
Although version 5.0 has beta support for running under Python3, it's not yet ready to be switched.
See https://www.mercurial-scm.org/wiki/Python3

Basic tests performed only:

```
bloody% hg --version
Mercurial Distributed SCM (version 5.0)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2019 Matt Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
bloody%
bloody% hg clone http://www.selenic.com/repo/hello my-hello
real URL is https://selenic.com/repo/hello
requesting all changes
adding changesets
adding manifests
adding file changes
added 2 changesets with 2 changes to 2 files
new changesets 0a04b987be5a:82e55d328c8c
updating to branch default
2 files updated, 0 files merged, 0 files removed, 0 files unresolved
bloody% ls my-hello
Makefile   hello.c
bloody% cd my-hello
/data/omnios-build/my-hello
bloody% hg summary
parent: 1:82e55d328c8c tip
 Create a makefile
branch: default
commit: (clean)
update: (current)
```