### PR TITLE
No longer ship rxvt-unicode for illumos curses (r151030)

### DIFF
--- a/build/urxvt/build.sh
+++ b/build/urxvt/build.sh
@@ -32,12 +32,6 @@ build() {
     logcmd /usr/gnu/bin/tic -xo $TERMINFO \
         $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
         || logerr 'failed to install terminfo file for ncurses'
-
-    # Also ship for the illumos libcurses
-    TERMINFO=${DESTDIR}/usr/share/lib/terminfo
-    logcmd mkdir -p $TERMINFO
-    TERMINFO=$TERMINFO /usr/bin/tic $TMPDIR/$BUILDDIR/doc/etc/${PROG}.terminfo \
-        2>/dev/null || logerr 'failed to install terminfo file for curses'
 }
 
 init


### PR DESCRIPTION
No longer ship rxvt-unicode for illumos curses (r151030)
