### PR TITLE
Add explicit checks for errors during build

### DIFF
--- a/build/libxslt/build.sh
+++ b/build/libxslt/build.sh
@@ -52,6 +52,9 @@ CONFIGURE_OPTS="
 REMOVE_PREVIOUS=1
 SKIP_LICENCES=libxslt
 
+# During build, several errors are output as part of validation checks.
+SKIP_BUILD_ERRCHK=1
+
 backup_man() {
     logmsg "making a backup of xsltproc.1"
     logcmd cp $TMPDIR/$BUILDDIR/doc/xsltproc.1 $TMPDIR/$BUILDDIR/backup.1

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1798,6 +1798,18 @@ build() {
     [ -n "$ENABLE_CTF" ] && convert_ctf
 }
 
+check_buildlog() {
+    typeset -i expected="${1:-0}"
+
+    logmsg "--- Checking logfile for errors (expect $expected)"
+
+    errs="`grep 'error: ' $LOGFILE | \
+        egrep -cv 'pathspec.*did not match any file'`"
+
+    [ "$errs" -ne "$expected" ] \
+        && logerr "Found $errs errors in logfile (expected $expected)"
+}
+
 build32() {
     pushd $TMPDIR/$BUILDDIR > /dev/null
     logmsg "Building 32-bit"
@@ -1805,6 +1817,7 @@ build32() {
     make_clean
     configure32
     make_prog32
+    [ -z "$SKIP_BUILD_ERRCHK" ] && check_buildlog ${EXPECTED_BUILD_ERRS:-0}
     make_install32
     popd > /dev/null
     unset ISALIST
@@ -1817,6 +1830,7 @@ build64() {
     make_clean
     configure64
     make_prog64
+    [ -z "$SKIP_BUILD_ERRCHK" ] && check_buildlog ${EXPECTED_BUILD_ERRS:-0}
     make_install64
     popd > /dev/null
 }


### PR DESCRIPTION
I came across a build problem that caused the resulting `python` package to be missing the shared library that provides the `select` extension, breaking pkg:

```
r151034% pkg list -u
Traceback (most recent call last):
  File "/usr/bin/pkg", line 75, in <module>
    import socket
  File "/usr/lib/python3.7/socket.py", line 52, in <module>
    import os, sys, io, selectors
  File "/usr/lib/python3.7/selectors.py", line 12, in <module>
    import select
ModuleNotFoundError: No module named 'select'
```

`select` failed to build for some reason, most likely a race. I've never seen this before in any build of the python package.

```
building 'select' extension
gcc -m64 -fPIC -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -O2 -fno-aggressive-loop-optimizations -m64 -D_REENTRANT -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type -Werror=implicit-function-declaration -I./Include -I. -I/usr/include/ncurses -I/data/omnios-build/omniosorg/r151034/_build/Python-3.7.7/Python-3.7.7/Include -I/data/omnios-build/omniosorg/r151034/_build/Python-3.7.7/Python-3.7.7 -c /data/omnios-build/omniosorg/r151034/_build/Python-3.7.7/Python-3.7.7/Modules/selectmodule.c -o build/temp.solaris-2.11-i86pc.64bit-3.7/data/omnios-build/omniosorg/r151034/_build/Python-3.7.7/Python-3.7.7/Modules/selectmodule.o
/data/omnios-build/omniosorg/r151034/_build/Python-3.7.7/Python-3.7.7/Modules/selectmodule.c:2389:25: error: 'select_devpoll' undeclared here (not in a function)
 2389 |     {"devpoll",         select_devpoll, METH_NOARGS,    devpoll_doc},
      |                         ^~~~~~~~~~~~~~
```

I've done a full build and it it seems that `error: ` appearing in a build.log file is not usually expected, so I'm adding a check to abort a build if it occurs.