### PR TITLE
Automatically format and strip manifests before publishing

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1225,6 +1225,10 @@ make_package() {
     grep '^depend ' $P5M_FINAL | while read line; do
         logmsg "$line"
     done
+
+    logmsg "--- Formatting manifest"
+    logcmd $PKGFMT -s $P5M_FINAL
+
     if [ -z "$SKIP_PKGLINT" ] && ( [ -n "$BATCH" ] || ask_to_pkglint ); then
         run_pkglint $PKGSRVR $P5M_FINAL
     fi


### PR DESCRIPTION
This cleans up manifests by removing unnecessary action attributes. Here's an example for the `git` package. This is an example where only a couple of lines change, for others it is more significant. For `pkg` itself this shrunk the manifest by around 7%.

Depends on https://github.com/omniosorg/pkg5/pull/151/

```diff
--- Published developer/versioning/git@2.22.0,5.11-151031.0
--- Comparing old package with new

-set name=pkg.debug.depend.bypassed value=usr/libexec/git-core/git-p4:.*
-file path=usr/libexec/amd64/git-core/git-p4 owner=root group=bin mode=0755 \
-    pkg.depend.bypass-generate=.*
+file path=usr/libexec/amd64/git-core/git-p4 owner=root group=bin mode=0755
-file path=usr/libexec/git-core/git-p4 owner=root group=bin mode=0755 \
-    pkg.depend.bypass-generate=.*
+file path=usr/libexec/git-core/git-p4 owner=root group=bin mode=0755
```