### PR TITLE
gcc7: bump illumos version (recently tagged upstream)

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -29,7 +29,7 @@
 PKG=developer/gcc7
 PROG=gcc
 VER=7.4.0
-ILVER=il-2
+ILVER=il-3
 SUMMARY="gcc $VER-$ILVER"
 DESC="The GNU Compiler Collection"
 


### PR DESCRIPTION
gcc7: bump illumos version (recently tagged upstream)
