### PR TITLE
Now that GNU binutils targets 64-bit by default, gcc needs to explicitly pass --32 to the assembler.

### DIFF
--- a/build/gcc44/patches/64bit.patch
+++ b/build/gcc44/patches/64bit.patch
@@ -1,0 +1,16 @@
+
+Now that GNU binutils targets 64-bit by default, gcc needs to explicitly
+pass --32 to the assembler.
+
+diff -ru gcc-gcc-4.4.4-il-4/gcc/config/i386/sol2-10.h gcc-gcc-4.4.4-il-4~/gcc/config/i386/sol2-10.h
+--- gcc-gcc-4.4.4-il-4/gcc/config/i386/sol2-10.h	2016-12-01 22:55:44.000000000 +0000
++++ gcc-gcc-4.4.4-il-4~/gcc/config/i386/sol2-10.h	2019-11-24 21:12:55.571811346 +0000
+@@ -26,7 +26,7 @@
+ #undef ASM_SPEC
+ #ifdef USE_GAS
+ #define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} " \
+-		 "%{Wa,*:%*} %{m32:--32} %{m64:--64} -s %(asm_cpu)"
++		 "%{Wa,*:%*} %{!m64:--32} %{m64:--64} -s %(asm_cpu)"
+ #else
+ #define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} " \
+ 		 "%{Wa,*:%*} %{m32:-xarch=generic} %{m64:-xarch=generic64} " \

--- a/build/gcc44/patches/series
+++ b/build/gcc44/patches/series
@@ -1,0 +1,1 @@
+64bit.patch


### PR DESCRIPTION
Now that GNU binutils targets 64-bit by default, gcc needs to explicitly pass --32 to the assembler.
