### PR TITLE
Fix missing mediated link for /usr/bin/python -> python3

### DIFF
--- a/build/python37/local.mog
+++ b/build/python37/local.mog
@@ -50,6 +50,9 @@ link path=usr/lib/amd64/libpython3.so target=libpython$(PYTHONVER).so
 <transform link mediator=python3 -> set mediator-priority vendor>
 
 # Add mediated link for /usr/bin/python
-<transform link path=usr/bin/python$ -> drop>
-link path=usr/bin/python target=python3 mediator=python mediator-version=3
+link path=usr/bin/python target=python3
+<transform link path=usr/bin/python$ -> set mediator python>
+<transform link path=usr/bin/python$ -> set mediator-version 3>
+<transform link path=usr/bin/python$ -> set target python3>
+<transform link path=usr/bin/python$ -> delete mediator-priority vendor>
 


### PR DESCRIPTION
See also #1646 