### PR TITLE
readline: add patches + fix linkage

### DIFF
--- a/build/readline/build.sh
+++ b/build/readline/build.sh
@@ -42,12 +42,18 @@ init
 prep_build
 
 # Build previous versions
+_BUILDDIR=$BUILDDIR
+_PATCHDIR=$PATCHDIR
 for pver in $PVERS; do
     note -n "Building previous version: $pver"
-    BUILDDIR=$PROG-$pver download_source $PROG $PROG $pver
-    PATCHDIR=patches-${pver##.*} patch_source
-    BUILDDIR=$PROG-$pver build
+    BUILDDIR=$PROG-$pver
+    PATCHDIR=patches-${pver%%.*}
+    download_source $PROG $PROG $pver
+    patch_source
+    build
 done
+BUILDDIR=$_BUILDDIR
+PATCHDIR=$_PATCHDIR
 
 note -n "Building current version: $VER"
 download_source $PROG $PROG $VER

--- a/build/readline/patches-6/link-ltermcap.patch
+++ b/build/readline/patches-6/link-ltermcap.patch
@@ -1,0 +1,12 @@
+diff -ru readline-6.3~/shlib/Makefile.in readline-6.3/shlib/Makefile.in
+--- readline-6.3~/shlib/Makefile.in	2012-01-12 21:54:33.000000000 +0000
++++ readline-6.3/shlib/Makefile.in	2020-06-20 14:20:01.114299415 +0000
+@@ -174,7 +174,7 @@
+ 
+ $(SHARED_READLINE):	$(SHARED_OBJ)
+ 	$(RM) $@
+-	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS)
++	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS) $(TERMCAP_LIB)
+ 
+ $(SHARED_HISTORY):	$(SHARED_HISTOBJ) xmalloc.so xfree.so
+ 	$(RM) $@

--- a/build/readline/patches-6/series
+++ b/build/readline/patches-6/series
@@ -6,3 +6,4 @@ readline63-005 -p0
 readline63-006 -p0
 readline63-007 -p0
 readline63-008 -p0
+link-ltermcap.patch

--- a/build/readline/patches-7/link-ltermcap.patch
+++ b/build/readline/patches-7/link-ltermcap.patch
@@ -1,0 +1,12 @@
+diff -ru readline-7.0~/shlib/Makefile.in readline-7.0/shlib/Makefile.in
+--- readline-7.0~/shlib/Makefile.in	2015-07-12 22:41:58.000000000 +0000
++++ readline-7.0/shlib/Makefile.in	2020-06-20 14:21:02.368191705 +0000
+@@ -174,7 +174,7 @@
+ 
+ $(SHARED_READLINE):	$(SHARED_OBJ)
+ 	$(RM) $@
+-	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS)
++	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS) $(TERMCAP_LIB)
+ 
+ $(SHARED_HISTORY):	$(SHARED_HISTOBJ) xmalloc.so xfree.so
+ 	$(RM) $@

--- a/build/readline/patches-7/series
+++ b/build/readline/patches-7/series
@@ -3,3 +3,4 @@ readline70-002 -p0
 readline70-003 -p0
 readline70-004 -p0
 readline70-005 -p0
+link-ltermcap.patch

--- a/build/readline/patches/README
+++ b/build/readline/patches/README
@@ -1,0 +1,2 @@
+Visit here:  https://ftp.gnu.org/gnu/readline/readline-8.0-patches/
+to keep this updated.

--- a/build/readline/patches/link-ltermcap.patch
+++ b/build/readline/patches/link-ltermcap.patch
@@ -1,0 +1,12 @@
+diff -ru readline-8.0~/shlib/Makefile.in readline-8.0/shlib/Makefile.in
+--- readline-8.0~/shlib/Makefile.in	2015-07-12 22:41:58.000000000 +0000
++++ readline-8.0/shlib/Makefile.in	2020-06-20 14:22:05.044303564 +0000
+@@ -174,7 +174,7 @@
+ 
+ $(SHARED_READLINE):	$(SHARED_OBJ)
+ 	$(RM) $@
+-	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS)
++	$(SHOBJ_LD) ${SHOBJ_LDFLAGS} ${SHLIB_XLDFLAGS} -o $@ $(SHARED_OBJ) $(SHLIB_LIBS) $(TERMCAP_LIB)
+ 
+ $(SHARED_HISTORY):	$(SHARED_HISTOBJ) xmalloc.so xfree.so
+ 	$(RM) $@

--- a/build/readline/patches/readline80-001
+++ b/build/readline/patches/readline80-001
@@ -1,0 +1,38 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 8.0
+Patch-ID: readline80-001
+
+Bug-Reported-by:	chet.ramey@case.edu
+Bug-Reference-ID:
+Bug-Reference-URL:
+
+Bug-Description:
+
+The history file reading code doesn't close the file descriptor open to
+the history file when it encounters a zero-length file.
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-8.0-patched/histfile.c	2018-06-11 09:14:52.000000000 -0400
+--- histfile.c	2019-05-16 15:55:57.000000000 -0400
+***************
+*** 306,309 ****
+--- 312,316 ----
+      {
+        free (input);
++       close (file);
+        return 0;	/* don't waste time if we don't have to */
+      }
+*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 0
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 1

--- a/build/readline/patches/readline80-002
+++ b/build/readline/patches/readline80-002
@@ -1,0 +1,60 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 8.0
+Patch-ID: readline80-002
+
+Bug-Reported-by:	lessbug@qq.com
+Bug-Reference-ID:	<tencent_6AA531D9A5CC4121D86BD5CDA2E0DA98C605@qq.com>
+Bug-Reference-URL:
+
+Bug-Description:
+
+When using previous-history to go back beyond the beginning of the history list,
+it's possible to move to an incorrect partial line.
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-8.0-patched/misc.c	2017-07-07 17:30:12.000000000 -0400
+--- misc.c	2019-05-16 11:43:46.000000000 -0400
+***************
+*** 577,580 ****
+--- 590,594 ----
+  {
+    HIST_ENTRY *old_temp, *temp;
++   int had_saved_line;
+  
+    if (count < 0)
+***************
+*** 589,592 ****
+--- 603,607 ----
+  
+    /* If we don't have a line saved, then save this one. */
++   had_saved_line = _rl_saved_line_for_history != 0;
+    rl_maybe_save_line ();
+  
+***************
+*** 612,616 ****
+    if (temp == 0)
+      {
+!       rl_maybe_unsave_line ();
+        rl_ding ();
+      }
+--- 627,632 ----
+    if (temp == 0)
+      {
+!       if (had_saved_line == 0)
+!         _rl_free_saved_history_line ();
+        rl_ding ();
+      }
+*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 1
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 2

--- a/build/readline/patches/readline80-003
+++ b/build/readline/patches/readline80-003
@@ -1,0 +1,69 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 8.0
+Patch-ID: readline80-003
+
+Bug-Reported-by:	HIROSE Masaaki <hirose31@gmail.com>
+Bug-Reference-ID:	<CAGSOfA-RqiTe=+GsXsDKyZrrMWH4bDbXgMVVegMa6OjqC5xbnQ@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2019-05/msg00038.html
+
+Bug-Description:
+
+Reading history entries with timestamps can result in history entries joined
+by linefeeds.
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-8.0-patched/histfile.c	2018-06-11 09:14:52.000000000 -0400
+--- histfile.c	2019-05-16 15:55:57.000000000 -0400
+***************
+*** 370,376 ****
+  
+    has_timestamps = HIST_TIMESTAMP_START (buffer);
+!   history_multiline_entries += has_timestamps && history_write_timestamps;  
+  
+    /* Skip lines until we are at FROM. */
+    for (line_start = line_end = buffer; line_end < bufend && current_line < from; line_end++)
+      if (*line_end == '\n')
+--- 370,378 ----
+  
+    has_timestamps = HIST_TIMESTAMP_START (buffer);
+!   history_multiline_entries += has_timestamps && history_write_timestamps;
+  
+    /* Skip lines until we are at FROM. */
++   if (has_timestamps)
++     last_ts = buffer;
+    for (line_start = line_end = buffer; line_end < bufend && current_line < from; line_end++)
+      if (*line_end == '\n')
+***************
+*** 381,385 ****
+--- 383,398 ----
+  	if (HIST_TIMESTAMP_START(p) == 0)
+  	  current_line++;
++ 	else
++ 	  last_ts = p;
+  	line_start = p;
++ 	/* If we are at the last line (current_line == from) but we have
++ 	   timestamps (has_timestamps), then line_start points to the
++ 	   text of the last command, and we need to skip to its end. */
++ 	if (current_line >= from && has_timestamps)
++ 	  {
++ 	    for (line_end = p; line_end < bufend && *line_end != '\n'; line_end++)
++ 	      ;
++ 	    line_start = (*line_end == '\n') ? line_end + 1 : line_end;
++ 	  }
+        }
+  
+
+*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 2
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 3

--- a/build/readline/patches/readline80-004
+++ b/build/readline/patches/readline80-004
@@ -1,0 +1,47 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 8.0
+Patch-ID: readline80-004
+
+Bug-Reported-by:	auroralanes@protonmail.ch
+Bug-Reference-ID:	<WikEDKluAyoha9IDLp83rbN7_Uinr2rrpvSV_z4wmt9qur9piN-FNOn17P0cAizEVah1Fvc9d641vIIWX_7SC6EUTz0CatnOH-C-UK3rPYc=@protonmail.ch>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-readline/2020-01/msg00008.html
+
+Bug-Description:
+
+If writing the history file fails, and renaming the backup history file fails,
+it's possible for readline's history code to return the wrong error to its
+caller.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-20200124/lib/readline/histfile.c	2019-11-19 10:31:58.000000000 -0500
+--- histfile.c	2020-02-01 16:28:29.000000000 -0500
+***************
+*** 621,624 ****
+--- 621,625 ----
+    if (rv != 0)
+      {
++       rv = errno;
+        if (tempname)
+  	unlink (tempname);
+***************
+*** 768,771 ****
+--- 769,773 ----
+    if (rv != 0)
+      {
++       rv = errno;
+        if (tempname)
+  	unlink (tempname);
+*** ../readline-8.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 3
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 4

--- a/build/readline/patches/series
+++ b/build/readline/patches/series
@@ -1,0 +1,5 @@
+readline80-001 -p0
+readline80-002 -p0
+readline80-003 -p0
+readline80-004 -p0
+link-ltermcap.patch


### PR DESCRIPTION
Reported by @ptrrkssn

This is a similar fix to the one in OpenIndiana, except they unnecessarily link libtermcap against libhistory too.

I installed this update and tested the core utilities that use libreadlin such as bash, gawk, sqlite3.