### PR TITLE
gcc7: use the new-style retpoline thunk names for external thunks (r151030)

### DIFF
--- a/build/gcc7/patches/0002-compare_tests-Use-nawk-1-on-illumos-since-awk-1-is-o.patch
+++ b/build/gcc7/patches/0002-compare_tests-Use-nawk-1-on-illumos-since-awk-1-is-o.patch
@@ -1,7 +1,7 @@
 From 57fce965e365852eef4032a9dad2f65556f65c21 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 26 Jan 2016 14:24:11 -0500
-Subject: [PATCH 02/24] compare_tests: Use nawk(1) on illumos, since awk(1) is
+Subject: compare_tests: Use nawk(1) on illumos, since awk(1) is
  old and bad
 
 ---

--- a/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
+++ b/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
@@ -1,7 +1,7 @@
 From 156f9a9b424f17037105c9c3734af868b81a66f5 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 5 Mar 2014 04:12:52 +0000
-Subject: [PATCH 03/24] gcc: enable the .eh_frame based unwinder
+Subject: gcc: enable the .eh_frame based unwinder
 
 ---
  gcc/configure    | 3 +++

--- a/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
+++ b/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
@@ -1,7 +1,7 @@
 From 6d45b594bda49c59307efc5f637dd58f4c59034e Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 11 Mar 2014 21:50:30 +0000
-Subject: [PATCH 04/24] intl: Don't use UTF-8 quotes.  Ever.
+Subject: intl: Don't use UTF-8 quotes.  Ever.
 
 ---
  gcc/intl.c | 17 ++++-------------

--- a/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
+++ b/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
@@ -1,7 +1,7 @@
 From 277612fffed37818c3c91711dfea07ed92e088dc Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sat, 27 Oct 2012 02:44:09 +0100
-Subject: [PATCH 05/24] Implement -fstrict-calling-conventions
+Subject: Implement -fstrict-calling-conventions
 
 Stock GCC is overly willing to violate the ABI when calling local functions,
 such that it passes arguments in registers on i386.  This hampers debugging

--- a/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
+++ b/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
@@ -1,7 +1,7 @@
 From b209a752a5851b222a091eb40b3023087d1eaead Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sun, 30 Sep 2012 16:44:14 -0400
-Subject: [PATCH 06/24] allow the global disabling of function cloning
+Subject: allow the global disabling of function cloning
 
 Optimizations which clone functions to create call-specific implementations
 which may be better optimized also dissociate these functions from their

--- a/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
+++ b/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
@@ -1,7 +1,7 @@
 From d72ebb049040e4f85dad32ebdc359057ea93e937 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 02:58:33 +0000
-Subject: [PATCH 07/24] strict-cc2: check that disabling function cloning
+Subject: strict-cc2: check that disabling function cloning
  prevents constant propagation eliding or changing arguments
 
 ---

--- a/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
+++ b/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
@@ -1,7 +1,7 @@
 From bb49ed7b975514aa7bd36c9fcd3ff9405b096be1 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 22:11:03 +0000
-Subject: [PATCH 08/24] sol2: enable full __cxa_atexit support
+Subject: sol2: enable full __cxa_atexit support
 
 ---
  gcc/config/sol2.h  | 4 ++--

--- a/build/gcc7/patches/0009-sol2-Use-appropriate-values-objects-for-the-various-.patch
+++ b/build/gcc7/patches/0009-sol2-Use-appropriate-values-objects-for-the-various-.patch
@@ -1,7 +1,7 @@
 From 516b8fa161f908cb95cb880d17930408a205298e Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 27 Jan 2016 16:49:07 -0500
-Subject: [PATCH 09/24] sol2: Use appropriate values objects for the various C
+Subject: sol2: Use appropriate values objects for the various C
  and C++ standards
 
 I'm reasonable confident of the C cases, less confident of the C++

--- a/build/gcc7/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
+++ b/build/gcc7/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
@@ -1,7 +1,7 @@
 From f26c31259095fccfadf060a829e31cdb6e613620 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sat, 23 Jan 2016 22:14:56 -0500
-Subject: [PATCH 10/24] i386: Save integer-passed arguments to the stack, to
+Subject: i386: Save integer-passed arguments to the stack, to
  aid debuggers.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/build/gcc7/patches/0011-16-update-cmn_err-format-specifier.patch
+++ b/build/gcc7/patches/0011-16-update-cmn_err-format-specifier.patch
@@ -1,7 +1,7 @@
 From 7decb085713a17b98dc07c6a3450ded6c8c80347 Mon Sep 17 00:00:00 2001
 From: Yuri Pankov <yuri.pankov@nexenta.com>
 Date: Sat, 5 Nov 2016 05:26:47 +0300
-Subject: [PATCH 11/24] 16 update cmn_err format specifier Reviewed by: Richard
+Subject: 16 update cmn_err format specifier Reviewed by: Richard
  Lowe <richlowe@richlowe.net> Reviewed by: Robert Mustacchi <rm@joyent.com>
 
 ---

--- a/build/gcc7/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
+++ b/build/gcc7/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
@@ -1,7 +1,7 @@
 From 1232a7637e426e091bc506d362cfc4ff4acc2651 Mon Sep 17 00:00:00 2001
 From: Yuri Pankov <yuri.pankov@nexenta.com>
 Date: Mon, 13 Feb 2017 18:14:45 +0300
-Subject: [PATCH 12/24] 19 cmn_err %b conversion should accept 0 flag Reviewed
+Subject: 19 cmn_err %b conversion should accept 0 flag Reviewed
  by: Robert Mustacchi <rm@joyent.com> Reviewed by: Richard Lowe
  <richlowe@richlowe.net>
 

--- a/build/gcc7/patches/0013-We-never-want-to-omit-the-frame-pointer-regardless-o.patch
+++ b/build/gcc7/patches/0013-We-never-want-to-omit-the-frame-pointer-regardless-o.patch
@@ -1,7 +1,7 @@
 From 3f3baddcfb42b8b10dab9372669c2a3d230dae08 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 25 Oct 2018 18:19:36 +0000
-Subject: [PATCH 13/24] We never want to omit the frame pointer, regardless of
+Subject: We never want to omit the frame pointer, regardless of
  the optimisation level or options to gcc - we like stack traces too much and
  it is of questionable benefit anyway, even on i386.
 

--- a/build/gcc7/patches/0014-libstdc-v3-illumos-and-Solaris-haven-t-needed-lrt-in.patch
+++ b/build/gcc7/patches/0014-libstdc-v3-illumos-and-Solaris-haven-t-needed-lrt-in.patch
@@ -1,7 +1,7 @@
 From bdbe8fad6da912353cf52c4d96e13ce146a08a26 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Mon, 29 Oct 2018 18:21:34 +0000
-Subject: [PATCH 14/24] libstdc++v3: illumos and Solaris haven't needed -lrt in
+Subject: libstdc++v3: illumos and Solaris haven't needed -lrt in
  a long time
 
 Originally from Andy Fiddaman <andy@omniosce.org>

--- a/build/gcc7/patches/0015-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
+++ b/build/gcc7/patches/0015-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
@@ -1,7 +1,7 @@
 From 537a897237b06194d2cfa9060f82234c5e47b567 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Mon, 29 Oct 2018 18:23:00 +0000
-Subject: [PATCH 15/24] libgo: libelf on illumos doesn't support largefile
+Subject: libgo: libelf on illumos doesn't support largefile
 
 Originally from pkgsrc
 ---

--- a/build/gcc7/patches/0016-libgcc-unwind.map-should-be-v2-style.patch
+++ b/build/gcc7/patches/0016-libgcc-unwind.map-should-be-v2-style.patch
@@ -1,7 +1,7 @@
 From 7fbfb040a15d0cf867d71764ec134785718deb5d Mon Sep 17 00:00:00 2001
 From: John Levon <john.levon@joyent.com>
 Date: Tue, 20 Nov 2018 16:07:51 +0000
-Subject: [PATCH 16/24] libgcc-unwind.map should be v2-style
+Subject: libgcc-unwind.map should be v2-style
 
 ---
  libgcc/config/t-slibgcc-sld | 27 +++++++++++++++++++++++----

--- a/build/gcc7/patches/0017-libpthread-is-a-filter-in-illumos-all-functionality-.patch
+++ b/build/gcc7/patches/0017-libpthread-is-a-filter-in-illumos-all-functionality-.patch
@@ -1,7 +1,7 @@
 From 494cb8aff90e7a2372b6b01c8847a9a136c0fcbb Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Mon, 11 Mar 2019 10:41:58 +0000
-Subject: [PATCH 17/24] libpthread is a filter in illumos; all functionality
+Subject: libpthread is a filter in illumos; all functionality
  has been migrated to libc. Prevent gcc from linking with libpthread if
  -pthread[s] is passed as an option.
 

--- a/build/gcc7/patches/0018-i386-Fix-grammar-of-msave-args-usage-message.patch
+++ b/build/gcc7/patches/0018-i386-Fix-grammar-of-msave-args-usage-message.patch
@@ -1,7 +1,7 @@
 From 37f365b7db87f58c2a4583dba6073eca2f619bfe Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 26 Apr 2019 03:05:14 +0000
-Subject: [PATCH 18/24] i386: Fix grammar of -msave-args usage message
+Subject: i386: Fix grammar of -msave-args usage message
 
 The GCC test suite checks that usage messages are properly punctuated,
 so this fixes a low-hanging test failure

--- a/build/gcc7/patches/0019-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc7/patches/0019-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,7 +1,7 @@
 From 6155fc5a019b533550dace1fdefff0ae96a8cfd0 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
-Subject: [PATCH 19/24] OOCE: Adjust default library paths for OmniOS
+Subject: OOCE: Adjust default library paths for OmniOS
 
 ---
  gcc/config/sol2.h | 8 ++++----

--- a/build/gcc7/patches/0020-tests-x86_64-pro_and_epilogue-RTL-can-t-work-with-ms.patch
+++ b/build/gcc7/patches/0020-tests-x86_64-pro_and_epilogue-RTL-can-t-work-with-ms.patch
@@ -1,7 +1,7 @@
 From fd11d4b82ab5744fc8753a1cd27a1d9246533c37 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Thu, 2 May 2019 17:54:20 +0000
-Subject: [PATCH 20/24] tests: x86_64 pro_and_epilogue RTL can't work with
+Subject: tests: x86_64 pro_and_epilogue RTL can't work with
  -msave-args
 
 The RTL is included directly in the test, and was generated without

--- a/build/gcc7/patches/0021-i386-don-t-assert-the-FP-is-valid-during-epilogue-ad.patch
+++ b/build/gcc7/patches/0021-i386-don-t-assert-the-FP-is-valid-during-epilogue-ad.patch
@@ -1,7 +1,7 @@
 From 21357fd22af9e0d7e458a49d867fdeff6e2a9f2b Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 00:56:45 +0000
-Subject: [PATCH 21/24] i386: don't assert the FP is valid during epilogue
+Subject: i386: don't assert the FP is valid during epilogue
  adjustment
 
 I did this, I think, to double check some assumptions.  Unfortunately,

--- a/build/gcc7/patches/0022-gcc.target-i386-retarg-skip-if-msave-args.patch
+++ b/build/gcc7/patches/0022-gcc.target-i386-retarg-skip-if-msave-args.patch
@@ -1,7 +1,7 @@
 From af1ecf30544ea3f6e52322ff1d9b1cd5ef3aa287 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:02:08 +0000
-Subject: [PATCH 22/24] gcc.target/i386/retarg: skip if msave-args
+Subject: gcc.target/i386/retarg: skip if msave-args
 
 This will always fail if saving arguments, because we're testing
 argument registers are untouched, so saving them will ruin that.

--- a/build/gcc7/patches/0023-i386-use-correct-error-message-about-msave-args-and-.patch
+++ b/build/gcc7/patches/0023-i386-use-correct-error-message-about-msave-args-and-.patch
@@ -1,7 +1,7 @@
 From 528c759b95bb57904acff325fde5fccd6c1f16af Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:20:30 +0000
-Subject: [PATCH 23/24] i386: use correct error message about -msave-args and
+Subject: i386: use correct error message about -msave-args and
  ABIs
 
 We used to say it made no sense in 32bit mode, but it doesn't make sense

--- a/build/gcc7/patches/0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
+++ b/build/gcc7/patches/0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
@@ -1,7 +1,7 @@
 From 00c10cd540ab26d4fa4c6ca9b2c3ed032c2998a9 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:22:56 +0000
-Subject: [PATCH 24/24] gcc.target/i386: skip 16bit tests when -msave-args
+Subject: gcc.target/i386: skip 16bit tests when -msave-args
 
 ---
  gcc/testsuite/gcc.target/i386/pr78691-i386.c | 1 +

--- a/build/gcc7/patches/0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch
+++ b/build/gcc7/patches/0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch
@@ -1,0 +1,27 @@
+From 54610bfb3e21b5903f36d641c6145740f298c986 Mon Sep 17 00:00:00 2001
+From: Richard Lowe <richlowe@richlowe.net>
+Date: Wed, 7 Feb 2018 02:13:42 +0000
+Subject: i386: use the new-style retpoline thunk names for
+ external thunks, because nothing else will work
+
+---
+ gcc/config/i386/i386.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
+index f7ac18317e7..afce9a6acab 100644
+--- a/gcc/config/i386/i386.c
++++ b/gcc/config/i386/i386.c
+@@ -12099,7 +12099,8 @@ indirect_thunk_name (char name[32], unsigned int regno,
+   if (regno != INVALID_REGNUM && regno != CX_REG && ret_p)
+     gcc_unreachable ();
+ 
+-  if (USE_HIDDEN_LINKONCE)
++  if (USE_HIDDEN_LINKONCE ||
++      (cfun && cfun->machine->indirect_branch_type == indirect_branch_thunk_extern))
+     {
+       const char *bnd = need_bnd_p ? "_bnd" : "";
+       const char *ret = ret_p ? "return" : "indirect";
+-- 
+2.21.0
+

--- a/build/gcc7/patches/0026-Use-GNU-backends-for-gcc-ar-nm-ranlib.patch
+++ b/build/gcc7/patches/0026-Use-GNU-backends-for-gcc-ar-nm-ranlib.patch
@@ -1,0 +1,32 @@
+From 3bab576aebc4cce41169275744f57a112a0948b7 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <omnios@citrus-it.co.uk>
+Date: Fri, 19 Jul 2019 11:42:58 +0000
+Subject: Use GNU backends for gcc-{ar,nm,ranlib}
+
+---
+ gcc/gcc-ar.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gcc/gcc-ar.c b/gcc/gcc-ar.c
+index d5d80e042e5..5f1d075fdd9 100644
+--- a/gcc/gcc-ar.c
++++ b/gcc/gcc-ar.c
+@@ -187,12 +187,12 @@ main (int ac, char **av)
+     }
+ 
+   /* Find the wrapped binutils program.  */
+-  exe_name = find_a_file (&target_path, PERSONALITY, X_OK);
++  exe_name = find_a_file (&target_path, "g" PERSONALITY, X_OK);
+   if (!exe_name)
+     {
+-      const char *real_exe_name = PERSONALITY;
++      const char *real_exe_name = "g" PERSONALITY;
+ #ifdef CROSS_DIRECTORY_STRUCTURE
+-      real_exe_name = concat (target_machine, "-", PERSONALITY, NULL);
++      real_exe_name = concat (target_machine, "-", "g" PERSONALITY, NULL);
+ #endif
+       exe_name = find_a_file (&path, real_exe_name, X_OK);
+       if (!exe_name)
+-- 
+2.21.0
+

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -21,3 +21,4 @@
 0022-gcc.target-i386-retarg-skip-if-msave-args.patch
 0023-i386-use-correct-error-message-about-msave-args-and-.patch
 0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
+0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -22,3 +22,4 @@
 0023-i386-use-correct-error-message-about-msave-args-and-.patch
 0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
 0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch
+0026-Use-GNU-backends-for-gcc-ar-nm-ranlib.patch


### PR DESCRIPTION
gcc7: use the new-style retpoline thunk names for external thunks (r151030)
