### PR TITLE
try to avoid configure reaching into /opt/local if pkgsrc is installed

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -52,6 +52,7 @@ CONFIGURE_OPTS="
     --enable-shared
     --disable-static
     --without-python
+    --with-zlib=/usr
 "
 
 init


### PR DESCRIPTION
When pkgsrc is installed in `/opt/local`, even if not present in `PATH` some include files are found within that tree by the OmniOS build.

Using the wrong headers and libraries is not correct in general, but in this case I noticed because the `network/dns/bind` package was failing to build with errors like:

```
libtool: compile:  gcc -I/ws/stock/tmp/bind-9.11.9/bind-9.11.9 -I../.. -I. -I../../lib/dns -Iinclude -I/ws/stock/tmp/bind-9.11.9/bind-9.11.9/lib/dns/include -I../../lib/dns/include -I/ws/stock/tmp/bind-9.11.9/bind-9.11.9/lib/isc/include -I../../lib/isc -I../../lib/isc/include -I../../lib/isc/unix/include -I../../lib/isc/pthreads/include -I../../lib/isc/x86_32/include -I/usr/include -D_REENTRANT -DUSE_MD5 -DOPENSSL -DGSSAPI -DUSE_ISC_SPNEGO -D_XPG4_2 -D__EXTENSIONS__ -O2 -fno-aggressive-loop-optimizations -m64 -I/usr/include/libxml2 -I /opt/local/include -fPIC -W -Wall -Wmissing-prototypes -Wcast-qual -Wwrite-strings -Wformat -Wpointer-arith -fno-strict-aliasing -fno-delete-null-pointer-checks -c openssleddsa_link.c  -fPIC -DPIC -o .libs/openssleddsa_link.o
openssleddsa_link.c:39:2: error: #error "Ed25519 group is not known (NID_ED25519)"
 #error "Ed25519 group is not known (NID_ED25519)"
  ^~~~~
openssleddsa_link.c:42:2: error: #error "Ed448 group is not known (NID_ED448)"
 #error "Ed448 group is not known (NID_ED448)"
  ^~~~~
openssleddsa_link.c: In function 'priv_ed25519_to_ossl':
openssleddsa_link.c:138:25: error: 'NID_ED25519' undeclared (first use in this function); did you mean 'NID_X509'?
  return (d2i_PrivateKey(NID_ED25519, NULL, &p,
                         ^~~~~~~~~~~
                         NID_X509
openssleddsa_link.c:138:25: note: each undeclared identifier is reported only once for each function it appears in
openssleddsa_link.c: In function 'priv_ed448_to_ossl':
openssleddsa_link.c:175:25: error: 'NID_ED448' undeclared (first use in this function); did you mean 'NID_md4'?
  return (d2i_PrivateKey(NID_ED448, NULL, &p,
                         ^~~~~~~~~
                         NID_md4
...
```

Digging into this a bit, I discovered that the `configure` script in the BIND distribution does this while looking for `zlib`:

```sh
have_zlib=""
case "$with_zlib" in
        no)
                zlib_libs=""
                ;;
        auto|yes)
                for d in /usr /usr/local /opt/local
                do
                        if test -f "${d}/include/zlib.h"
                        then
                                if test ${d} != /usr
                                then
                                        zlib_cflags="-I ${d}/include"
                                        LIBS="$LIBS -L${d}/lib"
                                fi
                                have_zlib="yes"
                        fi
                done
                ;;
...
```

In particular, it seems to retain the _last_ searched include path in `zlib_cflags`, and _every_ searched library path in `LIBS`.  This affects the rest of the `configure` script, which is now looking in `/opt/local` for things, and also the resultant build.