### PR TITLE
Drop duplicate curl header files

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -30,8 +30,6 @@ CONFIGURE_OPTS="
     --enable-thread
     --with-ca-bundle=/etc/ssl/cacert.pem
 "
-# curl has arch-dependent headers.
-CONFIGURE_OPTS_64+=" --includedir=$PREFIX/include/amd64"
 
 # Build backwards so that the 32-bit version is available for the test-suite.
 # Otherwise there are test failures because some tests preload a library

--- a/build/curl/local.mog
+++ b/build/curl/local.mog
@@ -1,25 +1,15 @@
-# CDDL HEADER START
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License, Version 1.0 only
-# (the "License").  You may not use this file except in compliance
-# with the License.
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 #
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
-#
-#
-# Copyright 2019 OmniOS Community Edition.  All rights reserved.
+
+# Copyright 2020 OmniOS Community Edition.  All rights reserved.
 
 license COPYING license=curl
 

--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -43,7 +43,6 @@ HARDLINK_TARGETS="
 
 # For inet_ntop which isn't detected properly in the configure script
 LDFLAGS="-lnsl"
-CFLAGS64+=" -I/usr/include/$ISAPART64"
 CONFIGURE_OPTS="
     --without-tcltk
     --with-curl=/usr


### PR DESCRIPTION
In the past, curl used to ship architecture-dependent header files so omnios
delivered two sets, `/usr/include/curl/` and `/usr/include/amd64/curl/`

In 2017, curl switched to using a single set of header files; the second
set is now redundant.

Fixes #1845, reported by @v-a-b 
