### PR TITLE
gmp: Do not rely on modern CPU features; enable testsuite

### DIFF
--- a/build/libgmp/testsuite.log
+++ b/build/libgmp/testsuite.log
@@ -1,0 +1,278 @@
+PASS: t-bswap
+PASS: t-constants
+PASS: t-count_zeros
+PASS: t-hightomask
+PASS: t-modlinv
+PASS: t-popc
+PASS: t-parity
+PASS: t-sub
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 8
+# PASS:  8
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-asmtype
+PASS: t-aors_1
+PASS: t-divrem_1
+PASS: t-mod_1
+PASS: t-fat
+PASS: t-get_d
+PASS: t-instrument
+PASS: t-iord_u
+PASS: t-mp_bases
+PASS: t-perfsqr
+PASS: t-scan
+PASS: logic
+PASS: t-toom22
+PASS: t-toom32
+PASS: t-toom33
+PASS: t-toom42
+PASS: t-toom43
+PASS: t-toom44
+PASS: t-toom52
+PASS: t-toom53
+PASS: t-toom54
+PASS: t-toom62
+PASS: t-toom63
+PASS: t-toom6h
+PASS: t-toom8h
+PASS: t-toom2-sqr
+PASS: t-toom3-sqr
+PASS: t-toom4-sqr
+PASS: t-toom6-sqr
+PASS: t-toom8-sqr
+PASS: t-div
+PASS: t-mul
+PASS: t-mullo
+PASS: t-sqrlo
+PASS: t-mulmod_bnm1
+PASS: t-sqrmod_bnm1
+PASS: t-mulmid
+PASS: t-hgcd
+PASS: t-hgcd_appr
+PASS: t-matrix22
+PASS: t-invert
+PASS: t-bdiv
+PASS: t-broot
+PASS: t-brootinv
+PASS: t-minvert
+PASS: t-sizeinbase
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 46
+# PASS:  46
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: reuse
+PASS: t-addsub
+PASS: t-cmp
+PASS: t-mul
+PASS: t-mul_i
+PASS: t-tdiv
+PASS: t-tdiv_ui
+PASS: t-fdiv
+PASS: t-fdiv_ui
+PASS: t-cdiv_ui
+PASS: t-gcd
+PASS: t-gcd_ui
+PASS: t-lcm
+PASS: t-invert
+PASS: dive
+PASS: dive_ui
+PASS: t-sqrtrem
+PASS: convert
+PASS: io
+PASS: t-inp_str
+PASS: logic
+PASS: bit
+PASS: t-powm
+PASS: t-powm_ui
+PASS: t-pow
+PASS: t-div_2exp
+PASS: t-root
+PASS: t-perfsqr
+PASS: t-perfpow
+PASS: t-jac
+PASS: t-bin
+PASS: t-get_d
+PASS: t-get_d_2exp
+PASS: t-get_si
+PASS: t-set_d
+PASS: t-set_si
+PASS: t-fac_ui
+PASS: t-mfac_uiui
+PASS: t-primorial_ui
+PASS: t-fib_ui
+PASS: t-lucnum_ui
+PASS: t-scan
+PASS: t-fits
+PASS: t-divis
+PASS: t-divis_2exp
+PASS: t-cong
+PASS: t-cong_2exp
+PASS: t-sizeinbase
+PASS: t-set_str
+PASS: t-aorsmul
+PASS: t-cmp_d
+PASS: t-cmp_si
+PASS: t-hamdist
+PASS: t-oddeven
+PASS: t-popcount
+PASS: t-set_f
+PASS: t-io_raw
+PASS: t-import
+PASS: t-export
+PASS: t-pprime_p
+PASS: t-nextprime
+PASS: t-remove
+PASS: t-limbs
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 63
+# PASS:  63
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-aors
+PASS: t-cmp
+PASS: t-cmp_ui
+PASS: t-cmp_si
+PASS: t-equal
+PASS: t-get_d
+PASS: t-get_str
+PASS: t-inp_str
+PASS: t-inv
+PASS: t-md_2exp
+PASS: t-set_f
+PASS: t-set_str
+PASS: io
+PASS: reuse
+PASS: t-cmp_z
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 15
+# PASS:  15
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-dm2exp
+PASS: t-conv
+PASS: t-add
+PASS: t-sub
+PASS: t-sqrt
+PASS: t-sqrt_ui
+PASS: t-muldiv
+PASS: reuse
+PASS: t-cmp_d
+PASS: t-cmp_si
+PASS: t-div
+PASS: t-fits
+PASS: t-get_d
+PASS: t-get_d_2exp
+PASS: t-get_si
+PASS: t-get_ui
+PASS: t-gsprec
+PASS: t-inp_str
+PASS: t-int_p
+PASS: t-mul_ui
+PASS: t-set
+PASS: t-set_q
+PASS: t-set_si
+PASS: t-set_ui
+PASS: t-trunc
+PASS: t-ui_div
+PASS: t-eq
+PASS: t-pow_ui
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 28
+# PASS:  28
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-iset
+PASS: t-lc2exp
+PASS: t-mt
+PASS: t-rand
+PASS: t-urbui
+PASS: t-urmui
+PASS: t-urndmm
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 7
+# PASS:  7
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-printf
+PASS: t-scanf
+PASS: t-locale
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 3
+# PASS:  3
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+PASS: t-binary
+PASS: t-cast
+PASS: t-cxx11
+PASS: t-headers
+PASS: t-iostream
+PASS: t-istream
+PASS: t-locale
+PASS: t-misc
+PASS: t-mix
+PASS: t-ops
+PASS: t-ops2
+PASS: t-ops3
+PASS: t-ostream
+PASS: t-prec
+PASS: t-ternary
+PASS: t-unary
+PASS: t-do-exceptions-work-at-all-with-this-compiler
+PASS: t-assign
+PASS: t-constr
+PASS: t-rand
+============================================================================
+Testsuite summary for GNU MP 6.1.2
+============================================================================
+# TOTAL: 20
+# PASS:  20
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================


### PR DESCRIPTION
gmp: Do not rely on modern CPU features Enable testsuite
