### PR TITLE
Continue to ship gfx-drm header file packages

### DIFF
--- a/build/jeos/illumos-gate.exclude
+++ b/build/jeos/illumos-gate.exclude
@@ -1,2 +1,1 @@
-driver/graphics/drm@
-driver/graphics/agpgart@
+system/package/to/be/excluded@

--- a/doc/baseline
+++ b/doc/baseline
@@ -592,6 +592,7 @@ omnios system/fru-id/platform
 omnios system/header
 omnios system/header/header-agp
 omnios system/header/header-audio
+omnios system/header/header-drm
 omnios system/header/header-firewire
 omnios system/header/header-picl
 omnios system/header/header-storage


### PR DESCRIPTION
Now that gfx-drm has been removed from gate, the `system/header/header-agp` package should be shipped from the gfx-drm gate. There is also `system/header/header-drm` which was not previously shipped but is being included for completeness and consistency with other distributions.