### PR TITLE
Do not enable inotify support in dbus

### DIFF
--- a/build/dbus/build.sh
+++ b/build/dbus/build.sh
@@ -40,6 +40,7 @@ CONFIGURE_OPTS="
     --with-x=no
     --with-dbus-user=root
     --disable-static
+    --disable-inotify
 "
 
 export MAKE


### PR DESCRIPTION
Otherwise the dbus and hal services fail if you `onu` from an OmniOS installation to illumos-gate.
Once @andy-js integrates the change to build 64-bit perl modules in gate, the onu-from-omnios experience should be much better.
