### PR TITLE
gcc7: update to 7.5.0

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -19,7 +19,7 @@
 
 PKG=developer/gcc7
 PROG=gcc
-VER=7.4.0
+VER=7.5.0
 ILVER=il-1
 SUMMARY="gcc $VER-$ILVER"
 DESC="The GNU Compiler Collection"

--- a/build/gcc7/patches/0002-compare_tests-Use-nawk-1-on-illumos-since-awk-1-is-o.patch
+++ b/build/gcc7/patches/0002-compare_tests-Use-nawk-1-on-illumos-since-awk-1-is-o.patch
@@ -1,4 +1,4 @@
-From 57fce965e365852eef4032a9dad2f65556f65c21 Mon Sep 17 00:00:00 2001
+From 90abf04317e49d6441830f35d625e83660f964d8 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 26 Jan 2016 14:24:11 -0500
 Subject: compare_tests: Use nawk(1) on illumos, since awk(1) is
@@ -31,5 +31,5 @@ index d16e7e9737e..94183568fac 100755
  before=$tmp1
  now=$tmp2
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
+++ b/build/gcc7/patches/0003-gcc-enable-the-.eh_frame-based-unwinder.patch
@@ -1,4 +1,4 @@
-From 156f9a9b424f17037105c9c3734af868b81a66f5 Mon Sep 17 00:00:00 2001
+From a24c8131fdad104ce14650130e1577c131d9c5ff Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 5 Mar 2014 04:12:52 +0000
 Subject: gcc: enable the .eh_frame based unwinder
@@ -51,5 +51,5 @@ index e1fa8af5e4f..43a5740401f 100644
          ;;
      esac
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
+++ b/build/gcc7/patches/0004-intl-Don-t-use-UTF-8-quotes.-Ever.patch
@@ -1,4 +1,4 @@
-From 6d45b594bda49c59307efc5f637dd58f4c59034e Mon Sep 17 00:00:00 2001
+From 9a4f2ab39a675bc27cb28a69ca508736aaee0277 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 11 Mar 2014 21:50:30 +0000
 Subject: intl: Don't use UTF-8 quotes.  Ever.
@@ -41,5 +41,5 @@ index c9090e06dd3..b7688848fd8 100644
 -
 -
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
+++ b/build/gcc7/patches/0005-Implement-fstrict-calling-conventions.patch
@@ -1,4 +1,4 @@
-From 277612fffed37818c3c91711dfea07ed92e088dc Mon Sep 17 00:00:00 2001
+From 5a10acedaedff0a604cc7da0ea4ccbd0d94bb600 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sat, 27 Oct 2012 02:44:09 +0100
 Subject: Implement -fstrict-calling-conventions
@@ -36,10 +36,10 @@ index 437db8e8615..978fbc83b89 100644
  Common Report Var(flag_strict_overflow) Optimization
  Treat signed overflow as undefined.
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index e74f37f1ca0..c6fbe17a556 100644
+index de71f56be6b..62254bc0864 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
-@@ -8015,6 +8015,7 @@ ix86_function_regparm (const_tree type, const_tree decl)
+@@ -8021,6 +8021,7 @@ ix86_function_regparm (const_tree type, const_tree decl)
  	 and callee not, or vice versa.  Instead look at whether the callee
  	 is optimized or not.  */
        if (target && opt_for_fn (target->decl, optimize)
@@ -47,7 +47,7 @@ index e74f37f1ca0..c6fbe17a556 100644
  	  && !(profile_flag && !flag_fentry))
  	{
  	  cgraph_local_info *i = &target->local;
-@@ -8112,6 +8113,7 @@ ix86_function_sseregparm (const_tree type, const_tree decl, bool warn)
+@@ -8118,6 +8119,7 @@ ix86_function_sseregparm (const_tree type, const_tree decl, bool warn)
        /* TARGET_SSE_MATH */
        && (target_opts_for_fn (target->decl)->x_ix86_fpmath & FPMATH_SSE)
        && opt_for_fn (target->decl, optimize)
@@ -56,10 +56,10 @@ index e74f37f1ca0..c6fbe17a556 100644
      {
        cgraph_local_info *i = &target->local;
 diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
-index 5f4fbf91c5b..c48d4e16323 100644
+index 8f279e454b0..c02a999d95f 100644
 --- a/gcc/doc/invoke.texi
 +++ b/gcc/doc/invoke.texi
-@@ -8642,6 +8642,12 @@ int f() @{
+@@ -8645,6 +8645,12 @@ int f() @{
  The @option{-fstrict-aliasing} option is enabled at levels
  @option{-O2}, @option{-O3}, @option{-Os}.
  
@@ -115,5 +115,5 @@ index 00000000000..fa0543e52ff
 +    printf("%d\n", a, b, c, d, e);
 +}
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
+++ b/build/gcc7/patches/0006-allow-the-global-disabling-of-function-cloning.patch
@@ -1,4 +1,4 @@
-From b209a752a5851b222a091eb40b3023087d1eaead Mon Sep 17 00:00:00 2001
+From fa6ce31139de48012fbba30e0b1dfd3cfb5d192a Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sun, 30 Sep 2012 16:44:14 -0400
 Subject: allow the global disabling of function cloning
@@ -54,7 +54,7 @@ index 978fbc83b89..e38dc343afd 100644
  Common Report Var(flag_combine_stack_adjustments) Optimization
  Looks for opportunities to reduce stack adjustments and stack references.
 diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
-index c48d4e16323..e17db23f790 100644
+index c02a999d95f..87545a2d244 100644
 --- a/gcc/doc/invoke.texi
 +++ b/gcc/doc/invoke.texi
 @@ -359,7 +359,7 @@ Objective-C and Objective-C++ Dialects}.
@@ -66,7 +66,7 @@ index c48d4e16323..e17db23f790 100644
  -fcompare-elim  -fcprop-registers  -fcrossjumping @gol
  -fcse-follow-jumps  -fcse-skip-blocks  -fcx-fortran-rules @gol
  -fcx-limited-range @gol
-@@ -7980,6 +7980,15 @@ and then tries to find ways to combine them.
+@@ -7983,6 +7983,15 @@ and then tries to find ways to combine them.
  
  Enabled by default at @option{-O1} and higher.
  
@@ -83,5 +83,5 @@ index c48d4e16323..e17db23f790 100644
  @opindex fipa-ra
  Use caller save registers for allocation if those registers are not used by
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
+++ b/build/gcc7/patches/0007-strict-cc2-check-that-disabling-function-cloning-pre.patch
@@ -1,4 +1,4 @@
-From d72ebb049040e4f85dad32ebdc359057ea93e937 Mon Sep 17 00:00:00 2001
+From ce4fc7ab0cf006a7c6c06c998d42e77fe5677032 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 02:58:33 +0000
 Subject: strict-cc2: check that disabling function cloning
@@ -44,5 +44,5 @@ index 00000000000..0955381c848
 +    printf("%d %d\n", a, b, c);
 +}
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
+++ b/build/gcc7/patches/0008-sol2-enable-full-__cxa_atexit-support.patch
@@ -1,4 +1,4 @@
-From bb49ed7b975514aa7bd36c9fcd3ff9405b096be1 Mon Sep 17 00:00:00 2001
+From 352223ca897efff743349d84ceedf269e47e048b Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Tue, 4 Mar 2014 22:11:03 +0000
 Subject: sol2: enable full __cxa_atexit support
@@ -31,7 +31,7 @@ index d522de03f4a..e2f7d2429a9 100644
  
  #undef  ENDFILE_SPEC
 diff --git a/libgcc/config.host b/libgcc/config.host
-index 8beb492b5fa..0238efb9a62 100644
+index b8e23766695..dd2b976a997 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -270,7 +270,7 @@ case ${host} in
@@ -52,5 +52,5 @@ index 8beb492b5fa..0238efb9a62 100644
        sparc*-*-solaris2.1[0-9]*)
          # Solaris 10+/SPARC lacks crt1.o and gcrt1.o.
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0009-sol2-Use-appropriate-values-objects-for-the-various-.patch
+++ b/build/gcc7/patches/0009-sol2-Use-appropriate-values-objects-for-the-various-.patch
@@ -1,4 +1,4 @@
-From 516b8fa161f908cb95cb880d17930408a205298e Mon Sep 17 00:00:00 2001
+From 8e2b0191c8831e70f8f2d149ab36bf21b20ce1eb Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 27 Jan 2016 16:49:07 -0500
 Subject: sol2: Use appropriate values objects for the various C
@@ -44,5 +44,5 @@ index e2f7d2429a9..f3e6140d9a0 100644
  #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
  #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
+++ b/build/gcc7/patches/0010-i386-Save-integer-passed-arguments-to-the-stack-to-a.patch
@@ -1,4 +1,4 @@
-From f26c31259095fccfadf060a829e31cdb6e613620 Mon Sep 17 00:00:00 2001
+From b0b14a68e8ee2a53a5e666a6f3924fae57c16466 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Sat, 23 Jan 2016 22:14:56 -0500
 Subject: i386: Save integer-passed arguments to the stack, to
@@ -43,7 +43,7 @@ Originally implemented in:
  create mode 100644 gcc/testsuite/gcc.target/i386/msave-args-push.c
 
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index c6fbe17a556..5f7337a1468 100644
+index 62254bc0864..e729d61c24c 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
 @@ -2572,6 +2572,8 @@ static unsigned int ix86_minimum_incoming_stack_boundary (bool);
@@ -65,7 +65,7 @@ index c6fbe17a556..5f7337a1468 100644
    /* Validate -mpreferred-stack-boundary= value or default it to
       PREFERRED_STACK_BOUNDARY_DEFAULT.  */
    ix86_preferred_stack_boundary = PREFERRED_STACK_BOUNDARY_DEFAULT;
-@@ -11979,7 +11984,7 @@ ix86_can_use_return_insn_p (void)
+@@ -11985,7 +11990,7 @@ ix86_can_use_return_insn_p (void)
    ix86_compute_frame_layout ();
    struct ix86_frame &frame = cfun->machine->frame;
    return (frame.stack_pointer_offset == UNITS_PER_WORD
@@ -74,7 +74,7 @@ index c6fbe17a556..5f7337a1468 100644
  }
  
  /* Value should be nonzero if functions must have frame pointers.
-@@ -12003,6 +12008,9 @@ ix86_frame_pointer_required (void)
+@@ -12009,6 +12014,9 @@ ix86_frame_pointer_required (void)
    if (TARGET_32BIT_MS_ABI && cfun->calls_setjmp)
      return true;
  
@@ -84,7 +84,7 @@ index c6fbe17a556..5f7337a1468 100644
    /* Win64 SEH, very large frames need a frame-pointer as maximum stack
       allocation is 4GB.  */
    if (TARGET_64BIT_MS_ABI && get_frame_size () > SEH_MAX_FRAME_SIZE)
-@@ -12786,6 +12794,7 @@ ix86_compute_frame_layout (void)
+@@ -12792,6 +12800,7 @@ ix86_compute_frame_layout (void)
  
    frame->nregs = ix86_nsaved_regs ();
    frame->nsseregs = ix86_nsaved_sseregs ();
@@ -92,7 +92,7 @@ index c6fbe17a556..5f7337a1468 100644
  
    /* 64-bit MS ABI seem to require stack alignment to be always 16,
       except for function prologues, leaf functions and when the defult
-@@ -12848,7 +12857,8 @@ ix86_compute_frame_layout (void)
+@@ -12860,7 +12869,8 @@ ix86_compute_frame_layout (void)
      }
  
    frame->save_regs_using_mov
@@ -102,7 +102,7 @@ index c6fbe17a556..5f7337a1468 100644
         /* If static stack checking is enabled and done with probes,
  	  the registers need to be saved before allocating the frame.  */
         && flag_stack_check != STATIC_BUILTIN_STACK_CHECK);
-@@ -12868,6 +12878,13 @@ ix86_compute_frame_layout (void)
+@@ -12880,6 +12890,13 @@ ix86_compute_frame_layout (void)
    /* The traditional frame pointer location is at the top of the frame.  */
    frame->hard_frame_pointer_offset = offset;
  
@@ -116,7 +116,7 @@ index c6fbe17a556..5f7337a1468 100644
    /* Register save area */
    offset += frame->nregs * UNITS_PER_WORD;
    frame->reg_save_offset = offset;
-@@ -12950,7 +12967,7 @@ ix86_compute_frame_layout (void)
+@@ -12962,7 +12979,7 @@ ix86_compute_frame_layout (void)
    /* Size prologue needs to allocate.  */
    to_allocate = offset - frame->sse_reg_save_offset;
  
@@ -125,7 +125,7 @@ index c6fbe17a556..5f7337a1468 100644
        || (TARGET_64BIT && to_allocate >= HOST_WIDE_INT_C (0x80000000)))
      frame->save_regs_using_mov = false;
  
-@@ -12962,7 +12979,11 @@ ix86_compute_frame_layout (void)
+@@ -12974,7 +12991,11 @@ ix86_compute_frame_layout (void)
      {
        frame->red_zone_size = to_allocate;
        if (frame->save_regs_using_mov)
@@ -138,7 +138,7 @@ index c6fbe17a556..5f7337a1468 100644
        if (frame->red_zone_size > RED_ZONE_SIZE - RED_ZONE_RESERVE)
  	frame->red_zone_size = RED_ZONE_SIZE - RED_ZONE_RESERVE;
      }
-@@ -12993,6 +13014,25 @@ ix86_compute_frame_layout (void)
+@@ -13005,6 +13026,25 @@ ix86_compute_frame_layout (void)
  	  frame->hard_frame_pointer_offset = frame->stack_pointer_offset - 128;
  	}
      }
@@ -164,7 +164,7 @@ index c6fbe17a556..5f7337a1468 100644
  }
  
  /* This is semi-inlined memory_address_length, but simplified
-@@ -13101,6 +13141,24 @@ ix86_emit_save_regs (void)
+@@ -13113,6 +13153,24 @@ ix86_emit_save_regs (void)
    unsigned int regno;
    rtx_insn *insn;
  
@@ -189,7 +189,7 @@ index c6fbe17a556..5f7337a1468 100644
    for (regno = FIRST_PSEUDO_REGISTER - 1; regno-- > 0; )
      if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true))
        {
-@@ -13179,9 +13237,30 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
+@@ -13191,9 +13249,30 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
  /* Emit code to save registers using MOV insns.
     First register is stored at CFA - CFA_OFFSET.  */
  static void
@@ -221,7 +221,7 @@ index c6fbe17a556..5f7337a1468 100644
  
    for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
      if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true))
-@@ -14239,7 +14318,7 @@ ix86_expand_prologue (void)
+@@ -14251,7 +14330,7 @@ ix86_expand_prologue (void)
  	}
      }
  
@@ -230,7 +230,7 @@ index c6fbe17a556..5f7337a1468 100644
    sse_registers_saved = (frame.nsseregs == 0);
  
    if (frame_pointer_needed && !m->fs.fp_valid)
-@@ -14290,7 +14369,7 @@ ix86_expand_prologue (void)
+@@ -14302,7 +14381,7 @@ ix86_expand_prologue (void)
  	       && (! TARGET_STACK_PROBE
  		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
  	{
@@ -239,7 +239,7 @@ index c6fbe17a556..5f7337a1468 100644
  	  int_registers_saved = true;
  	}
      }
-@@ -14533,7 +14612,7 @@ ix86_expand_prologue (void)
+@@ -14548,7 +14627,7 @@ ix86_expand_prologue (void)
      }
  
    if (!int_registers_saved)
@@ -248,7 +248,7 @@ index c6fbe17a556..5f7337a1468 100644
    if (!sse_registers_saved)
      ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
  
-@@ -14566,6 +14645,7 @@ ix86_expand_prologue (void)
+@@ -14581,6 +14660,7 @@ ix86_expand_prologue (void)
       relative to the value of the stack pointer at the end of the function
       prologue, and moving instructions that access redzone area via frame
       pointer inside push sequence violates this assumption.  */
@@ -256,7 +256,7 @@ index c6fbe17a556..5f7337a1468 100644
    if (frame_pointer_needed && frame.red_zone_size)
      emit_insn (gen_memory_blockage ());
  
-@@ -14778,6 +14858,7 @@ ix86_expand_epilogue (int style)
+@@ -14793,6 +14873,7 @@ ix86_expand_epilogue (int style)
  
    /* See the comment about red zone and frame
       pointer usage in ix86_expand_prologue.  */
@@ -264,7 +264,7 @@ index c6fbe17a556..5f7337a1468 100644
    if (frame_pointer_needed && frame.red_zone_size)
      emit_insn (gen_memory_blockage ());
  
-@@ -14973,6 +15054,36 @@ ix86_expand_epilogue (int style)
+@@ -14988,6 +15069,36 @@ ix86_expand_epilogue (int style)
        ix86_emit_restore_regs_using_pop ();
      }
  
@@ -301,7 +301,7 @@ index c6fbe17a556..5f7337a1468 100644
    /* If we used a stack pointer and haven't already got rid of it,
       then do so now.  */
    if (m->fs.fp_valid)
-@@ -15984,6 +16095,19 @@ ix86_cannot_force_const_mem (machine_mode mode, rtx x)
+@@ -15999,6 +16110,19 @@ ix86_cannot_force_const_mem (machine_mode mode, rtx x)
    return !ix86_legitimate_constant_p (mode, x);
  }
  
@@ -322,7 +322,7 @@ index c6fbe17a556..5f7337a1468 100644
      otherwise zero.  */
  
 diff --git a/gcc/config/i386/i386.h b/gcc/config/i386/i386.h
-index 0fe4c8b2caa..eb126ff9947 100644
+index 8e31c30787d..a966dec9ab2 100644
 --- a/gcc/config/i386/i386.h
 +++ b/gcc/config/i386/i386.h
 @@ -2462,6 +2462,11 @@ enum avx_u128_state
@@ -375,10 +375,10 @@ index b90da9f89ec..d53f69c18be 100644
  Target RejectNegative Joined Var(ix86_tune_string)
  Schedule code for given CPU.
 diff --git a/gcc/doc/invoke.texi b/gcc/doc/invoke.texi
-index e17db23f790..22132ea9a0d 100644
+index 87545a2d244..c310103178f 100644
 --- a/gcc/doc/invoke.texi
 +++ b/gcc/doc/invoke.texi
-@@ -13893,6 +13893,10 @@ dynamically linked.  This is the default code model.
+@@ -13896,6 +13896,10 @@ dynamically linked.  This is the default code model.
  Generate code for the large code model.  This makes no assumptions about
  addresses and sizes of sections.  Programs can be statically linked only.
  
@@ -390,10 +390,10 @@ index e17db23f790..22132ea9a0d 100644
  @opindex mstrict-align
  Avoid generating memory accesses that may not be aligned on a natural object
 diff --git a/gcc/dwarf2out.c b/gcc/dwarf2out.c
-index 5223e3b2fb4..4f2bf11e9ec 100644
+index 5590845d2a4..ace76996fa0 100644
 --- a/gcc/dwarf2out.c
 +++ b/gcc/dwarf2out.c
-@@ -22441,6 +22441,11 @@ gen_subprogram_die (tree decl, dw_die_ref context_die)
+@@ -22449,6 +22449,11 @@ gen_subprogram_die (tree decl, dw_die_ref context_die)
      /* Add the calling convention attribute if requested.  */
      add_calling_convention_attribute (subr_die, decl);
  
@@ -483,5 +483,5 @@ index ea6194ef33e..28532c190de 100644
  DW_AT (DW_AT_upc_threads_scaled, 0x3210)
  /* PGI (STMicroelectronics) extensions.  */
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0011-16-update-cmn_err-format-specifier.patch
+++ b/build/gcc7/patches/0011-16-update-cmn_err-format-specifier.patch
@@ -1,4 +1,4 @@
-From 7decb085713a17b98dc07c6a3450ded6c8c80347 Mon Sep 17 00:00:00 2001
+From a471df2645c5005da8aa06119088dfba8a6410cb Mon Sep 17 00:00:00 2001
 From: Yuri Pankov <yuri.pankov@nexenta.com>
 Date: Sat, 5 Nov 2016 05:26:47 +0300
 Subject: 16 update cmn_err format specifier Reviewed by: Richard
@@ -63,5 +63,5 @@ index 5a44a88d1ac..ebd7449b368 100644
    }
  };
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
+++ b/build/gcc7/patches/0012-19-cmn_err-b-conversion-should-accept-0-flag.patch
@@ -1,4 +1,4 @@
-From 1232a7637e426e091bc506d362cfc4ff4acc2651 Mon Sep 17 00:00:00 2001
+From 208923df55b0440589736ff815962db09bd692bd Mon Sep 17 00:00:00 2001
 From: Yuri Pankov <yuri.pankov@nexenta.com>
 Date: Mon, 13 Feb 2017 18:14:45 +0300
 Subject: 19 cmn_err %b conversion should accept 0 flag Reviewed
@@ -23,5 +23,5 @@ index ebd7449b368..3519818d792 100644
  };
  
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0013-We-never-want-to-omit-the-frame-pointer-regardless-o.patch
+++ b/build/gcc7/patches/0013-We-never-want-to-omit-the-frame-pointer-regardless-o.patch
@@ -1,4 +1,4 @@
-From 3f3baddcfb42b8b10dab9372669c2a3d230dae08 Mon Sep 17 00:00:00 2001
+From 4009efd770bd700f13579b1ccc145b126780db26 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 25 Oct 2018 18:19:36 +0000
 Subject: We never want to omit the frame pointer, regardless of
@@ -10,7 +10,7 @@ Subject: We never want to omit the frame pointer, regardless of
  1 file changed, 9 insertions(+)
 
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index 5f7337a1468..00aaa73edb9 100644
+index e729d61c24c..1745253d8ec 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
 @@ -6281,6 +6281,15 @@ ix86_option_override_internal (bool main_args_p,
@@ -30,5 +30,5 @@ index 5f7337a1468..00aaa73edb9 100644
       options.  */
    if (main_args_p)
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0014-libstdc-v3-illumos-and-Solaris-haven-t-needed-lrt-in.patch
+++ b/build/gcc7/patches/0014-libstdc-v3-illumos-and-Solaris-haven-t-needed-lrt-in.patch
@@ -1,4 +1,4 @@
-From bdbe8fad6da912353cf52c4d96e13ce146a08a26 Mon Sep 17 00:00:00 2001
+From e39f075469e16e159b4005382cd15425f002d005 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Mon, 29 Oct 2018 18:21:34 +0000
 Subject: libstdc++v3: illumos and Solaris haven't needed -lrt in
@@ -11,10 +11,10 @@ Originally from Andy Fiddaman <andy@omniosce.org>
  2 files changed, 2 deletions(-)
 
 diff --git a/libstdc++-v3/acinclude.m4 b/libstdc++-v3/acinclude.m4
-index 67d84472653..917c3899ef8 100644
+index 08319dc5549..347825e5dcf 100644
 --- a/libstdc++-v3/acinclude.m4
 +++ b/libstdc++-v3/acinclude.m4
-@@ -1434,7 +1434,6 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME], [
+@@ -1443,7 +1443,6 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME], [
          ac_has_nanosleep=yes
          ;;
        solaris*)
@@ -23,10 +23,10 @@ index 67d84472653..917c3899ef8 100644
          ac_has_clock_realtime=yes
          ac_has_nanosleep=yes
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
-index e1c55aa72ff..b957a7230f6 100755
+index de8390703e2..c57a30495cf 100755
 --- a/libstdc++-v3/configure
 +++ b/libstdc++-v3/configure
-@@ -20578,7 +20578,6 @@ $as_echo "$glibcxx_glibc217" >&6; }
+@@ -20579,7 +20579,6 @@ $as_echo "$glibcxx_glibc217" >&6; }
          ac_has_nanosleep=yes
          ;;
        solaris*)
@@ -35,5 +35,5 @@ index e1c55aa72ff..b957a7230f6 100755
          ac_has_clock_realtime=yes
          ac_has_nanosleep=yes
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0015-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
+++ b/build/gcc7/patches/0015-libgo-libelf-on-illumos-doesn-t-support-largefile.patch
@@ -1,4 +1,4 @@
-From 537a897237b06194d2cfa9060f82234c5e47b567 Mon Sep 17 00:00:00 2001
+From 83ad3f77b788d2fa01d34777f5dbd2a028857a89 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Mon, 29 Oct 2018 18:23:00 +0000
 Subject: libgo: libelf on illumos doesn't support largefile
@@ -24,5 +24,5 @@ index 06a9c2ad6b8..966972d6b96 100644
  #endif
  
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0016-libgcc-unwind.map-should-be-v2-style.patch
+++ b/build/gcc7/patches/0016-libgcc-unwind.map-should-be-v2-style.patch
@@ -1,4 +1,4 @@
-From 7fbfb040a15d0cf867d71764ec134785718deb5d Mon Sep 17 00:00:00 2001
+From 50585bd2746dad3646149f18a9cc8d635e186989 Mon Sep 17 00:00:00 2001
 From: John Levon <john.levon@joyent.com>
 Date: Tue, 20 Nov 2018 16:07:51 +0000
 Subject: libgcc-unwind.map should be v2-style
@@ -49,5 +49,5 @@ index 0b9539114e4..55fd6e1caa7 100644
  install-libgcc-unwind-map-forbuild: libgcc-unwind.map
  	dest=$(gcc_objdir)/tmp$$$$-$<; \
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0017-libpthread-is-a-filter-in-illumos-all-functionality-.patch
+++ b/build/gcc7/patches/0017-libpthread-is-a-filter-in-illumos-all-functionality-.patch
@@ -1,4 +1,4 @@
-From 494cb8aff90e7a2372b6b01c8847a9a136c0fcbb Mon Sep 17 00:00:00 2001
+From 556de13090838373a2a03a79f3a68d5277902eb3 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Mon, 11 Mar 2019 10:41:58 +0000
 Subject: libpthread is a filter in illumos; all functionality
@@ -23,5 +23,5 @@ index f3e6140d9a0..ff34bd74e66 100644
  
  #ifndef CROSS_DIRECTORY_STRUCTURE
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0018-i386-Fix-grammar-of-msave-args-usage-message.patch
+++ b/build/gcc7/patches/0018-i386-Fix-grammar-of-msave-args-usage-message.patch
@@ -1,4 +1,4 @@
-From 37f365b7db87f58c2a4583dba6073eca2f619bfe Mon Sep 17 00:00:00 2001
+From 5b7f5f9d2339317827b4056bea91ca011796480b Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 26 Apr 2019 03:05:14 +0000
 Subject: i386: Fix grammar of -msave-args usage message
@@ -23,5 +23,5 @@ index d53f69c18be..92c3fd7db62 100644
  mforce-save-regs-using-mov
  Target Report Mask(FORCE_SAVE_REGS_USING_MOV)
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0019-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc7/patches/0019-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,4 +1,4 @@
-From 6155fc5a019b533550dace1fdefff0ae96a8cfd0 Mon Sep 17 00:00:00 2001
+From 5c69e2a6cbb74b5a6bcf45e1fbc8a02e08d8638c Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS
@@ -34,5 +34,5 @@ index ff34bd74e66..6cf6b6ac9cd 100644
  #undef LINK_ARCH64_SPEC
  #ifndef USE_GLD
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0020-tests-x86_64-pro_and_epilogue-RTL-can-t-work-with-ms.patch
+++ b/build/gcc7/patches/0020-tests-x86_64-pro_and_epilogue-RTL-can-t-work-with-ms.patch
@@ -1,4 +1,4 @@
-From fd11d4b82ab5744fc8753a1cd27a1d9246533c37 Mon Sep 17 00:00:00 2001
+From 521686e82445eccf847440e46e51f29b08f88ed2 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Thu, 2 May 2019 17:54:20 +0000
 Subject: tests: x86_64 pro_and_epilogue RTL can't work with
@@ -39,5 +39,5 @@ index b6f723a6e60..ed5db9cace3 100644
  /* { dg-final { scan-rtl-dump-times "simple_return" 2 "pro_and_epilogue" } }  */
 -
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0021-i386-don-t-assert-the-FP-is-valid-during-epilogue-ad.patch
+++ b/build/gcc7/patches/0021-i386-don-t-assert-the-FP-is-valid-during-epilogue-ad.patch
@@ -1,4 +1,4 @@
-From 21357fd22af9e0d7e458a49d867fdeff6e2a9f2b Mon Sep 17 00:00:00 2001
+From 2109c03b028b1f5df8b20534fac15e63ba76f543 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 00:56:45 +0000
 Subject: i386: don't assert the FP is valid during epilogue
@@ -15,10 +15,10 @@ While here, make the code more readable and conventional.
  1 file changed, 32 insertions(+), 37 deletions(-)
 
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index 00aaa73edb9..6cb4cf253ee 100644
+index 1745253d8ec..60a33dec70f 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
-@@ -13148,21 +13148,21 @@ static void
+@@ -13160,21 +13160,21 @@ static void
  ix86_emit_save_regs (void)
  {
    unsigned int regno;
@@ -43,7 +43,7 @@ index 00aaa73edb9..6cb4cf253ee 100644
  	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
  				   GEN_INT (-UNITS_PER_WORD), -1, false);
      }
-@@ -13246,22 +13246,21 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
+@@ -13258,22 +13258,21 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
  /* Emit code to save registers using MOV insns.
     First register is stored at CFA - CFA_OFFSET.  */
  static void
@@ -70,7 +70,7 @@ index 00aaa73edb9..6cb4cf253ee 100644
  	{
  	  regno = x86_64_int_parameter_registers[i];
  	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
-@@ -13269,7 +13268,7 @@ ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
+@@ -13281,7 +13280,7 @@ ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
  	}
      }
  
@@ -79,7 +79,7 @@ index 00aaa73edb9..6cb4cf253ee 100644
  
    for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
      if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true))
-@@ -14378,7 +14377,7 @@ ix86_expand_prologue (void)
+@@ -14390,7 +14389,7 @@ ix86_expand_prologue (void)
  	       && (! TARGET_STACK_PROBE
  		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
  	{
@@ -88,7 +88,7 @@ index 00aaa73edb9..6cb4cf253ee 100644
  	  int_registers_saved = true;
  	}
      }
-@@ -14621,7 +14620,7 @@ ix86_expand_prologue (void)
+@@ -14636,7 +14635,7 @@ ix86_expand_prologue (void)
      }
  
    if (!int_registers_saved)
@@ -97,7 +97,7 @@ index 00aaa73edb9..6cb4cf253ee 100644
    if (!sse_registers_saved)
      ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
  
-@@ -15063,36 +15062,32 @@ ix86_expand_epilogue (int style)
+@@ -15078,36 +15077,32 @@ ix86_expand_epilogue (int style)
        ix86_emit_restore_regs_using_pop ();
      }
  
@@ -157,5 +157,5 @@ index 00aaa73edb9..6cb4cf253ee 100644
       then do so now.  */
    if (m->fs.fp_valid)
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0022-gcc.target-i386-retarg-skip-if-msave-args.patch
+++ b/build/gcc7/patches/0022-gcc.target-i386-retarg-skip-if-msave-args.patch
@@ -1,4 +1,4 @@
-From af1ecf30544ea3f6e52322ff1d9b1cd5ef3aa287 Mon Sep 17 00:00:00 2001
+From ec67aff57de9f31869d3922032284892a1716392 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:02:08 +0000
 Subject: gcc.target/i386/retarg: skip if msave-args
@@ -21,5 +21,5 @@ index a69b60feaf4..3967ef76b1f 100644
  #include <string.h>
  
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0023-i386-use-correct-error-message-about-msave-args-and-.patch
+++ b/build/gcc7/patches/0023-i386-use-correct-error-message-about-msave-args-and-.patch
@@ -1,4 +1,4 @@
-From 528c759b95bb57904acff325fde5fccd6c1f16af Mon Sep 17 00:00:00 2001
+From 8efba58976130acdbfbdad14af3e5811f39c410c Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:20:30 +0000
 Subject: i386: use correct error message about -msave-args and
@@ -11,7 +11,7 @@ in 16bit mode either
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index 6cb4cf253ee..f7ac18317e7 100644
+index 60a33dec70f..0c20ffdc30c 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
 @@ -5899,7 +5899,7 @@ ix86_option_override_internal (bool main_args_p,
@@ -24,5 +24,5 @@ index 6cb4cf253ee..f7ac18317e7 100644
    /* Validate -mpreferred-stack-boundary= value or default it to
       PREFERRED_STACK_BOUNDARY_DEFAULT.  */
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
+++ b/build/gcc7/patches/0024-gcc.target-i386-skip-16bit-tests-when-msave-args.patch
@@ -1,4 +1,4 @@
-From 00c10cd540ab26d4fa4c6ca9b2c3ed032c2998a9 Mon Sep 17 00:00:00 2001
+From 2449174c24531fdf8ff1c96da511687c6bc13ec8 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Fri, 3 May 2019 01:22:56 +0000
 Subject: gcc.target/i386: skip 16bit tests when -msave-args
@@ -32,5 +32,5 @@ index 8e11c40bb08..92a86380f78 100644
  void load_kernel(void *setup_addr)
  {
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch
+++ b/build/gcc7/patches/0025-i386-use-the-new-style-retpoline-thunk-names-for-ext.patch
@@ -1,4 +1,4 @@
-From 54610bfb3e21b5903f36d641c6145740f298c986 Mon Sep 17 00:00:00 2001
+From fb181be5fb3ae5b87fe972875348860b8ae4b337 Mon Sep 17 00:00:00 2001
 From: Richard Lowe <richlowe@richlowe.net>
 Date: Wed, 7 Feb 2018 02:13:42 +0000
 Subject: i386: use the new-style retpoline thunk names for
@@ -9,10 +9,10 @@ Subject: i386: use the new-style retpoline thunk names for
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/gcc/config/i386/i386.c b/gcc/config/i386/i386.c
-index f7ac18317e7..afce9a6acab 100644
+index 0c20ffdc30c..621416d1904 100644
 --- a/gcc/config/i386/i386.c
 +++ b/gcc/config/i386/i386.c
-@@ -12099,7 +12099,8 @@ indirect_thunk_name (char name[32], unsigned int regno,
+@@ -12105,7 +12105,8 @@ indirect_thunk_name (char name[32], unsigned int regno,
    if (regno != INVALID_REGNUM && regno != CX_REG && ret_p)
      gcc_unreachable ();
  
@@ -23,5 +23,5 @@ index f7ac18317e7..afce9a6acab 100644
        const char *bnd = need_bnd_p ? "_bnd" : "";
        const char *ret = ret_p ? "return" : "indirect";
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0026-Use-GNU-backends-for-gcc-ar-nm-ranlib.patch
+++ b/build/gcc7/patches/0026-Use-GNU-backends-for-gcc-ar-nm-ranlib.patch
@@ -1,4 +1,4 @@
-From 3bab576aebc4cce41169275744f57a112a0948b7 Mon Sep 17 00:00:00 2001
+From da63b5ebf2f6e09037ced1df7825bbf5e6b37f7e Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Fri, 19 Jul 2019 11:42:58 +0000
 Subject: Use GNU backends for gcc-{ar,nm,ranlib}
@@ -28,5 +28,5 @@ index d5d80e042e5..5f1d075fdd9 100644
        exe_name = find_a_file (&path, real_exe_name, X_OK);
        if (!exe_name)
 -- 
-2.21.0
+2.23.0
 

--- a/build/gcc7/patches/0027-gcc-configure-must-call-gas-with-32-for-32-bit.patch
+++ b/build/gcc7/patches/0027-gcc-configure-must-call-gas-with-32-for-32-bit.patch
@@ -1,4 +1,4 @@
-From 64da12397ef7eb641a1359ca8e5810be30335123 Mon Sep 17 00:00:00 2001
+From 153e71c36643df6a0a84b2d7e3537a0cb22f9613 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Sun, 1 Dec 2019 00:10:53 +0000
 Subject: gcc configure must call gas with --32 for 32-bit

--- a/build/gcc7/testsuite.log
+++ b/build/gcc7/testsuite.log
@@ -1,100 +1,97 @@
 		=== g++ Summary for unix/ ===
-# of expected passes		105329
+# of expected passes		105732
 # of unexpected failures	218
-# of expected failures		392
+# of expected failures		393
 # of unresolved testcases	81
-# of unsupported tests		4135
+# of unsupported tests		4172
 		=== g++ Summary for unix//-msave-args ===
-# of expected passes		2171
-# of unexpected failures	76288
+# of expected passes		2174
+# of unexpected failures	76472
 # of unexpected successes	186
-# of expected failures		115
-# of unresolved testcases	10661
-# of unsupported tests		5098
+# of expected failures		116
+# of unresolved testcases	10701
+# of unsupported tests		5168
 		=== g++ Summary ===
-# of expected passes		107500
-# of unexpected failures	76506
+# of expected passes		107906
+# of unexpected failures	76690
 # of unexpected successes	186
-# of expected failures		507
-# of unresolved testcases	10742
-# of unsupported tests		9233
+# of expected failures		509
+# of unresolved testcases	10782
+# of unsupported tests		9340
 		=== gcc Summary for unix/ ===
-# of expected passes		117534
+# of expected passes		118098
 # of unexpected failures	147
 # of unexpected successes	1
 # of expected failures		370
 # of unresolved testcases	53
-# of unsupported tests		2096
+# of unsupported tests		2134
 		=== gcc Summary for unix//-msave-args ===
-# of expected passes		1547
-# of unexpected failures	63683
+# of expected passes		1460
+# of unexpected failures	63919
 # of unexpected successes	42
 # of expected failures		55
-# of unresolved testcases	26506
-# of unsupported tests		7012
+# of unresolved testcases	26655
+# of unsupported tests		7180
 		=== gcc Summary ===
-# of expected passes		119081
-# of unexpected failures	63830
+# of expected passes		119558
+# of unexpected failures	64066
 # of unexpected successes	43
 # of expected failures		425
-# of unresolved testcases	26559
-# of unsupported tests		9108
+# of unresolved testcases	26708
+# of unsupported tests		9314
 		=== gfortran Summary for unix/ ===
-# of expected passes		45391
+# of expected passes		45756
 # of unexpected failures	27
 # of expected failures		77
 # of unresolved testcases	17
 # of unsupported tests		201
 		=== gfortran Summary for unix//-msave-args ===
 # of expected passes		85
-# of unexpected failures	24444
+# of unexpected failures	24631
 # of expected failures		44
 # of untested testcases		1752
-# of unresolved testcases	14566
+# of unresolved testcases	14698
 # of unsupported tests		689
 		=== gfortran Summary ===
-# of expected passes		45476
-# of unexpected failures	24471
+# of expected passes		45841
+# of unexpected failures	24658
 # of expected failures		121
 # of untested testcases		1752
-# of unresolved testcases	14583
+# of unresolved testcases	14715
 # of unsupported tests		890
 		=== libatomic Summary for unix/ ===
-# of expected passes		43
-# of unresolved testcases	1
+# of expected passes		44
 # of unsupported tests		5
 		=== libatomic Summary for unix//-msave-args ===
 # of unexpected failures	22
 # of unresolved testcases	22
 # of unsupported tests		5
 		=== libatomic Summary ===
-# of expected passes		43
+# of expected passes		44
 # of unexpected failures	22
-# of unresolved testcases	23
+# of unresolved testcases	22
 # of unsupported tests		10
 		=== libgomp Summary for unix/ ===
-# of expected passes		5197
-# of unexpected failures	6
-# of unresolved testcases	17
+# of expected passes		5224
 # of unsupported tests		321
 		=== libgomp Summary for unix//-msave-args ===
-# of expected passes		9
-# of unexpected failures	2476
-# of unresolved testcases	2444
+# of expected passes		6
+# of unexpected failures	2477
+# of unresolved testcases	2450
 # of unsupported tests		446
 		=== libgomp Summary ===
-# of expected passes		5206
-# of unexpected failures	2482
-# of unresolved testcases	2461
+# of expected passes		5230
+# of unexpected failures	2477
+# of unresolved testcases	2450
 # of unsupported tests		767
 		=== libstdc++ Summary for unix/ ===
-# of expected passes		1237
-# of expected failures		20
-# of unresolved testcases	2
-# of unsupported tests		122
+# of expected passes		961
+# of expected failures		6
+# of unresolved testcases	4
+# of unsupported tests		63
 		=== libstdc++ Summary for unix//-msave-args ===
 		=== libstdc++ Summary ===
-# of expected passes		1237
-# of expected failures		20
-# of unresolved testcases	2
-# of unsupported tests		122
+# of expected passes		961
+# of expected failures		6
+# of unresolved testcases	4
+# of unsupported tests		63

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -13,7 +13,7 @@
 | developer/build/automake		| 1.16.1		| https://git.savannah.gnu.org/cgit/automake.git/refs/tags https://ftp.gnu.org/gnu/automake/
 | developer/build/gnu-make		| 4.2.1			| http://git.savannah.gnu.org/cgit/make.git/refs/tags
 | developer/build/libtool		| 2.4.6			| https://www.gnu.org/software/libtool/
-| developer/gcc7			| 7.4			| https://ftp.gnu.org/gnu/gcc/
+| developer/gcc7			| 7.5			| https://ftp.gnu.org/gnu/gcc/
 | developer/gcc8			| 8.3			| https://ftp.gnu.org/gnu/gcc/
 | developer/gcc9			| 9.2			| https://ftp.gnu.org/gnu/gcc/
 | developer/java/openjdk8		| 1.8.232-09		| https://github.com/battleblow/openjdk-jdk8u/releases


### PR DESCRIPTION
In addition to comparing the testsuite results with the previous version, I have also done an illumos build with this new version, onu'd and compared CTF data with one built with 7.4.