### PR TITLE
glib2: update to 2.66.0

### DIFF
--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -141,7 +141,7 @@ file/gnu-findutils				4.7	require
 install/beadm					0.5.11	require
 library/c++/sigcpp				3	require
 library/expat					2.2	require
-library/glib2					2.64	require
+library/glib2					2.66	require
 library/gmp					6.2	require
 library/libffi					3.3	require
 library/libidn					1	require

--- a/build/glib/build.sh
+++ b/build/glib/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=glib
-VER=2.64.5
+VER=2.66.0
 PKG=library/glib2
 SUMMARY="GNOME utility library"
 DESC="The GNOME general-purpose utility library"

--- a/build/glib/patches/libsocket.patch
+++ b/build/glib/patches/libsocket.patch
@@ -13,7 +13,7 @@ diff -wpruN '--exclude=*.orig' a~/gio/tests/meson.build a/gio/tests/meson.build
    'socket-listener' : {},
    'socket-service' : {},
    'srvtarget' : {},
-@@ -139,11 +142,20 @@ if host_machine.system() != 'windows'
+@@ -140,11 +143,20 @@ if host_machine.system() != 'windows'
        'dependencies' : [libgdbus_example_objectmanager_dep],
        'install_rpath' : installed_tests_execdir
      },
@@ -37,7 +37,7 @@ diff -wpruN '--exclude=*.orig' a~/gio/tests/meson.build a/gio/tests/meson.build
      'unix-mounts' : {},
      'unix-streams' : {},
      'g-file-info-filesystem-readonly' : {},
-@@ -354,8 +366,8 @@ if host_machine.system() != 'windows'
+@@ -355,8 +367,8 @@ if host_machine.system() != 'windows'
  
    # This test is currently unreliable
    executable('gdbus-overflow', 'gdbus-overflow.c',

--- a/build/glib/patches/no_inotify.patch
+++ b/build/glib/patches/no_inotify.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/meson.build a/meson.build
 --- a~/meson.build	1970-01-01 00:00:00
 +++ a/meson.build	1970-01-01 00:00:00
-@@ -250,7 +250,6 @@ headers = [
+@@ -282,7 +282,6 @@ headers = [
    'sys/auxv.h',
    'sys/event.h',
    'sys/filio.h',
@@ -9,7 +9,7 @@ diff -wpruN '--exclude=*.orig' a~/meson.build a/meson.build
    'sys/mkdev.h',
    'sys/mntctl.h',
    'sys/mnttab.h',
-@@ -439,7 +438,6 @@ functions = [
+@@ -490,7 +489,6 @@ functions = [
    'getvfsstat',
    'gmtime_r',
    'hasmntopt',

--- a/build/glib/testsuite.log
+++ b/build/glib/testsuite.log
@@ -64,6 +64,7 @@ glib:gio / srvtarget                       OK
 glib:gio / stream-rw_all                   OK
 glib:gio / task                            OK
 glib:gio / thumbnail-verification          OK
+glib:gio / tls-bindings                    OK
 glib:gio / tls-certificate                 OK
 glib:gio / tls-database                    OK
 glib:gio / tls-interaction                 OK
@@ -246,7 +247,7 @@ glib:refcount+slow / objects2              OK
 glib:refcount+slow / properties2           OK
 glib:refcount+slow / properties3           OK
 
-Ok:                 232 
+Ok:                 233 
 Expected Fail:      0   
 Fail:               14  
 Unexpected Pass:    0   

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -40,7 +40,7 @@ file/gnu-coreutils			8
 file/gnu-findutils			4.7
 library/c++/sigcpp			3
 library/expat				2.2
-library/glib2				2.64
+library/glib2				2.66
 library/gmp				6.2
 library/mpfr				4
 library/mpc				1

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -106,7 +106,7 @@
 | text/less				| 551			| http://www.greenwoodsoftware.com/less/download.html
 | web/curl				| 7.72.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.20.3		| https://ftp.gnu.org/gnu/wget/
-| library/glib2				| 2.64.5		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
+| library/glib2				| 2.66.0		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
 | developer/gnu-binutils		| 2.35			| https://ftp.gnu.org/gnu/binutils
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
 | system/virtualization/azure-agent	| 2.2.46		| https://github.com/Azure/WALinuxAgent/releases


### PR DESCRIPTION
I tested that an illumos-omnios build was clean with this upgraded glib.