### PR TITLE
Require ctf tools for illumos builds

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -6,6 +6,7 @@ depend fmri=developer/as type=require
 depend fmri=developer/astdev type=require
 depend fmri=developer/build/make type=require
 depend fmri=developer/build/onbld type=require
+depend fmri=developer/debug/ctf type=require
 depend fmri=developer/gcc44 type=require
 depend fmri=developer/gcc7 type=require
 depend fmri=developer/gnu-binutils type=require


### PR DESCRIPTION
Whilst not strictly required, this can help bldenv set VERSION properly so that incremental builds can be performed.