### PR TITLE
Fix missing mediated link for /usr/bin/python -> python3

### DIFF
--- a/build/python35/local.mog
+++ b/build/python35/local.mog
@@ -47,7 +47,9 @@ link path=usr/lib/amd64/libpython3.so target=libpython$(PYTHONVER).so
 <transform link path=usr/(bin|share|lib/amd64) -> set mediator-priority vendor>
 
 # Add mediated link for /usr/bin/python
-<transform link path=usr/bin/python$ -> drop>
-link path=usr/bin/python target=python3 mediator=python mediator-version=3 \
-    mediator-priority=vendor
+link path=usr/bin/python target=python3
+<transform link path=usr/bin/python$ -> set mediator python>
+<transform link path=usr/bin/python$ -> set mediator-version 3>
+<transform link path=usr/bin/python$ -> set target python3>
+<transform link path=usr/bin/python$ -> delete mediator-priority vendor>
 

--- a/build/python37/local.mog
+++ b/build/python37/local.mog
@@ -44,7 +44,3 @@ link path=usr/lib/amd64/libpython3.so target=libpython$(PYTHONVER).so
 <transform link path=usr/(bin|share|lib/amd64) -> \
     set mediator-version $(PYTHONVER)>
 
-# Add mediated link for /usr/bin/python
-<transform link path=usr/bin/python$ -> drop>
-link path=usr/bin/python target=python3 mediator=python mediator-version=3
-


### PR DESCRIPTION
Problem reported by @ptribble

Fix confirmed in updated package:

```
r151032% pkg mediator -a python
MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
python   vendor    2       vendor

r151032% pfexec pkg update python-35

r151032% pkg mediator -a python
MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
python   vendor    2       vendor
python   system    3       system

r151032% readlink /usr/bin/python
python2
r151032% pfexec pkg set-mediator -V 3 python
r151032% readlink /usr/bin/python
python3
```