### PR TITLE
illumos build.cf must skip gfx-drm too

### DIFF
--- a/build/illumos/build.sh
+++ b/build/illumos/build.sh
@@ -67,7 +67,7 @@ push_pkgs() {
     [ "$FLAVOR" = ctf ] && \
         FLAVOR="SUNWcs `pkg search -H -o pkg.name \
             dir:path:/kernel OR dir:path:/platform \
-            | egrep -v '^ooce/|driver/virtualization/kvm'`"
+            | egrep -v '^ooce/|virtualization/kvm|graphics/(agpgart|drm)'`"
 
     pkgmerge -d $PKGSRVR \
         -s debug.illumos=false,$ndrepo/ \


### PR DESCRIPTION
`illumos/build.sh -f ctf` is failing with:

```
pkgmerge: The following pattern(s) did not match any packages in any of the specified repositories for publisher omnios:
driver/graphics/agpgart
driver/graphics/drm
```