### PR TITLE
Add Azure Guest Agent

### DIFF
--- a/build/azure/build.sh
+++ b/build/azure/build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+# The "rmvolmgr" service is relied upon to mount and umount the
+# provisioning ISO that is attached to the VM when running on Azure.
+RUN_DEPENDS_IPS="
+    runtime/python-$PYTHONPKGVER
+    system/hyperv/tools
+    service/storage/media-volume-manager
+"
+
+PROG=WAGuestAgent
+PKG=system/virtualization/azure-agent
+VER=2.2.40
+SUMMARY="Microsoft Azure Guest Agent"
+DESC="The $SUMMARY (waagent) manages provisioning and VM interaction "
+DESC+="with the Azure Fabric Controller."
+
+# Respect environmental overrides for these to ease development.
+: ${WAAGENT_SOURCE_REPO:=$GITHUB/$PROG}
+: ${WAAGENT_SOURCE_BRANCH:=master}
+
+# Extend VER so that the temporary build directory is branch specific.
+# Branch names can include '/' so remove them.
+_VER=$VER
+VER+="-${WAAGENT_SOURCE_BRANCH//\//_}"
+
+clone_source() {
+    clone_github_source $PROG \
+        "$WAAGENT_SOURCE_REPO" "$WAAGENT_SOURCE_BRANCH" "$WAAGENT_CLONE"
+}
+
+init
+clone_source
+BUILDDIR+=/$PROG
+EXTRACTED_SRC=$BUILDDIR
+prep_build
+python_build
+VER=$_VER make_package
+#clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/azure/local.mog
+++ b/build/azure/local.mog
@@ -1,0 +1,21 @@
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE.txt license=Apache2
+
+# waagent uses just /usr/bin/python3 in its shebang so pkg cannot determine
+# dependencies properly
+<transform file path=opt/azure/sbin/waagent \
+    -> set pkg.depend.bypass-generate .*>
+

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -143,6 +143,7 @@ system/pciutils/pci.ids			2.2
 system/pciutils				3.6
 system/pkgtree				1
 system/prerequisite/gnu			0.5.11
+system/virtualization/azure-agent	2
 system/virtualization/open-vm-tools	10
 terminal/screen				4.6
 terminal/tmux				2.9

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -96,6 +96,7 @@
 | library/glib2				| 2.60.0		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
 | developer/gnu-binutils		| 2.32			| https://ftp.gnu.org/gnu/binutils
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
+| system/virtualization/azure-agent	| 2.2.40		| https://github.com/Azure/WALinuxAgent/releases
 | system/virtualization/open-vm-tools	| 10.3.10		| https://github.com/vmware/open-vm-tools/releases https://docs.vmware.com/en/VMware-Tools/
 | developer/swig			| 4.0.0			| http://www.swig.org/download.html
 | library/security/trousers		| 0.3.14		| https://sourceforge.net/projects/trousers/files/trousers


### PR DESCRIPTION
This adds the Azure Guest Agent (waagent) to OmniOS core.
It builds from https://github.com/omniosorg/waguestagent which will no doubt receive several more updates as testing progresses, but that should not require changes to these build scripts.