### PR TITLE
Re-introduce sunpro package

### DIFF
--- a/build/obsolete/library-sunpro.p5m
+++ b/build/obsolete/library-sunpro.p5m
@@ -1,5 +1,0 @@
-set name=pkg.fmri value=pkg://@PKGPUBLISHER@/system/library/c++/sunpro@0.5.11,@SUNOSVER@-@PVER@
-set name=pkg.summary value="Sun Workshop Compilers Bundled libC"
-set name=pkg.description value="Sun Workshop Compilers Bundled libC"
-set name=publisher value=sa@omniosce.org
-set name=pkg.obsolete value=true

--- a/build/sunpro/build.sh
+++ b/build/sunpro/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=sunpro
+VER=0.5.11
+PKG=system/library/c++/sunpro
+SUMMARY="Sun Workshop Compilers Bundled libC"
+DESC="$SUMMARY"
+
+set_builddir sunpro-runtime
+
+install() {
+    pushd $TMPDIR/$BUILDDIR >/dev/null
+    logcmd rsync -avr ${PREFIX#/}/ $DESTDIR/${PREFIX#/}/
+    popd >/dev/null
+}
+
+init
+download_source on-closed sunpro-runtime
+prep_build
+install
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/sunpro/local.mog
+++ b/build/sunpro/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+license SUNWlibC.copyright license="Sun Binary License"
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -652,7 +652,7 @@ omnios system/kernel/ultra-wideband o
 omnios system/kvm
 omnios system/library
 omnios system/library/bhyve
-omnios system/library/c++/sunpro o
+omnios system/library/c++/sunpro
 omnios system/library/c-runtime
 omnios system/library/dbus
 omnios system/library/demangle


### PR DESCRIPTION
In order to support any binaries which were built in the past with studio; they may still have dependencies on these.