### PR TITLE
Deliver more complete /usr/dict/words

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -356,6 +356,7 @@ text/gnu-sed					4	require
 text/groff					1.22	require
 text/less					551	require
 text/locale					0.5.11	require
+text/words					20200724	require
 web/ca-bundle					5.11	require
 web/curl					7	optional
 web/wget					1.20	optional

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -158,6 +158,7 @@ text/gnu-patch				2.7
 text/gnu-sed				4
 text/groff				1.22
 text/less				551
+text/words				20200724
 web/ca-bundle				5.11
 web/curl				7
 web/wget				1.20

--- a/build/words/build.sh
+++ b/build/words/build.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/functions.sh
+
+PROG=words
+VER=20200724
+PKG=text/words
+SUMMARY="A collection of international words files for /usr/share/lib/dict"
+DESC="$SUMMARY"
+
+# Aspell is built just to obtain the word list decompression utility
+ASPELL_VER=0.60.8
+
+set_arch 64
+
+SKIP_LICENCES='*'
+
+XFORM_ARGS="-D ROOT=usr/share/lib/dict"
+
+pr_EN=aspell6;      ver_EN="2017.08.24-0"
+pr_DE=aspell;       ver_DE="0.50-2"
+pr_DE_alt=aspell6;  ver_DE_alt="2.1-1"
+pr_ES=aspell6;      ver_ES="1.11-2"
+pr_IT=aspell6;      ver_IT="2.2_20050523-0"
+pr_FR=aspell;       ver_FR="0.50-3"
+
+DICTIONARIES="
+    $pr_EN-en-$ver_EN
+    $pr_DE-de-$ver_DE
+    $pr_DE_alt-de-alt-$ver_DE_alt
+    $pr_ES-es-$ver_ES
+    $pr_IT-it-$ver_IT
+    $pr_FR-fr-$ver_FR
+"
+
+fetch_dicts() {
+    logcmd rm -rf $TMPDIR/$BUILDDIR
+    logcmd mkdir -p $TMPDIR/$BUILDDIR
+
+    tmog=$TMPDIR/licence.mog
+    rm -f $tmog
+
+    for dict in $DICTIONARIES; do
+        logmsg "-- Fetch dictionary $dict"
+        BUILDDIR=$dict download_source aspell $dict
+        logcmd cp $TMPDIR/$dict/*.cwl $TMPDIR/$BUILDDIR || logerr "cp failed"
+        logcmd cp $TMPDIR/$dict/Copyright $TMPDIR/$BUILDDIR/Copyright.$dict \
+            || logerr "cp copyright failed"
+        echo "license Copyright.$dict license=$dict" >> $tmog
+    done
+}
+
+build_dicts() {
+    pushd $TMPDIR/$BUILDDIR >/dev/null
+
+    logcmd $SHELL preunzip *.cwl || logerr "preunzip failed"
+    for wl in *.wl; do
+        logmsg "--- converting $wl to UTF-8"
+        logcmd mv $wl $wl~
+        logcmd -p iconv -f ISO-8859-1 -t UTF-8 $wl~ \
+            | cut -d/ -f1 | sort -df > $wl
+        logcmd rm -f $wl~
+    done
+
+    popd >/dev/null
+}
+
+combine() {
+    logmsg "--- combining $@" >> /dev/stderr
+    cat "$@" | sort -u | sort -df
+}
+
+makehash() {
+    typeset int=`mktemp`
+    grep -hv "'" "$@" | /usr/lib/spell/hashmake > $int
+    args=`wc $int | awk '{print $1}'`
+    /usr/lib/spell/spellin $args < $int
+    rm -f $int
+}
+
+install_dicts() {
+    pushd $TMPDIR/$BUILDDIR >/dev/null
+
+    out=$DESTDIR/usr/share/lib/dict/
+    mkdir -p $out
+
+    combine en-common.wl en_GB-ise*wl en_GB-variant*wl > $out/british-english
+    combine en-common.wl en_US*wl > $out/american-english
+    combine en-common.wl en_AU*wl > $out/australian-english
+    combine en-common.wl en_CA*wl > $out/canadian-english
+
+    combine de-only.wl de_*wl > $out/ngerman
+    combine de-alt.wl > $out/ogerman
+
+    combine es.wl > $out/spanish
+    combine it.wl > $out/italian
+    combine fr-40-only.wl > $out/french
+
+    # The following code is not yet working, so we continue to ship the
+    # hash lists from illumos.
+
+    #hash=$DESTDIR/usr/lib/spell
+    #mkdir -p $hash
+    #makehash en-common.wl en_US-wo_accents-only.wl > $hash/hlista
+    #makehash en-common.wl en_GB-ise-wo_accents-only.wl > $hash/hlistb
+
+    popd >/dev/null
+}
+
+init
+prep_build
+
+build_dependency aspell aspell-$ASPELL_VER aspell aspell $ASPELL_VER
+PATH+=":$DEPROOT/usr/bin"
+
+fetch_dicts
+build_dicts
+install_dicts
+make_package $tmog
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/words/local.mog
+++ b/build/words/local.mog
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+link target=british-english path=$(ROOT)/british
+link target=american-english path=$(ROOT)/usa
+link target=australian-english path=$(ROOT)/australian
+link target=canadian-english path=$(ROOT)/canadian
+
+link target=ngerman path=$(ROOT)/german
+
+<transform file path=$(ROOT)/(.*)$ -> emit \
+    link path=$(ROOT)/words mediator=words \
+        mediator-implementation=%<1> target=%<1> >
+
+<transform link mediator-implementation=american-english \
+    -> set mediator-priority vendor >
+
+# The mediated links for words conflict with the file delivered by
+# illumos-gate, so mark them with the 'onu.ooceonly' facet so that it is
+# still possible to ONU to stock gate.
+<transform link mediator=words -> set facet.onu.ooceonly true >
+<transform file path=usr/lib/spell -> set facet.onu.ooceonly true >
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -802,6 +802,7 @@ omnios text/groff
 omnios text/intltool
 omnios text/less
 omnios text/locale
+omnios text/words
 omnios web/ca-bundle
 omnios web/curl
 omnios web/wget


### PR DESCRIPTION
The current version from illumos-gate has not been updated much over the years. This replaces it with a more complete list built from the GNU aspell dictionaries. An small set of initial languages is included and `/usr/share/lib/dict/words` is a mediated link which defaults to american-english.