### PR TITLE
Remove APIC Timer Preferred Mode workaround

### DIFF
--- a/build/system/files/system
+++ b/build/system/files/system
@@ -59,14 +59,6 @@ set dump_plat_mincpu=0
 set dump_bzip2_level=1
 
 *
-* KVM is unstable on Sandy/Ivy Bridge Hardware with the default timers
-*   https://smartos.org/bugview/OS-1361
-*
-set pcplusmp:apic_timer_preferred_mode=0
-set apix:apic_timer_preferred_mode=0
-
-
-*
 * The traditional (and essentially entirely brain dead) cfgadm(1M)-centric
 * model of hotpluggin' appears to be basically unnecessary.  This tunable
 * enables the system to create device nodes for newly inserted devices


### PR DESCRIPTION
Fixes #1990 - see that issue for analysis and details of why this is no longer required. Thanks @Leftwing