### PR TITLE
Enforce linting of manifest-style packages

### DIFF
--- a/build/buildctl
+++ b/build/buildctl
@@ -263,25 +263,18 @@ build_manifest() {
 
     init_repo
     logmsg "Found a manifest file. Preparing it for publishing."
-    translate_manifest $mf $mf.final
     if [ -f root.tar.bz2 ]; then
         logmsg "File archive found. Extracting..."
         bzip2 -dc root.tar.bz2 | tar xf - \
             || logerr "Failed to extract root.tar.bz2"
-        logmsg "Publishing from $mf.final"
-        logcmd pkgsend -s $PKGSRVR publish -d $PKGROOT $mf.final \
-            || logerr "pkgsend failed"
+        publish_manifest "" $mf $PKGROOT
         logcmd rm -rf $PKGROOT
     elif [ -d "$PKGROOT" ]; then
         # In case we just have a tree of files and not a tarball
-        logmsg "Publishing from $mf.final"
-        logcmd pkgsend -s $PKGSRVR publish -d $PKGROOT $mf.final \
-            || logerr "pkgsend failed"
+        publish_manifest "" $mf $PKGROOT
     else
         # Else we just have a manifest to import
-        logmsg "Simple manifest to import... importing to $PKGSRVR"
-        logcmd pkgsend -s $PKGSRVR publish $mf.final \
-            || logerr "pkgsend failed"
+        publish_manifest "" $mf
     fi
     rm -f $mf.final
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1334,11 +1334,21 @@ publish_manifest()
 {
     local pkg=$1
     local pmf=$2
+    local root=$3
+
+    [ -n "$root" ] && root="-d $root"
 
     translate_manifest $pmf $pmf.final
 
-    logcmd pkgsend -s $PKGSRVR publish $pmf.final || logerr "pkgsend failed"
-    [ -z "$SKIP_PKG_DIFF" ] && diff_latest $pkg
+    logmsg "Publishing from $pmf.final"
+
+    if [ -z "$SKIP_PKGLINT" ] && ( [ -n "$BATCH" ] || ask_to_pkglint ); then
+        run_pkglint $PKGSRVR $pmf.final
+    fi
+
+    logcmd pkgsend -s $PKGSRVR publish $root $pmf.final \
+        || logerr "pkgsend failed"
+    [ -n "$pkg" -a -z "$SKIP_PKG_DIFF" ] && diff_latest $pkg
 }
 
 # Create a list of the items contained within a package in a format suitable


### PR DESCRIPTION
This would have prevented the recent problem with sunpro...

```
% ./buildctl build sunpro
===== Build started at Thu Jan 30 11:38:32 UTC 2020 =====

***
*** Building sunpro
***
--- sunpro -> system/library/c++/sunpro
Found a manifest file. Preparing it for publishing.
File archive found. Extracting...

Lint engine setup...
Starting lint run...

WARNING pkglint.manifest009.2     pkg.description matches pkg.summary in pkg:/system/library/c++/sunpro@0.5.11,5.11-151033.0
ERROR pkglint.action007           license action in pkg:/system/library/c++/sunpro@0.5.11,5.11-151033.0 has a path attribute, ../SUNWlibC.copyright
----- pkglint failed
An Error occured in the build. Do you wish to continue anyway? (y/n)
```