### PR TITLE
Also ship unicode-rxvt for curses

### DIFF
--- a/build/urxvt/build.sh
+++ b/build/urxvt/build.sh
@@ -31,7 +31,13 @@ build() {
     logcmd mkdir -p $TERMINFO
     logcmd /usr/gnu/bin/tic -xo $TERMINFO \
         $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
-        || logerr 'failed to install terminfo file'
+        || logerr 'failed to install terminfo file for ncurses'
+
+    # Also ship for the illumos libcurses
+    TERMINFO=${DESTDIR}/usr/share/lib/terminfo
+    logcmd mkdir -p $TERMINFO
+    TERMINFO=$TERMINFO /usr/bin/tic $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
+        2>/dev/null || logerr 'failed to install terminfo file for curses'
 }
 
 init


### PR DESCRIPTION
If `11669 terminfo could know aobut rxvt-unicode` ever lands, we will have to revert this but let's get it in ready for r151032.