### PR TITLE
Disable libgmp's use of mulx instructions which has crept back in as …

### DIFF
--- a/build/libgmp/build.sh
+++ b/build/libgmp/build.sh
@@ -48,6 +48,7 @@ CONFIGURE_OPTS="
     --enable-fft
     --disable-fat
     --with-pic
+    gmp_cv_asm_x86_mulx=no
 "
 
 CONFIGURE_OPTS_WS_32="
@@ -60,11 +61,21 @@ CONFIGURE_OPTS_WS_64="
     MPN_PATH=\"$MPN64\"
 "
 
+tests() {
+    # In the past, libgmp has had a habit of detecting that the build host
+    # CPU supports the BMI2 mulx instruction and building a binary that does
+    # not work on pre-Haswell processors. We explicitly check for this in the
+    # resulting 64-bit library file.
+    dis $DESTDIR/usr/lib/$ISAPART64/libgmp.so | egrep -s mulx \
+        && logerr "libgmp has been built with mulx instructions"
+}
+
 init
 download_source $PROG $PROG $VER
 patch_source
 prep_build
 build
+tests
 run_testsuite check
 make_package
 clean_up


### PR DESCRIPTION
…of 6.2.0