### PR TITLE
Add beta bhyve firmware

### DIFF
--- a/build/bhyve-fw/build.sh
+++ b/build/bhyve-fw/build.sh
@@ -12,7 +12,7 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/functions.sh
 
@@ -23,145 +23,171 @@ BUILD_DEPENDS_IPS="
 
 PROG=uefi-edk2
 PKG=system/bhyve/firmware
-VER=20180309
-VERHUMAN=$VER
+VER=20190904
 SUMMARY="UEFI-EDK2(+CSM) firmware for bhyve"
 DESC="$SUMMARY"
 
 # Respect environmental overrides for these to ease development.
 : ${EDK2_SOURCE_REPO:=$GITHUB/$PROG}
 : ${EDK2_SOURCE_BRANCH:=master}
+: ${EDK2_BETA_BRANCH:=edk2-stable201903}
 
-# Extend VER so that the temporary build directory is branch specific.
-# Branch names can include '/' so remove them.
-VER+="-${EDK2_SOURCE_BRANCH//\//_}"
+setup_env() {
 
-set_gccver 4.4.4
+    case $1 in
+        $EDK2_SOURCE_BRANCH)
+            UPKGPREFIX=Bhyve
+            set_gccver 4.4.4
+            unset PYTHON3_ENABLE
+            PKGSUFFIX=
+            EXTRA_BUILD_ARGS=
+            ;;
+        $EDK2_BETA_BRANCH)
+            UPKGPREFIX=Ovmf
+            set_gccver $DEFAULT_GCC_VER
+            export PYTHON3_ENABLE=TRUE
+            PKGSUFFIX=-beta
+            EXTRA_BUILD_ARGS="-DHTTP_BOOT_ENABLE=TRUE"
+            ;;
+    esac
 
-MAKE_ARGS="
-        AS=/usr/bin/gas
-        AR=/usr/bin/gar
-        LD=/usr/bin/gld
-        OBJCOPY=/usr/bin/gobjcopy
-        CC=${GCCPATH}/bin/gcc
-        CXX=${GCCPATH}/bin/g++
-"
+    MAKE_ARGS="
+            AS=/usr/bin/gas
+            AR=/usr/bin/gar
+            LD=/usr/bin/gld
+            OBJCOPY=/usr/bin/gobjcopy
+            CC=$GCC BUILD_CC=$GCC
+            CXX=$GXX BUILD_CXX=$GXX
+    "
 
-export OOGCC_BIN=$GCCPATH/bin/
+    export OOGCC_BIN=$GCCPATH/bin/
+}
+
 export IASL_PREFIX=/usr/sbin/
 export NASM_PREFIX=/usr/bin/
 
-clone_source() {
-    clone_github_source $PROG \
-        "$EDK2_SOURCE_REPO" "$EDK2_SOURCE_BRANCH" "$EDK2_CLONE"
-}
-
 edksetup() {
-    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null || logerr "--- chdir failed"
     source edksetup.sh
-    popd > /dev/null
 }
 
 cleanup() {
     logmsg "-- Cleaning source tree"
 
-    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null || logerr "--- chdir failed"
-
-    logcmd gmake $MAKE_ARGS ARCH=X64 -C BaseTools clean
+    logcmd gmake $MAKE_ARGS HOST_ARCH=X64 ARCH=X64 -C BaseTools clean
     rm -rf Build Conf/{target,build_rule,tools_def}.txt Conf/.cache 2>/dev/null
-
-    popd > /dev/null
 }
 
 build_tools() {
     logmsg "-- Building tools"
 
-    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null || logerr "--- chdir failed"
-
     # The code isn't able to detect the build architecture - it doesn't
     # expect `uname -m` to return `i86pc`
-    logcmd gmake $MAKE_ARGS ARCH=X64 -C BaseTools \
+    logcmd gmake $MAKE_ARGS HOST_ARCH=X64 ARCH=X64 -C BaseTools \
         || logerr "--- BaseTools build failed"
-
-    popd > /dev/null
 }
 
 build() {
-    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null || logerr "--- chdir failed"
-
     [ "$1" = "-csm" ] && csm=1 || csm=0
 
     BUILD_ARGS="-DDEBUG_ON_SERIAL_PORT=TRUE -DFD_SIZE_2MB"
     [ $csm -eq 1 ] && BUILD_ARGS+=" -DCSM_ENABLE=TRUE"
+    BUILD_ARGS+=" $EXTRA_BUILD_ARGS"
+
     export BUILD_ARGS
 
     for mode in RELEASE DEBUG; do
-        [[ "$FLAVOR" = *DEBUG* && $mode = RELEASE ]] && continue
-        [[ "$FLAVOR" = *RELEASE* && $mode = DEBUG ]] && continue
+
         logmsg "-- Building $mode firmware"
 
         case $mode in
             RELEASE)    dport=0x2f8; level=CRIT ;;
             DEBUG)      dport=0x3f8; level=INFO ;;
         esac
+
+        dir=${UPKGPREFIX}Pkg
+        dec=$dir/${UPKGPREFIX}Pkg.dec
+        dsc=$dir/${UPKGPREFIX}PkgX64.dsc
+
         logcmd sed -i "/PcdDebugIoPort|0x[0-9A-Fa-f]/s/0x[0-9A-Fa-f]*/$dport/" \
-            BhyvePkg/BhyvePkg.dec || logerr "sed BhyvePkg.dec"
+            $dec || logerr "sed $dec"
         logcmd sed -i "/DEBUG_PORT=0x/s/0x.*/$dport/" \
-            BhyvePkg/Csm/BhyveCsm16/GNUmakefile || logerr "sed GNUmakefile"
+            $dir/Csm/BhyveCsm16/GNUmakefile || logerr "sed GNUmakefile"
         logcmd sed -i "/DebugLevel = DBG/s/DBG_.*/DBG_$level;/" \
-            BhyvePkg/Csm/BhyveCsm16/Printf.c || logerr "sed Printf.c"
+            $dir/Csm/BhyveCsm16/Printf.c || logerr "sed Printf.c"
 
         if [ $csm -eq 1 ]; then
             logmsg "-- Building compatibility support module (CSM)"
-            logcmd gmake $MAKE_ARGS -C BhyvePkg/Csm/BhyveCsm16/ clean all \
+            logcmd gmake $MAKE_ARGS -C $dir/Csm/BhyveCsm16/ clean all \
                 || logerr "--- CSM build failed"
         fi
 
         logcmd `which build` \
             -t OOGCC -a X64 -b $mode \
-            -p BhyvePkg/BhyvePkgX64.dsc \
+            -p $dsc \
             $BUILD_ARGS || logerr "--- $mode build failed"
     done
-
-    popd > /dev/null
 }
 
 install() {
     suffix="$1"
-    pushd $TMPDIR/$BUILDDIR/$PROG > /dev/null || logerr "--- chdir failed"
     logcmd mkdir -p $DESTDIR/usr/share/bhyve/firmware
     [ -f $DESTDIR/LICENCE ] || cp OvmfPkg/License.txt $DESTDIR/LICENCE
     for mode in RELEASE DEBUG; do
-        logcmd cp Build/BhyveX64/${mode}_OOGCC/FV/BHYVE.fd \
-            $DESTDIR/usr/share/bhyve/firmware/BHYVE_$mode$suffix.fd
+        logcmd cp Build/${UPKGPREFIX}X64/${mode}_OOGCC/FV/${UPKGPREFIX^^}.fd \
+            $DESTDIR/usr/share/bhyve/firmware/BHYVE_$mode$suffix$PKGSUFFIX.fd \
+            || logerr "firmware copy failed"
     done
-    popd > /dev/null
 }
+
+######################################################################
+# The default release branch
 
 init
 prep_build
-clone_source
 
-cleanup
-build_tools
-edksetup
+for branch in $EDK2_SOURCE_BRANCH $EDK2_BETA_BRANCH; do
 
-if [[ -z "$FLAVOR" || "$FLAVOR" = *UEFI* ]]; then
-    # Build UEFI firmware
-    note "UEFI Firmware"
-    build
-    install
-fi
+    [ -n "$DEPVER" -a "$DEPVER" != $branch ] && continue
 
-if [[ -z "$FLAVOR" || "$FLAVOR" = *CSM* ]]; then
-    # Build UEFI+CSM firmware
-    note "UEFI+CSM Firmware"
-    build -csm
-    install _CSM
-fi
+    # branch names can contain '/', create a copy with these replaced
+    # that can be used for directory/file names.
+    sbranch="${branch//\//_}"
 
-# Reset version for package creation
-VER=$VERHUMAN
+    note -n "-- Building firmware from $branch branch"
+
+    clone_github_source $sbranch/ "$EDK2_SOURCE_REPO" "$branch" "$EDK2_CLONE"
+
+    (
+        setup_env $branch
+
+        pushd "$TMPDIR/$BUILDDIR/$sbranch" >/dev/null || logerr "Cannot pushd"
+
+        logmsg "-- Updating git submodules"
+        logcmd git submodule update --init --progress .
+
+        cleanup
+
+        build_tools
+        edksetup
+
+        if [[ -z "$FLAVOR" || "$FLAVOR" = *UEFI* ]]; then
+            # Build UEFI firmware
+            note -n "UEFI Firmware"
+            build
+            install
+        fi
+
+        if [[ -z "$FLAVOR" || "$FLAVOR" = *CSM* ]]; then
+            # Build UEFI+CSM firmware
+            note -n "UEFI+CSM Firmware"
+            build -csm
+            install _CSM
+        fi
+
+        popd >/dev/null
+    )
+done
+
 make_package
 clean_up
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -369,8 +369,8 @@ set_gccver() {
     [ -x "$GCC" ] || logerr "Unknown compiler version $GCCVER"
     PATH="$GCCPATH/bin:$BASEPATH"
     for cmd in gcc g++; do
-        [ -h $TMPDIR/tools/$cmd ] && rm -f $TMPDIR/tools/$cmd
-        ln -sf $GCCPATH/bin/$cmd $TMPDIR/tools/$cmd || logerr "$cmd link"
+        [ -h $BASE_TMPDIR/tools/$cmd ] && rm -f $TMPDIR/tools/$cmd
+        ln -sf $GCCPATH/bin/$cmd $BASE_TMPDIR/tools/$cmd || logerr "$cmd link"
     done
     if [ -n "$USE_CCACHE" ]; then
         [ -x $CCACHE_PATH/ccache ] || logerr "Ccache is not installed"


### PR DESCRIPTION
This adds the new 2019 firmware images as part of the bhyve/firmware package but tagged as beta until more testing is performed.

```
% pkg contents -g ../_repo system/bhyve/firmware
PATH
usr/share/bhyve
usr/share/bhyve/firmware
usr/share/bhyve/firmware/BHYVE.fd
usr/share/bhyve/firmware/BHYVE_CSM.fd
usr/share/bhyve/firmware/BHYVE_DEBUG-beta.fd
usr/share/bhyve/firmware/BHYVE_DEBUG.fd
usr/share/bhyve/firmware/BHYVE_DEBUG_CSM-beta.fd
usr/share/bhyve/firmware/BHYVE_DEBUG_CSM.fd
usr/share/bhyve/firmware/BHYVE_RELEASE-beta.fd
usr/share/bhyve/firmware/BHYVE_RELEASE.fd
usr/share/bhyve/firmware/BHYVE_RELEASE_CSM-beta.fd
usr/share/bhyve/firmware/BHYVE_RELEASE_CSM.fd
```