### PR TITLE
gcc compilers are not being built with optimisation

### DIFF
--- a/build/gcc44/build.sh
+++ b/build/gcc44/build.sh
@@ -44,10 +44,10 @@ set_arch 32
 # Although we're building a 32-bit version of the compiler, gcc will take
 # care of building 32 and 64-bit objects to support its toolchain. We need
 # to unset the build flags and leave it to the gcc build system.
-unset CFLAGS CFLAGS32 CFLAGS64
-unset CPPFLAGS CPPFLAGS32 CPPFLAGS64
-unset CXXFLAGS CXXFLAGS32 CXXFLAGS64
-unset LDFLAGS LDFLAGS32 LDFLAGS64
+unset CFLAGS32 CFLAGS64
+unset CPPFLAGS32 CPPFLAGS64
+unset CXXFLAGS32 CXXFLAGS64
+unset LDFLAGS32 LDFLAGS64
 
 XFORM_ARGS="-D TRIPLET=$TRIPLET32 -D VER=$VER -D PREFIX=${PREFIX#/}"
 
@@ -70,7 +70,6 @@ HARDLINK_TARGETS="
     ${PREFIX/#\/}/bin/$TRIPLET32-gcc-$VER
     ${PREFIX/#\/}/bin/$TRIPLET32-c++
     ${PREFIX/#\/}/bin/$TRIPLET32-g++
-    ${PREFIX/#\/}/bin/$TRIPLET32-gfortran
 "
 
 export LD=/bin/ld
@@ -86,7 +85,7 @@ CONFIGURE_OPTS="
     --with-gmp=/opt/gcc-${VER}
     --with-mpfr=/opt/gcc-${VER}
     --with-mpc=/opt/gcc-${VER}
-    --enable-languages=c,c++,fortran
+    --enable-languages=c,c++
     --without-gnu-ld --with-ld=/bin/ld
     --with-as=/usr/bin/gas --with-gnu-as
     --with-build-time-tools=/usr/gnu/$TRIPLET64/bin
@@ -111,9 +110,10 @@ build
 # For some reason, this gcc44 package doesn't properly push the LDFLAGS shown
 # above into various subdirectories.  Use elfedit to fix it.
 ESTRING="dyn:runpath /opt/gcc-${VER}/lib:%o"
-elfedit -e "${ESTRING}" ${TMPDIR}/${BUILDDIR}/host-${TRIPLET32}/gcc/cc1
-elfedit -e "${ESTRING}" ${TMPDIR}/${BUILDDIR}/host-${TRIPLET32}/gcc/cc1plus
-elfedit -e "${ESTRING}" ${TMPDIR}/${BUILDDIR}/host-${TRIPLET32}/gcc/f951
+logcmd elfedit -e "$ESTRING" $TMPDIR/$BUILDDIR/host-$TRIPLET32/gcc/cc1 \
+    || logerr "elfedit cc1 failed"
+logcmd elfedit -e "$ESTRING" $TMPDIR/$BUILDDIR/host-$TRIPLET32/gcc/cc1plus \
+    || logerr "elfedit cc1plus failed"
 
 make_package gcc.mog depends.mog
 clean_up

--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -36,10 +36,10 @@ set_arch 32
 # Although we're building a 32-bit version of the compiler, gcc will take
 # care of building 32 and 64-bit objects to support its toolchain. We need
 # to unset the build flags and leave it to the gcc build system.
-unset CFLAGS CFLAGS32 CFLAGS64
-unset CPPFLAGS CPPFLAGS32 CPPFLAGS64
-unset CXXFLAGS CXXFLAGS32 CXXFLAGS64
-unset LDFLAGS LDFLAGS32 LDFLAGS64
+unset CFLAGS32 CFLAGS64
+unset CPPFLAGS32 CPPFLAGS64
+unset CXXFLAGS32 CXXFLAGS64
+unset LDFLAGS32 LDFLAGS64
 
 RUN_DEPENDS_IPS="
     developer/linker

--- a/build/gcc8/build.sh
+++ b/build/gcc8/build.sh
@@ -36,10 +36,10 @@ set_arch 32
 # Although we're building a 32-bit version of the compiler, gcc will take
 # care of building 32 and 64-bit objects to support its toolchain. We need
 # to unset the build flags and leave it to the gcc build system.
-unset CFLAGS CFLAGS32 CFLAGS64
-unset CPPFLAGS CPPFLAGS32 CPPFLAGS64
-unset CXXFLAGS CXXFLAGS32 CXXFLAGS64
-unset LDFLAGS LDFLAGS32 LDFLAGS64
+unset CFLAGS32 CFLAGS64
+unset CPPFLAGS32 CPPFLAGS64
+unset CXXFLAGS32 CXXFLAGS64
+unset LDFLAGS32 LDFLAGS64
 
 RUN_DEPENDS_IPS="
     developer/linker

--- a/build/gcc9/build.sh
+++ b/build/gcc9/build.sh
@@ -43,10 +43,10 @@ ARCH=$TRIPLET64
 # to unset all of the flags that we usually pass for a 64-bit object so that
 # gcc can properly create the multilib targets.
 CONFIGURE_OPTS_64="$CONFIGURE_OPTS_32"
-unset CFLAGS CFLAGS32 CFLAGS64
-unset CPPFLAGS CPPFLAGS32 CPPFLAGS64
-unset CXXFLAGS CXXFLAGS32 CXXFLAGS64
-unset LDFLAGS LDFLAGS32 LDFLAGS64
+unset CFLAGS32 CFLAGS64
+unset CPPFLAGS32 CPPFLAGS64
+unset CXXFLAGS32 CXXFLAGS64
+unset LDFLAGS32 LDFLAGS64
 
 # Use bash for all shells - some corruption occurs in libstdc++-v3/config.status
 # otherwise.


### PR DESCRIPTION
This problem was introduced during the recent work to move userland up to
gcc 9 which produces 64-bit binaries by default. As part of that, an explicit
"-m32" was added to the 32-bit CFLAGS and other environment variables since
the old configuration where this was just omitted for the 32-bit case now
resulted in 64-bit binaries being created.

gcc is built in a single configure/make pass and it generates both 32 and
64-bit components along the way. To make this work properly we need to
make sure that none of -m32 or -m64 are passed into environment variables
used by configure.

Unsetting CFLAGS had the unforseen effect of causing the compilers to be
build without optimisation, resulting in a significant performance penalty
when compiling code. For example, the illumos-omnios build time doubled
for several developers.