### PR TITLE
open-vm-tools wrongly looks for plugins in amd64/ subdirectory

### DIFF
--- a/build/open-vm-tools/patches/gnu-ld.patch
+++ b/build/open-vm-tools/patches/gnu-ld.patch
@@ -8,7 +8,7 @@ This has been submitted upstream at:
 diff -wpruN '--exclude=*.orig' a~/configure.ac a/configure.ac
 --- a~/configure.ac	1970-01-01 00:00:00
 +++ a/configure.ac	1970-01-01 00:00:00
-@@ -1523,7 +1523,11 @@ VMTOOLS_LIBS="$BUILDDIR/libvmtools/libvm
+@@ -1459,7 +1459,11 @@ VMTOOLS_LIBS="$BUILDDIR/libvmtools/libvm
  VMTOOLS_CPPFLAGS="-DVMTOOLS_USE_GLIB $GLIB2_CPPFLAGS"
  
  PLUGIN_CPPFLAGS="$VMTOOLS_CPPFLAGS $PLUGIN_CPPFLAGS"

--- a/build/open-vm-tools/patches/nicInfo.patch
+++ b/build/open-vm-tools/patches/nicInfo.patch
@@ -31,7 +31,7 @@ diff -wpruN '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/lib/nicInfo/nicIn
  static unsigned
  CountNetmaskBitsV6(struct sockaddr *netmask)
  {
-@@ -409,7 +406,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
+@@ -442,7 +439,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
     }
  
     return TRUE;
@@ -40,7 +40,7 @@ diff -wpruN '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/lib/nicInfo/nicIn
     struct ifaddrs *ifaddrs = NULL;
  
     if (getifaddrs(&ifaddrs) == 0 && ifaddrs != NULL) {
-@@ -458,6 +455,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
+@@ -491,6 +488,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
   */
  #if defined(__FreeBSD__) || \
      defined(__APPLE__) || \

--- a/build/open-vm-tools/patches/plugindir.patch
+++ b/build/open-vm-tools/patches/plugindir.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' a~/services/vmtoolsd/pluginMgr.c a/services/vmtoolsd/pluginMgr.c
+--- a~/services/vmtoolsd/pluginMgr.c	1970-01-01 00:00:00
++++ a/services/vmtoolsd/pluginMgr.c	1970-01-01 00:00:00
+@@ -638,7 +638,7 @@ ToolsCore_LoadPlugins(ToolsServiceState
+    guint i;
+    GPtrArray *plugins = NULL;
+ 
+-#if defined(sun) && defined(__x86_64__)
++#if 0 && defined(sun) && defined(__x86_64__)
+    const char *subdir = "/amd64";
+ #else
+    const char *subdir = "";

--- a/build/open-vm-tools/patches/series
+++ b/build/open-vm-tools/patches/series
@@ -2,3 +2,4 @@ ucontext.patch
 lock.patch
 nicInfo.patch
 gnu-ld.patch
+plugindir.patch


### PR DESCRIPTION
Fixes #1674 