### PR TITLE
openjdk8: Fix build

### DIFF
--- a/build/openjdk8/patches/ldflags-pie.patch
+++ b/build/openjdk8/patches/ldflags-pie.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' a~/common/autoconf/generated-configure.sh a/common/autoconf/generated-configure.sh
+--- a~/common/autoconf/generated-configure.sh	1970-01-01 00:00:00
++++ a/common/autoconf/generated-configure.sh	1970-01-01 00:00:00
+@@ -42341,7 +42341,7 @@ $as_echo "$supports" >&6; }
+       # Enabling pie on 32 bit builds prevents the JVM from allocating a continuous
+       # java heap.
+       if test "x$OPENJDK_TARGET_CPU_BITS" != "x32"; then
+-        LDFLAGS_JDKEXE="$LDFLAGS_JDKEXE -pie"
++        LDFLAGS_JDKEXE="$LDFLAGS_JDKEXE"
+       fi
+     fi
+   fi

--- a/build/openjdk8/patches/series
+++ b/build/openjdk8/patches/series
@@ -55,3 +55,4 @@ patch-jdk_test_java_lang_management_OperatingSystemMXBean_GetSystemLoadAverage.j
 patch-jdk_test_sun_security_ec_TestEC.java.patch
 patch-pkcs11.patch
 demangle.patch
+ldflags-pie.patch


### PR DESCRIPTION
Unfortunately the previous openjdk update was incomplete and the build fails due to the attempted use of `-pie` with illumos gcc.

```
% java -version
openjdk version "1.8.0_252"
OpenJDK Runtime Environment (build 1.8.0_252-omnios-151033-b09)
OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
```