### PR TITLE
Ship CDDL as /usr/src/OPENSOLARIS.LICENSE [sic]

### DIFF
--- a/build/release/notices.mog
+++ b/build/release/notices.mog
@@ -1,4 +1,3 @@
-# {{{ CDDL HEADER
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
@@ -8,16 +7,19 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-# }}}
 
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
-link path=etc/notices/LICENCE target=COPYRIGHT
-link path=etc/notices/LICENSE target=COPYRIGHT
-
+<transform file dir -> set owner root>
 <transform file dir -> set group sys>
 <transform file -> set mode 0444>
 <transform dir -> set mode 0755>
+
+file ../../LICENSE path=etc/notices/LICENSE
+link path=etc/notices/LICENCE target=LICENSE
+
+# The headers of many files still point users here to find the CDDL text
+link path=usr/share/src/OPENSOLARIS.LICENSE target=etc/notices/LICENSE
 
 license ../../LICENSE license=CDDL
 


### PR DESCRIPTION
A lot of files that we ship with OmniOS include a header that directs a user at `/usr/src/OPENSOLARIS.LICENSE`, for example the default crontab:

```
bloody% pfexec crontab -l
#ident  "%Z%%M% %I%     %E% SMI"
#
# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
# Use is subject to license terms.
#
# CDDL HEADER START
#
# The contents of this file are subject to the terms of the
# Common Development and Distribution License (the "License").
# You may not use this file except in compliance with the License.
#
# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
# or http://www.opensolaris.org/os/licensing.
# See the License for the specific language governing permissions
# and limitations under the License.
...
```

We should put a copy of the CDDL at that location.