### PR TITLE
openjdk8: drop mediator-priority set to vendor

### DIFF
--- a/build/openjdk8/jrefinal.mog
+++ b/build/openjdk8/jrefinal.mog
@@ -13,5 +13,5 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 link path=usr/java target=jdk/openjdk$(IVER) \
-    mediator=openjdk mediator-priority=vendor mediator-version=$(VER)
+    mediator=openjdk mediator-version=$(VER)
 

--- a/build/openjdk8/local.mog
+++ b/build/openjdk8/local.mog
@@ -14,9 +14,9 @@
 
 <transform file path=$(IFULL)/bin/(.*) -> emit \
     link path=usr/bin/%<1> target=../java/bin/%<1> \
-    mediator=openjdk mediator-priority=vendor mediator-version=$(VER)>
+    mediator=openjdk mediator-version=$(VER)>
 
 <transform file path=$(IFULL)/man/man1/(.*) -> emit \
     link path=usr/share/man/man1/%<1> target=../../../java/man/man1/%<1> \
-    mediator=openjdk mediator-priority=vendor mediator-version=$(VER)>
+    mediator=openjdk mediator-version=$(VER)>
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -71,7 +71,7 @@
 | runtime/java/openjdk8			| 1.8.265-01		| https://hg.openjdk.java.net/jdk8u/jdk8u/tags
 | runtime/perl				| 5.32.0		| http://www.cpan.org/src/README.html
 | runtime/python-27			| 2.7.18		| https://www.python.org/downloads/source/
-| runtime/python-35			| 3.5.9			| https://www.python.org/downloads/source/
+| runtime/python-35			| 3.5.10		| https://www.python.org/downloads/source/
 | runtime/python-37			| 3.7.9			| https://www.python.org/downloads/source/
 | security/sudo				| 1.9.2			| https://www.sudo.ws/
 | service/network/ntpsec		| 1.1.9			| https://github.com/ntpsec/ntpsec/releases https://blog.ntpsec.org/


### PR DESCRIPTION
stop using `openjdk8` as default if `openjdk11` is installed