### PR TITLE
Update bhyve firmware

### DIFF
--- a/build/bhyve-fw/build.sh
+++ b/build/bhyve-fw/build.sh
@@ -23,176 +23,77 @@ BUILD_DEPENDS_IPS="
 
 PROG=uefi-edk2
 PKG=system/bhyve/firmware
-VER=20190904
+VER=20200501
 SUMMARY="UEFI-EDK2(+CSM) firmware for bhyve"
 DESC="$SUMMARY"
-
-# Respect environmental overrides for these to ease development.
-: ${EDK2_SOURCE_REPO:=$GITHUB/$PROG}
-: ${EDK2_LEGACY_BRANCH:=master}
-: ${EDK2_SOURCE_BRANCH:=edk2-stable201903}
-
-# The UEFI 2.70 firmware does not work with PCI pass-through so we continue
-# to set the links so that 2.40 is the default for now.
-XFORM_ARGS+=" -D UEFIVER=2.40 -D CSMVER=2.40"
-
-setup_env() {
-
-    case $1 in
-        $EDK2_LEGACY_BRANCH)
-            UPKGPREFIX=Bhyve
-            set_gccver 4.4.4
-            unset PYTHON3_ENABLE
-            PKGSUFFIX=-2.40
-            BUILD_CSM=1
-            EXTRA_BUILD_ARGS=
-            ;;
-        $EDK2_SOURCE_BRANCH)
-            UPKGPREFIX=Ovmf
-            set_gccver $DEFAULT_GCC_VER
-            export PYTHON3_ENABLE=TRUE
-            PKGSUFFIX=-2.70
-            BUILD_CSM=0
-            EXTRA_BUILD_ARGS="-DHTTP_BOOT_ENABLE=TRUE"
-            ;;
-    esac
-
-    MAKE_ARGS="
-            AS=/usr/bin/gas
-            AR=/usr/bin/gar
-            LD=/usr/bin/gld
-            OBJCOPY=/usr/bin/gobjcopy
-            CC=$GCC BUILD_CC=$GCC
-            CXX=$GXX BUILD_CXX=$GXX
-    "
-
-    export OOGCC_BIN=$GCCPATH/bin/
-}
-
-export IASL_PREFIX=/usr/sbin/
-export NASM_PREFIX=/usr/bin/
-
-edksetup() {
-    source edksetup.sh
-}
-
-cleanup() {
-    logmsg "-- Cleaning source tree"
-
-    logcmd gmake $MAKE_ARGS HOST_ARCH=X64 ARCH=X64 -C BaseTools clean
-    rm -rf Build Conf/{target,build_rule,tools_def}.txt Conf/.cache 2>/dev/null
-}
-
-build_tools() {
-    logmsg "-- Building tools"
-
-    # The code isn't able to detect the build architecture - it doesn't
-    # expect `uname -m` to return `i86pc`
-    logcmd gmake $MAKE_ARGS HOST_ARCH=X64 ARCH=X64 -C BaseTools \
-        || logerr "--- BaseTools build failed"
-}
-
-build() {
-    [ "$1" = "-csm" ] && csm=1 || csm=0
-
-    BUILD_ARGS="-DDEBUG_ON_SERIAL_PORT=TRUE -DFD_SIZE_2MB"
-    [ $csm -eq 1 ] && BUILD_ARGS+=" -DCSM_ENABLE=TRUE"
-    BUILD_ARGS+=" $EXTRA_BUILD_ARGS"
-
-    export BUILD_ARGS
-
-    for mode in RELEASE DEBUG; do
-
-        logmsg "-- Building $mode firmware"
-
-        case $mode in
-            RELEASE)    dport=0x2f8; level=CRIT ;;
-            DEBUG)      dport=0x3f8; level=INFO ;;
-        esac
-
-        dir=${UPKGPREFIX}Pkg
-        dec=$dir/${UPKGPREFIX}Pkg.dec
-        dsc=$dir/${UPKGPREFIX}PkgX64.dsc
-
-        logcmd sed -i "/PcdDebugIoPort|0x[0-9A-Fa-f]/s/0x[0-9A-Fa-f]*/$dport/" \
-            $dec || logerr "sed $dec"
-        logcmd sed -i "/DEBUG_PORT=0x/s/0x.*/$dport/" \
-            $dir/Csm/BhyveCsm16/GNUmakefile || logerr "sed GNUmakefile"
-        logcmd sed -i "/DebugLevel = DBG/s/DBG_.*/DBG_$level;/" \
-            $dir/Csm/BhyveCsm16/Printf.c || logerr "sed Printf.c"
-
-        if [ $csm -eq 1 ]; then
-            logmsg "-- Building compatibility support module (CSM)"
-            logcmd gmake $MAKE_ARGS -C $dir/Csm/BhyveCsm16/ clean all \
-                || logerr "--- CSM build failed"
-        fi
-
-        logcmd `which build` \
-            -t OOGCC -a X64 -b $mode \
-            -p $dsc \
-            $BUILD_ARGS || logerr "--- $mode build failed"
-    done
-}
-
-install() {
-    suffix="$1"
-    logcmd mkdir -p $DESTDIR/usr/share/bhyve/firmware
-    [ -f $DESTDIR/LICENCE ] || cp OvmfPkg/License.txt $DESTDIR/LICENCE
-    for mode in RELEASE DEBUG; do
-        logcmd cp Build/${UPKGPREFIX}X64/${mode}_OOGCC/FV/${UPKGPREFIX^^}.fd \
-            $DESTDIR/usr/share/bhyve/firmware/BHYVE_$mode$suffix$PKGSUFFIX.fd \
-            || logerr "firmware copy failed"
-    done
-}
-
-######################################################################
-# The default release branch
 
 init
 prep_build
 
-for branch in $EDK2_SOURCE_BRANCH $EDK2_LEGACY_BRANCH; do
+fwdir=$DESTDIR/usr/share/bhyve/firmware
+XFORM_ARGS+=" -D FWDIR=usr/share/bhyve/firmware"
+logcmd mkdir -p $fwdir
 
-    [ -n "$DEPVER" -a "$DEPVER" != $branch ] && continue
+export GMAKE=/usr/bin/gmake
+export GAS=/usr/bin/gas
+export GAR=/usr/bin/gar
+export GLD=/usr/bin/gld
+export GOBJCOPY=/usr/bin/gobjcopy
 
-    # branch names can contain '/', create a copy with these replaced
-    # that can be used for directory/file names.
-    sbranch="${branch//\//_}"
+# Build the UEFI firmware
 
-    note -n "-- Building firmware from $branch branch"
+tag=il-edk2-stable202005-1
+XFORM_ARGS+=" -D UEFITAG=$tag"
 
-    clone_github_source $sbranch/ "$EDK2_SOURCE_REPO" "$branch" "$EDK2_CLONE"
-
-    (
-        setup_env $branch
-
-        pushd "$TMPDIR/$BUILDDIR/$sbranch" >/dev/null || logerr "Cannot pushd"
-
-        logmsg "-- Updating git submodules"
-        logcmd git submodule update --init --progress .
-
-        cleanup
-
-        build_tools
-        edksetup
-
-        if [[ -z "$FLAVOR" || "$FLAVOR" = *UEFI* ]]; then
-            # Build UEFI firmware
-            note -n "UEFI Firmware"
-            build
-            install
-        fi
-
-        if [ $BUILD_CSM -ne 0 ] && [[ -z "$FLAVOR" || "$FLAVOR" = *CSM* ]]; then
-            # Build UEFI+CSM firmware
-            note -n "UEFI+CSM Firmware"
-            build -csm
-            install _CSM
-        fi
-
+(
+    if [ -z "$FLAVOR" -o "$FLAVOR" = UEFI ]; then
+        set_gccver $DEFAULT_GCC_VER
+        set_builddir uefi-edk2-$tag
+        download_source bhyve-fw uefi-edk2 $tag
+        pushd $TMPDIR/$BUILDDIR >/dev/null
+        logcmd cp OvmfPkg/License.txt $fwdir/LICENCE.$tag.OvmfPkg
+        logcmd cp BhyvePkg/License.txt $fwdir/LICENCE.$tag.BhyvePkg
+        for v in RELEASE DEBUG; do
+            [ -n "$DEPVER" -a "$DEPVER" != $v ] && continue
+            note "Building UEFI $v firmware"
+            logcmd ./build clean
+            logcmd ./build $v || logerr "UEFI $v build failed"
+            logcmd cp Build/BhyveX64/${v}_ILLGCC/FV/BHYVE_CODE.fd \
+                $fwdir/BHYVE_$v.fd \
+                || logerr "Copy firmware failed"
+        done
         popd >/dev/null
-    )
-done
+    fi
+) &
+
+# At present, the CSM firmware is still built from the old 2014 branch
+# using gcc 4.
+
+tag=il-udk2014.sp1-2
+XFORM_ARGS+=" -D CSMTAG=$tag"
+
+(
+    if [ -z "$FLAVOR" -o "$FLAVOR" = CSM ]; then
+        set_gccver 4.4.4
+        set_builddir uefi-edk2-$tag
+        download_source bhyve-fw uefi-edk2 $tag
+        pushd $TMPDIR/$BUILDDIR >/dev/null
+        logcmd cp OvmfPkg/License.txt $fwdir/LICENCE.$tag.OvmfPkg
+        for v in RELEASE DEBUG; do
+            [ -n "$DEPVER" -a "$DEPVER" != $v ] && continue
+            note "Building CSM $v firmware"
+            logcmd ./build clean
+            logcmd bash -x ./build -csm $v || logerr "CSM $v build failed"
+            logcmd cp Build/BhyveX64/${v}_ILLGCC/FV/BHYVE.fd \
+                $fwdir/BHYVE_${v}_CSM.fd \
+                || logerr "Copy firmware failed"
+        done
+        popd >/dev/null
+    fi
+) &
+
+# Both firmware branches are built in parallel, wait for them to finish
+wait
 
 make_package
 clean_up

--- a/build/bhyve-fw/local.mog
+++ b/build/bhyve-fw/local.mog
@@ -9,21 +9,14 @@
 
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
-license LICENCE license=simplified-BSD
-<transform file path=LICENCE -> drop>
+license $(FWDIR)/LICENCE.$(UEFITAG).BhyvePkg license=BSD-2-Clause-Patent
+license $(FWDIR)/LICENCE.$(UEFITAG).OvmfPkg license=BSD-2-Clause-Patent
+license $(FWDIR)/LICENCE.$(UEFITAG).OvmfPkg license=MIT
 
-<transform file -> set mode 0755>
+license $(FWDIR)/LICENCE.$(CSMTAG).OvmfPkg license=simplified-BSD
 
-link path=usr/share/bhyve/firmware/BHYVE_RELEASE.fd \
-    target=BHYVE_RELEASE-$(UEFIVER).fd
-link path=usr/share/bhyve/firmware/BHYVE_RELEASE_CSM.fd \
-    target=BHYVE_RELEASE_CSM-$(CSMVER).fd
+<transform file -> default mode 0755>
 
-link path=usr/share/bhyve/firmware/BHYVE.fd target=BHYVE_RELEASE.fd
-link path=usr/share/bhyve/firmware/BHYVE_CSM.fd target=BHYVE_RELEASE_CSM.fd
-
-link path=usr/share/bhyve/firmware/BHYVE_DEBUG.fd \
-    target=BHYVE_DEBUG-$(UEFIVER).fd
-link path=usr/share/bhyve/firmware/BHYVE_DEBUG_CSM.fd \
-    target=BHYVE_DEBUG_CSM-$(CSMVER).fd
+link path=$(FWDIR)/BHYVE.fd target=BHYVE_RELEASE.fd
+link path=$(FWDIR)/BHYVE_CSM.fd target=BHYVE_RELEASE_CSM.fd
 

--- a/doc/licences
+++ b/doc/licences
@@ -19,6 +19,8 @@ GCC runtime license	GCC RUNTIME LIBRARY EXCEPTION
 MIT			Permission is hereby granted, free of charge(?s:.)*The above copyright notice and this permission notice(?s).*shall be.*included.*in.all.copies.or.substantial.portions.of.the.*Software.(?-s)$(?s:.)*THE SOFTWARE IS PROVIDED .AS IS., WITHOUT WARRANTY OF(?s:.)*ANY KIND,( EXPRESS( OR)?)?
 old-MIT			"Old MIT"(?s:.)*Permission is hereby granted, without written agreement and without
 #
+# The BSD-2-Clause Patent licence
+BSD-2-Clause-Patent	SPDX-License-Identifier: BSD-2-Clause-Patent
 # The original 4-clause BSD licence
 BSD			Redistribution and use in source and binary forms, with or without(?s).*modification,.*are(?-s) permitted provided that the following(?s).*conditions.*are.*met:.*(?-s)[1\*#]\.? Redistributions of source code must retain(?s:.)*[2\*#]\.? Redistributions in binary form must reproduce(?s:.)*[3\*#]\.? All advertising materials mentioning features(?s:.)*[4\*#]\.? Neither the name of the(?s:.)*prior written permission\.\n\n.*THIS SOFTWARE
 # The modified 3-clause BSD licence

--- a/tools/licence
+++ b/tools/licence
@@ -33,7 +33,7 @@ for f in "$@"; do
                 /^#/ { next }
                 $1 == type { print $2 }
             ' $doc`"
-            if $RIPGREP -qU "$pattern" "$f"; then
+            if dos2unix "$f" | $RIPGREP -qU "$pattern"; then
                 echo "$f: $lic"
             fi
     done


### PR DESCRIPTION
This updates the UEFI bhyve firmware to the latest freebsd 202005 branch but also switches to using the uefi-edk2 releases from https://github.com/omniosorg/uefi-edk2, and the common build script which is held there. This simplifies the firmware build script significantly.

I also changed the build so that two branches are built in parallel, speeding up the package build.