### PR TITLE
Adjust pthread library patches for newer gcc behaviour

### DIFF
--- a/build/libxslt/build.sh
+++ b/build/libxslt/build.sh
@@ -21,8 +21,7 @@
 # CDDL HEADER END }}}
 #
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-# Use is subject to license terms.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../lib/functions.sh
 
@@ -34,7 +33,6 @@ DESC="The portable XSLT C library built on libxml2"
 
 CFLAGS32+=" -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
 CFLAGS64+=" -D_LARGEFILE_SOURCE"
-LDFLAGS="-lpthread"
 
 # Without --with-libxml-prefix, configure does not find /usr/bin/xml2-config!
 CONFIGURE_OPTS="

--- a/build/mozilla-nss-nspr/files/nspr.pc
+++ b/build/mozilla-nss-nspr/files/nspr.pc
@@ -6,5 +6,5 @@ includedir=/usr/include/mps
 Name: NSPR
 Description: Netscape Portable Runtime
 Version: __NSPRVER__
-Libs: -L${libdir} -lplds4 -lplc4 -lnspr4 -lpthread -ldl -lposix4
+Libs: -L${libdir} -lplds4 -lplc4 -lnspr4 -ldl -lposix4
 Cflags: -I${includedir}

--- a/build/openssl/build.sh
+++ b/build/openssl/build.sh
@@ -152,6 +152,7 @@ if [ -z "$FLAVOR" -o "$FLAVOR" = "1.1" ]; then
     patch_source
     prep_build
     build
+    convert_ctf
     (cd $DESTDIR; gpatch -p1 < $SRCDIR/$PATCHDIR/post/opensslconf.dualarch)
     run_testsuite
     move_libs

--- a/build/openssl/patches/libs.patch
+++ b/build/openssl/patches/libs.patch
@@ -11,6 +11,9 @@ unecessary library is linked.
 Openssl is one of the libraries used by illumos-omnios and therefore we
 patch the configuration script to stop linking against these two libraries.
 
+We also patch out the desire to omit the frame pointer and add in dwarf-2
+debug information which can be converted to CTF.
+
 diff -wpruN '--exclude=*.orig' a~/Configurations/10-main.conf a/Configurations/10-main.conf
 --- a~/Configurations/10-main.conf	1970-01-01 00:00:00
 +++ a/Configurations/10-main.conf	1970-01-01 00:00:00
@@ -23,25 +26,21 @@ diff -wpruN '--exclude=*.orig' a~/Configurations/10-main.conf a/Configurations/1
          dso_scheme       => "dlfcn",
          thread_scheme    => "pthreads",
          shared_target    => "self",
-@@ -226,10 +226,8 @@ my %targets = (
+@@ -226,7 +226,7 @@ my %targets = (
          CC               => "gcc",
          CFLAGS           => add_before(picker(default => "-Wall",
                                                debug   => "-O0 -g",
 -                                              release => "-O3 -fomit-frame-pointer")),
--        cflags           => add(threads("-pthread")),
-+                                              release => "-O3")),
++                                              release => "-O3 -gdwarf-2")),
+         cflags           => add(threads("-pthread")),
          lib_cppflags     => add("-DL_ENDIAN"),
--        ex_libs          => add(threads("-pthread")),
-         bn_ops           => "BN_LLONG",
-         shared_cflag     => "-fPIC",
-         shared_ldflag    => add_before("-shared -static-libgcc"),
-@@ -248,9 +246,7 @@ my %targets = (
+         ex_libs          => add(threads("-pthread")),
+@@ -247,7 +247,7 @@ my %targets = (
+         CC               => "gcc",
          CFLAGS           => add_before(picker(default => "-Wall",
                                                debug   => "-O0 -g",
-                                               release => "-O3")),
--        cflags           => add_before("-m64", threads("-pthread")),
+-                                              release => "-O3")),
++                                              release => "-O3 -gdwarf-2")),
+         cflags           => add_before("-m64", threads("-pthread")),
          lib_cppflags     => add("-DL_ENDIAN"),
--        ex_libs          => add(threads("-pthread")),
-         bn_ops           => "SIXTY_FOUR_BIT_LONG",
-         perlasm_scheme   => "elf",
-         shared_cflag     => "-fPIC",
+         ex_libs          => add(threads("-pthread")),

--- a/build/openssl/testsuite.log
+++ b/build/openssl/testsuite.log
@@ -154,5 +154,5 @@
 ../test/recipes/99-test_ecstress.t ................. ok
 ../test/recipes/99-test_fuzz.t ..................... ok
 All tests successful.
-Files=155, Tests=1462, 188 wallclock secs ( 1.86 usr  0.65 sys + 100.28 cusr 51.35 csys = 154.13 CPU)
+Files=155, Tests=1462, 180 wallclock secs ( 1.78 usr  0.65 sys + 92.84 cusr 52.33 csys = 147.59 CPU)
 Result: PASS

--- a/build/xz/patches/pthread.diff
+++ b/build/xz/patches/pthread.diff
@@ -1,5 +1,5 @@
 
-illumos does  not need the -mt and -pthreads flags. pthreads are native to
+illumos does  not need the -mt and -lpthread flags. pthreads are native to
 libc these days.
 
 diff -wpruN '--exclude=*.orig' a~/m4/ax_pthread.m4 a/m4/ax_pthread.m4
@@ -10,7 +10,7 @@ diff -wpruN '--exclude=*.orig' a~/m4/ax_pthread.m4 a/m4/ax_pthread.m4
          # standard Solaris way of linking pthreads (-mt -lpthread).
  
 -        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
-+        #ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
++        ax_pthread_flags="pthread $ax_pthread_flags"
          ;;
  esac
  
@@ -18,10 +18,9 @@ diff -wpruN '--exclude=*.orig' a~/m4/ax_pthread.m4 a/m4/ax_pthread.m4
  # [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
  # To solve this, first try -pthread together with -lpthread for GCC
  
--AS_IF([test "x$GCC" = "xyes"],
+ AS_IF([test "x$GCC" = "xyes"],
 -      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
-+#AS_IF([test "x$GCC" = "xyes"],
-+#      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
++      [ax_pthread_flags="-pthread,-pthread -pthreads $ax_pthread_flags"])
  
  # Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
  

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -176,7 +176,7 @@ CHECK_RTIME=/opt/onbld/bin/check_rtime
 PFEXEC=sudo
 
 CTFCONVERT=/opt/onbld/bin/i386/ctfconvert
-CTFCONVERTFLAGS=-l
+CTFCONVERTFLAGS=-mi
 PKGSEND=/usr/bin/pkgsend
 PKGLINT=/usr/bin/pkglint
 PKGMOGRIFY=/usr/bin/pkgmogrify

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2260,11 +2260,19 @@ convert_ctf() {
     while read file; do
         file $file | $EGREP -s 'ELF.*not stripped' || continue
         logmsg "------ Converting CTF data for $file"
-        MODE=$(stat -c %a "$file")
-        logcmd chmod u+w "$file" || logerr -b "chmod failed: $file"
-        logcmd $CTFCONVERT $CTFCONVERTFLAGS "$PROG-$VER" -o $file $file
-        logcmd strip -x "$file" || logerr -b "strip failed: $file"
-        logcmd chmod $MODE "$file" || logerr -b "chmod failed: $file"
+        typeset tf="$file.$$"
+        rm -f "$tf"
+        if logcmd $CTFCONVERT $CTFCONVERTFLAGS -l "$PROG-$VER" -o "$tf" "$file"
+        then
+            if [ -s "$tf" ]; then
+                typeset mode=`stat -c %a "$file"`
+                logcmd chmod u+w "$file" || logerr -b "chmod u+w failed: $file"
+                logcmd cp "$tf" "$file" || logerr -b "copy failed: $file"
+                logcmd chmod $mode "$file" || logerr -b "chmod failed: $file"
+            fi
+        fi
+        logcmd rm -f "$tf"
+        logcmd strip -x "$file"
     done < <(find . -depth -type f -perm -0100)
     popd >/dev/null
 }


### PR DESCRIPTION
The OmniOS gcc these days does not automatically add `-lpthread` for threaded applications.
These patches can be simplified.