### PR TITLE
kvm/gfx-drm: switch to using the same gcc version as illumos-omnios (gcc7)

### DIFF
--- a/build/gfx-drm/build.sh
+++ b/build/gfx-drm/build.sh
@@ -35,6 +35,8 @@ BUILDARCH=64
 : ${GFX_DRM_SOURCE_REPO:=$GITHUB/gfx-drm}
 : ${GFX_DRM_SOURCE_BRANCH:=r$RELVER}
 
+set_gccver $ILLUMOS_GCC_VER
+
 init
 WORKDIR=$TMPDIR/$BUILDDIR/$PROG
 DESTDIR=$WORKDIR/proto/root_i386
@@ -66,7 +68,7 @@ pre_build() {
 			export PKGPUBLISHER=$PKGPUBLISHER
 			export SUPPRESSPKGDEP=true
 			export PKGVERS_BRANCH=$PVER
-			export GNUC_ROOT=/opt/gcc-4.4.4
+			export GNUC_ROOT=$GCCPATH
 		EOM
     ) > env-d.sh
     sed < env-d.sh > env.sh '

--- a/build/illumos-kvm/build.sh
+++ b/build/illumos-kvm/build.sh
@@ -45,7 +45,7 @@ BUILD_DEPENDS_IPS="
 "
 SKIP_LICENCES='qemu.license'
 
-set_gccver 4.4.4
+set_gccver $ILLUMOS_GCC_VER
 set_arch 64
 
 # Unset the prefix because we actually DO want things in kernel etc
@@ -84,8 +84,8 @@ make_prog() {
     logcmd $MAKE \
         KERNEL_SOURCE=$KERNEL_SOURCE \
         PROTO_AREA=$PROTO_AREA \
-        CC=/opt/gcc-4.4.4/bin/gcc \
-        PRIMARY_COMPILER_VER=4 \
+        CC=$GCC \
+        PRIMARY_COMPILER_VER=$GCCVER \
         || logerr "--- Make failed"
     logcmd cp $KERNEL_SOURCE/usr/src/OPENSOLARIS.LICENSE \
         $SRCDIR/OPENSOLARIS.LICENSE \

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -221,6 +221,7 @@ CXX=g++
 
 # Specify default versions for building packages
 DEFAULT_GCC_VER=8
+ILLUMOS_GCC_VER=7
 PYTHON2VER=2.7
 PYTHON3VER=3.5
 DEFAULT_PYTHON_VER=$PYTHON3VER


### PR DESCRIPTION
gfx-drm: switch to using the same gcc version as illumos-omnios (gcc7)
