### PR TITLE
add missing omnios-build tool

### DIFF
--- a/build/meta/omnios-build-tools.p5m
+++ b/build/meta/omnios-build-tools.p5m
@@ -45,6 +45,7 @@ depend fmri=service/network/tftp type=require
 depend fmri=system/header/header-audio type=require
 depend fmri=system/library type=require
 depend fmri=system/library/gfortran-runtime type=require
+depend fmri=system/library/iconv/unicode type=require
 depend fmri=system/library/math type=require
 depend fmri=system/pciutils/pci.ids type=require
 depend fmri=system/zones/internal type=require


### PR DESCRIPTION
`library/iconv/unicode` is required to build current `vim`