### PR TITLE
coreutils: fix bugs in GNU ln

### DIFF
--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -33,16 +33,27 @@ DESC="GNU core utilities"
 
 BUILD_DEPENDS_IPS="compress/xz library/gmp"
 
-CPPFLAGS="-I/usr/include/gmp"
 PREFIX=/usr/gnu
-reset_configure_opts
+
+# We ship 64-bit binaries under /usr/gnu/bin/ with selected ones linked back
+# to /usr/bin/, but we need to continue building dual arch so that the
+# 32-bit libstdbuf.so is available. This enables the stdbuf command to
+# work with 32-bit binaries.
+set_arch both
+
+CPPFLAGS="-I/usr/include/gmp"
 CONFIGURE_OPTS+="
     --with-openssl=auto
     gl_cv_host_operating_system=illumos
     ac_cv_func_inotify_init=no
 "
-CONFIGURE_OPTS_32+=" --libexecdir=/usr/lib --bindir=/usr/gnu/bin"
-CONFIGURE_OPTS_64+=" --libexecdir=/usr/lib/$ISAPART64"
+CONFIGURE_OPTS_32+="
+    --bindir=/usr/gnu/bin/__i386
+    --libexecdir=/usr/lib
+"
+CONFIGURE_OPTS_64+="
+    --libexecdir=/usr/lib/$ISAPART64
+"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'
 

--- a/build/coreutils/local.mog
+++ b/build/coreutils/local.mog
@@ -21,9 +21,9 @@
 #
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Use is subject to license terms.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
-<transform file dir path=usr/gnu/bin/amd64 -> drop>
+<transform path=usr/gnu/bin/__i386 -> drop>
 <transform file path=license -> drop>
 license COPYING license=GPLv3
 

--- a/build/coreutils/patches/ln-port-to-platforms-lacking-O_DIRECTORY.patch
+++ b/build/coreutils/patches/ln-port-to-platforms-lacking-O_DIRECTORY.patch
@@ -1,0 +1,40 @@
+From 6a707feee86ffd8eee1f8f1e7a701693d0489ffb Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Sat, 16 Mar 2019 11:24:19 -0700
+Subject: [PATCH] ln: port to platforms lacking O_DIRECTORY
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* src/ln.c (main): Port to older platforms lacking
+support for POSIX.1-2008’s O_DIRECTORY flag (Bug#34876).
+diff -wpruN '--exclude=*.orig' a~/src/ln.c a/src/ln.c
+--- a~/src/ln.c	1970-01-01 00:00:00
++++ a/src/ln.c	1970-01-01 00:00:00
+@@ -611,13 +611,25 @@ main (int argc, char **argv)
+           int flags = (O_PATHSEARCH | O_DIRECTORY
+                        | (dereference_dest_dir_symlinks ? 0 : O_NOFOLLOW));
+           destdir_fd = openat_safer (AT_FDCWD, d, flags);
++          int err = errno;
++          if (!O_DIRECTORY && 0 <= destdir_fd)
++            {
++              struct stat st;
++              err = (fstat (destdir_fd, &st) != 0 ? errno
++                     : S_ISDIR (st.st_mode) ? 0 : ENOTDIR);
++              if (err != 0)
++                {
++                  close (destdir_fd);
++                  destdir_fd = -1;
++                }
++            }
+           if (0 <= destdir_fd)
+             {
+               n_files -= !target_directory;
+               target_directory = d;
+             }
+           else if (! (n_files == 2 && !target_directory))
+-            die (EXIT_FAILURE, errno, _("target %s"), quoteaf (d));
++            die (EXIT_FAILURE, err, _("target %s"), quoteaf (d));
+         }
+     }
+ 

--- a/build/coreutils/patches/ln-s-catch-EINVAL.patch
+++ b/build/coreutils/patches/ln-s-catch-EINVAL.patch
@@ -1,0 +1,21 @@
+From 3e0dff3925b5e521cae468087950e85b60002d1c Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Sun, 17 Mar 2019 13:20:42 -0700
+Subject: ln: port to symlink ("x", ".") failing with EINVAL
+
+Problem reported by John Marino (Bug#34894).
+* src/ln.c (main): Port ln -s to Solaris symlink function,
+where symlink ("x", ".") fails with errno == EINVAL.
+diff -wpruN '--exclude=*.orig' a~/src/ln.c a/src/ln.c
+--- a~/src/ln.c	1970-01-01 00:00:00
++++ a/src/ln.c	1970-01-01 00:00:00
+@@ -603,7 +603,8 @@ main (int argc, char **argv)
+     {
+       if (n_files == 2 && !target_directory)
+         link_errno = atomic_link (file[0], AT_FDCWD, file[1]);
+-      if (link_errno < 0 || link_errno == EEXIST || link_errno == ENOTDIR)
++      if (link_errno < 0 || link_errno == EEXIST || link_errno == ENOTDIR
++	  || link_errno == EINVAL)
+         {
+           char const *d
+             = target_directory ? target_directory : file[n_files - 1];

--- a/build/coreutils/patches/series
+++ b/build/coreutils/patches/series
@@ -3,3 +3,8 @@ man-sections.patch
 mountlist.c.patch
 who.c.patch
 Makefile.in.patch
+tests_df_no-mtab-status.sh.patch
+set-permission.c.patch
+ln-s-catch-EINVAL.patch
+ln-port-to-platforms-lacking-O_DIRECTORY.patch
+stdbuf.c.patch

--- a/build/coreutils/patches/set-permission.c.patch
+++ b/build/coreutils/patches/set-permission.c.patch
@@ -1,0 +1,39 @@
+GNU Coreutils bug 21062 coreutils-8.24 - cp(1) check failures on tmpfs filesystem (Solaris 10 / Solaris 11)
+
+/* Avoid spoiling errno when we are going to ignore it immediately anyway */
+
+diff -wpruN '--exclude=*.orig' a~/lib/set-permissions.c a/lib/set-permissions.c
+--- a~/lib/set-permissions.c	1970-01-01 00:00:00
++++ a/lib/set-permissions.c	1970-01-01 00:00:00
+@@ -230,6 +230,7 @@ set_acls_from_mode (const char *name, in
+         {
+           if (errno == ENOSYS)
+             {
++              errno = 0;
+               *must_chmod = true;
+               return 0;
+             }
+@@ -264,6 +265,7 @@ set_acls_from_mode (const char *name, in
+       {
+         if (errno == ENOSYS || errno == EOPNOTSUPP)
+           {
++            errno = 0;
+             *must_chmod = true;
+             return 0;
+           }
+@@ -634,6 +636,7 @@ set_acls (struct permission_context *ctx
+           if ((errno == ENOSYS || errno == EOPNOTSUPP || errno == EINVAL)
+               && acl_nontrivial (ctx->count, ctx->entries) == 0)
+             ret = 0;
++            errno = 0; 
+         }
+       else
+         *acls_set = true;
+@@ -651,6 +654,7 @@ set_acls (struct permission_context *ctx
+           if ((errno == ENOSYS || errno == EINVAL || errno == ENOTSUP)
+               && acl_ace_nontrivial (ctx->ace_count, ctx->ace_entries) == 0)
+             ret = 0;
++            errno = 0; 
+         }
+       else
+         *acls_set = true;

--- a/build/coreutils/patches/stdbuf.c.patch
+++ b/build/coreutils/patches/stdbuf.c.patch
@@ -1,0 +1,23 @@
+Change needed to get stdbuf to successfully preload libstdbuf.so
+for both 32-bit and 64-bit applications.
+
+Since we don't link against libstdbuf.so, we need to LD_PRELOAD it.
+libstdbuf.so lives in /usr/lib and /usr/lib/64, so we just use a
+search path value of "" and that equates to LD_PRELOAD=libstdbuf.so,
+and ld.so.1 finds the right one associated with the process class.
+ie. we don't use full path names for the preload names.
+
+This change has been passed upstream, but the GNU coreutils maintainer
+turned it into a comment explaining why it's not included by default.
+
+diff -wpruN '--exclude=*.orig' a~/src/stdbuf.c a/src/stdbuf.c
+--- a~/src/stdbuf.c	1970-01-01 00:00:00
++++ a/src/stdbuf.c	1970-01-01 00:00:00
+@@ -216,6 +216,6 @@ set_LD_PRELOAD (void)
+   char const *const search_path[] = {
+     program_path,
+-    PKGLIBEXECDIR,
++    "",			/* System default */
+     NULL
+   };
+ 

--- a/build/coreutils/patches/tests_df_no-mtab-status.sh.patch
+++ b/build/coreutils/patches/tests_df_no-mtab-status.sh.patch
@@ -1,0 +1,42 @@
+diff -wpruN '--exclude=*.orig' a~/tests/df/no-mtab-status.sh a/tests/df/no-mtab-status.sh
+--- a~/tests/df/no-mtab-status.sh	1970-01-01 00:00:00
++++ a/tests/df/no-mtab-status.sh	1970-01-01 00:00:00
+@@ -35,9 +35,13 @@ cat > k.c <<EOF || framework_failure_
+ #define _GNU_SOURCE
+ #include <stdio.h>
+ #include <errno.h>
+-#include <mntent.h>
+ #include <string.h>
+ #include <dlfcn.h>
++#ifdef __sun
++#include <sys/mnttab.h>
++#else
++#include <mntent.h>
++#endif
+ 
+ #define STREQ(a, b) (strcmp (a, b) == 0)
+ 
+@@ -69,7 +73,11 @@ FILE* fopen(const char *path, const char
+     return fopen_func(path, mode);
+ }
+ 
++#ifdef __sun
++int getmntent (FILE *fp, struct mnttab *mp)
++#else
+ struct mntent *getmntent (FILE *fp)
++#end
+ {
+   /* Prove that LD_PRELOAD works. */
+   static int done = 0;
+@@ -80,7 +88,11 @@ struct mntent *getmntent (FILE *fp)
+     }
+   /* Now simulate the failure. */
+   errno = ENOENT;
++#ifdef __sun
++  return -1;
++#else
+   return NULL;
++#endif
+ }
+ EOF
+ 

--- a/build/coreutils/testsuite.log
+++ b/build/coreutils/testsuite.log
@@ -256,7 +256,7 @@ PASS: tests/misc/time-style.sh
 PASS: tests/misc/timeout.sh
 PASS: tests/misc/timeout-blocked.pl
 SKIP: tests/misc/timeout-group.sh
-PASS: tests/misc/timeout-parameters.sh
+FAIL: tests/misc/timeout-parameters.sh
 PASS: tests/misc/tr.pl
 PASS: tests/misc/tr-case-class.sh
 PASS: tests/misc/truncate-dangling-symlink.sh
@@ -323,8 +323,8 @@ PASS: tests/cp/link-no-deref.sh
 PASS: tests/cp/link-preserve.sh
 PASS: tests/cp/link-symlink.sh
 SKIP: tests/cp/nfs-removal-race.sh
-FAIL: tests/cp/no-deref-link1.sh
-FAIL: tests/cp/no-deref-link2.sh
+PASS: tests/cp/no-deref-link1.sh
+PASS: tests/cp/no-deref-link2.sh
 PASS: tests/cp/no-deref-link3.sh
 PASS: tests/cp/parent-perm.sh
 PASS: tests/cp/parent-perm-race.sh
@@ -615,10 +615,10 @@ SKIP: tests/factor/t34.sh
 SKIP: tests/factor/t35.sh
 SKIP: tests/factor/t36.sh
 # TOTAL: 616
-# PASS:  470
+# PASS:  471
 # SKIP:  144
 # XFAIL: 0
-# FAIL:  2
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0
 SKIP: tests/tail-2/inotify-race
@@ -687,6 +687,8 @@ SKIP: tests/misc/tac-continue
 SKIP tests/misc/tac-continue.sh (exit status: 77)
 SKIP: tests/misc/timeout-group
 SKIP tests/misc/timeout-group.sh (exit status: 77)
+FAIL: tests/misc/timeout-parameters
+FAIL tests/misc/timeout-parameters.sh (exit status: 1)
 SKIP: tests/misc/xattr
 SKIP tests/misc/xattr.sh (exit status: 77)
 SKIP: tests/cp/acl
@@ -701,10 +703,6 @@ SKIP: tests/cp/fiemap-2
 SKIP tests/cp/fiemap-2.sh (exit status: 77)
 SKIP: tests/cp/nfs-removal-race
 SKIP tests/cp/nfs-removal-race.sh (exit status: 77)
-FAIL: tests/cp/no-deref-link1
-FAIL tests/cp/no-deref-link1.sh (exit status: 1)
-FAIL: tests/cp/no-deref-link2
-FAIL tests/cp/no-deref-link2.sh (exit status: 1)
 SKIP: tests/cp/perm
 SKIP tests/cp/perm.sh (exit status: 77)
 SKIP: tests/cp/proc-short-read
@@ -914,9 +912,9 @@ SKIP tests/factor/t35.sh (exit status: 77)
 SKIP: tests/factor/t36
 SKIP tests/factor/t36.sh (exit status: 77)
 # TOTAL: 616
-# PASS:  470
+# PASS:  471
 # SKIP:  144
 # XFAIL: 0
-# FAIL:  2
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -436,7 +436,7 @@ forgo_isaexec() {
 }
 
 set_arch() {
-    [[ $1 =~ ^(32|64)$ ]] || logerr "Bad argument to set_arch"
+    [[ $1 =~ ^(both|32|64)$ ]] || logerr "Bad argument to set_arch"
     BUILDARCH=$1
     forgo_isaexec
 }


### PR DESCRIPTION
and switch to 64-bit binaries.

stdbuf works with both 32-bit and 64-bit targets:

```
% stdbuf -oL /usr/bin/amd64/ls
build.log      build.sh       patches        tmp
build.log.1    local.mog      testsuite.log
```
```
% stdbuf -oL /usr/bin/ls
build.log      build.sh       patches        tmp
build.log.1    local.mog      testsuite.log

```
