### PR TITLE
zstd: update to 1.4.8

### DIFF
--- a/build/zstd/build.sh
+++ b/build/zstd/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=zstd
-VER=1.4.7
+VER=1.4.8
 PKG=compress/zstd
 SUMMARY="Zstandard"
 DESC="Zstandard is a real-time compression algorithm, providing high "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -9,7 +9,7 @@
 | compress/unzip			| 6.0			| https://sourceforge.net/projects/infozip/files/UnZip%206.x%20%28latest%29/ https://www.cvedetails.com/vulnerability-list/vendor_id-816/product_id-1395/Info-zip-Unzip.html
 | compress/xz				| 5.2.5			| https://tukaani.org/xz/
 | compress/zip				| 3.0			| https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/ http://www.info-zip.org/Zip.html
-| compress/zstd				| 1.4.7			| https://github.com/facebook/zstd/releases
+| compress/zstd				| 1.4.8			| https://github.com/facebook/zstd/releases
 | data/iso-codes			| 4.5.0			| https://salsa.debian.org/iso-codes-team/iso-codes/tags
 | database/sqlite-3			| 3340000		| https://www.sqlite.org/download.html
 | developer/build/autoconf		| 2.70			| https://ftp.gnu.org/gnu/autoconf/


### PR DESCRIPTION
Due to hotfix for fixing 'wrong alignment of an internal buffer'