### PR TITLE
Also ship rxvt-unicode terminfo for libcurses (r151030)

### DIFF
--- a/build/urxvt/build.sh
+++ b/build/urxvt/build.sh
@@ -28,10 +28,16 @@ DESC="$SUMMARY"
 
 build() {
     TERMINFO=${DESTDIR}/usr/gnu/share/terminfo
-    mkdir -p $TERMINFO
-    /usr/gnu/bin/tic -xo $TERMINFO \
+    logcmd mkdir -p $TERMINFO
+    logcmd /usr/gnu/bin/tic -xo $TERMINFO \
         $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
-        || logerr 'failed to install terminfo file'
+        || logerr 'failed to install terminfo file for ncurses'
+
+    # Also ship for the illumos libcurses
+    TERMINFO=${DESTDIR}/usr/share/lib/terminfo
+    logcmd mkdir -p $TERMINFO
+    TERMINFO=$TERMINFO /usr/bin/tic $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
+        2>/dev/null || logerr 'failed to install terminfo file for curses'
 }
 
 init


### PR DESCRIPTION
This is currently going through review to be added to illumos-gate for the system libcurses but that won't be backported to r151030. For this release, deliver both files from this package.