### PR TITLE
Python 3.9 - use correct type for gid

### DIFF
--- a/build/openssh/README
+++ b/build/openssh/README
@@ -33,7 +33,7 @@ SunSSH 1.5.
 
 In particular, the PAM and RBAC behaviour of SunSSH had to be preserved, so that
 login into roles, reduced privileges at login, and other features specific to
-Illumos work correctly. The reason these don't work on stock upstream OpenSSH is
+illumos work correctly. The reason these don't work on stock upstream OpenSSH is
 due to differences between our PAM and other PAM implementations -- openssh-
 portable's PAM support is written primarily against Linux-PAM and OpenPAM.
 
@@ -72,7 +72,7 @@ the Makefile here will regenerate configure using autoreconf.
 
 # Patches for upstreaming
 
-Patches #21 and #29 relate to dropping Illumos privileges, and can probably be
+Patches #21 and #29 relate to dropping illumos privileges, and can probably be
 eventually upstreamed (in a form modified to have some more `#ifdef`s, maybe a
 `configure` arg).
 

--- a/build/python39/patches/gid-convert.patch
+++ b/build/python39/patches/gid-convert.patch
@@ -1,0 +1,17 @@
+See https://github.com/python/cpython/pull/23762
+
+Should be fixed in the next Python 3.9.x release at which point we can drop
+the patch.
+
+diff -wpruN '--exclude=*.orig' a~/Modules/_posixsubprocess.c a/Modules/_posixsubprocess.c
+--- a~/Modules/_posixsubprocess.c	1970-01-01 00:00:00
++++ a/Modules/_posixsubprocess.c	1970-01-01 00:00:00
+@@ -753,7 +753,7 @@ subprocess_fork_exec(PyObject* self, PyO
+     if (groups_list != Py_None) {
+ #ifdef HAVE_SETGROUPS
+         Py_ssize_t i;
+-        unsigned long gid;
++        gid_t gid;
+ 
+         if (!PyList_Check(groups_list)) {
+             PyErr_SetString(PyExc_TypeError,

--- a/build/python39/patches/series
+++ b/build/python39/patches/series
@@ -11,6 +11,7 @@ encoding-alias.patch
 pty.patch
 locale-encoding.patch
 cgiserver.patch
+gid-convert.patch
 #
 # Additional modules
 module-ucred.patch

--- a/build/release/files/COPYRIGHT
+++ b/build/release/files/COPYRIGHT
@@ -1,9 +1,9 @@
 Open Maryland, not Indiana Operating System (OmniOS)
 @@COPYRIGHT@@
-Copyright 2016 OmniTI Computer Consulting, Inc. All rights reserved.
+Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
 All rights reserved.
 
-OpenIndiana Project, part of The Illumos Foundation (C) 2010
+OpenIndiana Project, part of The illumos Foundation (C) 2010
 
 Copyright  2009 Sun Microsystems, Inc., 4150 Network Circle,
 Santa Clara, California 95054, U.S.A. All rights reserved.

--- a/build/release/release.mog
+++ b/build/release/release.mog
@@ -1,4 +1,3 @@
-# {{{ CDDL HEADER
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
@@ -8,7 +7,6 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-# }}}
 
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 


### PR DESCRIPTION
See https://github.com/python/cpython/pull/23762
It is in the process of being back-ported to python 3.9 so we should be able to drop this patch in the next update.