### PR TITLE
Core package updates

### DIFF
--- a/build/autoconf/build.sh
+++ b/build/autoconf/build.sh
@@ -13,12 +13,12 @@
 # }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../lib/functions.sh
 
 PROG=autoconf
-VER=2.70
+VER=2.71
 PKG=developer/build/autoconf
 SUMMARY="GNU $PROG"
 DESC="$PROG - GNU autoconf utility"

--- a/build/autoconf/testsuite.log
+++ b/build/autoconf/testsuite.log
@@ -1,5 +1,5 @@
 ## ----------------------------- ##
-## GNU Autoconf 2.70 test suite. ##
+## GNU Autoconf 2.71 test suite. ##
 ## ----------------------------- ##
 
 Executables (autoheader, autoupdate...).
@@ -22,669 +22,671 @@ Executables (autoheader, autoupdate...).
  16: autoconf: input from stdin                      ok
  17: autoconf: AC_AUTOCONF_VERSION                   ok
  18: autoconf: AC_PRESERVE_HELP_ORDER                ok
- 19: ifnames                                         ok
- 20: autoheader                                      ok
- 21: autoheader and macros                           ok
- 22: autoheader with multiple headers                ok
- 23: autoupdate                                      ok
- 24: autoupdating AC_LINK_FILES                      ok
- 25: autoupdating AC_PREREQ                          ok
- 26: autoupdating AU_ALIAS                           ok
- 27: autoupdating OLD to NEW                         ok
- 28: autoupdating macros recursively                 expected failure (tools.at:1100)
- 29: autoupdating AC_HELP_STRING                     ok
- 30: autoupdating with m4sugar                       ok
- 31: autoupdating with m4_pushdef                    expected failure (tools.at:1183)
- 32: autoupdating with AC_REQUIRE                    expected failure (tools.at:1209)
- 33: autoupdating with complex quoting               expected failure (tools.at:1236)
- 34: autoupdating AC_LANG_SAVE                       ok
- 35: autoupdating AC_FOREACH                         ok
- 36: autoupdating AC_OBSOLETE                        ok
- 37: autoupdating AC_DIAGNOSE and AC_WARNING         ok
- 38: autoupdating AC_FATAL                           ok
- 39: autoupdating with aclocal and m4_include        ok
- 40: autom4te preselections                          ok
- 41: autom4te cache creation                         ok
- 42: autom4te cache locking                          ok
- 43: autotools and whitespace in file names          ok
- 44: autotools and relative TMPDIR                   ok
+ 19: autoconf: timestamp changes                     ok
+ 20: ifnames                                         ok
+ 21: autoheader                                      ok
+ 22: autoheader and macros                           ok
+ 23: autoheader with multiple headers                ok
+ 24: autoupdate                                      ok
+ 25: autoupdating AC_LINK_FILES                      ok
+ 26: autoupdating AC_PREREQ                          ok
+ 27: autoupdating AU_ALIAS                           ok
+ 28: autoupdating OLD to NEW                         ok
+ 29: autoupdating macros recursively                 expected failure (tools.at:1146)
+ 30: autoupdating AC_HELP_STRING                     ok
+ 31: autoupdating with m4sugar                       ok
+ 32: autoupdating with m4_pushdef                    expected failure (tools.at:1229)
+ 33: autoupdating with AC_REQUIRE                    expected failure (tools.at:1255)
+ 34: autoupdating with complex quoting               expected failure (tools.at:1282)
+ 35: autoupdating AC_LANG_SAVE                       ok
+ 36: autoupdating AC_FOREACH                         ok
+ 37: autoupdating AC_OBSOLETE                        ok
+ 38: autoupdating AC_DIAGNOSE and AC_WARNING         ok
+ 39: autoupdating AC_FATAL                           ok
+ 40: autoupdating with aclocal and m4_include        ok
+ 41: autom4te preselections                          ok
+ 42: autom4te cache creation                         ok
+ 43: autom4te cache locking                          ok
+ 44: autotools and whitespace in file names          ok
+ 45: autotools and relative TMPDIR                   ok
 
 M4sugar.
 
- 45: m4_stack                                        ok
- 46: m4_defn                                         ok
- 47: m4_dumpdef                                      ok
- 48: m4_warn                                         ok
- 49: m4_divert_stack                                 ok
- 50: m4_expansion_stack                              ok
- 51: m4_require: error message                       ok
- 52: m4_require: warning message                     ok
- 53: m4_require: circular dependencies               ok
- 54: m4_require: one-shot initialization             ok
- 55: m4_require: nested                              ok
- 56: m4sugar shorthand conditionals                  ok
- 57: m4_cond                                         ok
- 58: m4 lists                                        ok
- 59: m4_split                                        ok
- 60: m4_do                                           ok
- 61: m4_append                                       ok
- 62: m4_join                                         ok
- 63: m4_expand                                       ok
- 64: m4_text_box                                     ok
- 65: m4_text_wrap                                    ok
- 66: m4_version_compare                              ok
- 67: Standard regular expressions                    ok
- 68: m4_bmatch                                       ok
- 69: m4_toupper and m4_tolower                       ok
- 70: m4_bpatsubsts                                   ok
- 71: m4_esyscmd_s                                    ok
- 72: M4 loops                                        ok
- 73: m4_map                                          ok
- 74: m4_map_args and m4_curry                        ok
- 75: m4_combine                                      ok
- 76: m4_max and m4_min                               ok
- 77: recursion                                       ok
- 78: m4_set                                          ok
- 79: __file__ and __line__                           ok
+ 46: m4_stack                                        ok
+ 47: m4_defn                                         ok
+ 48: m4_dumpdef                                      ok
+ 49: m4_warn                                         ok
+ 50: m4_divert_stack                                 ok
+ 51: m4_expansion_stack                              ok
+ 52: m4_require: error message                       ok
+ 53: m4_require: warning message                     ok
+ 54: m4_require: circular dependencies               ok
+ 55: m4_require: one-shot initialization             ok
+ 56: m4_require: nested                              ok
+ 57: m4sugar shorthand conditionals                  ok
+ 58: m4_cond                                         ok
+ 59: m4 lists                                        ok
+ 60: m4_split                                        ok
+ 61: m4_do                                           ok
+ 62: m4_append                                       ok
+ 63: m4_join                                         ok
+ 64: m4_expand                                       ok
+ 65: m4_text_box                                     ok
+ 66: m4_text_wrap                                    ok
+ 67: m4_version_compare                              ok
+ 68: Standard regular expressions                    ok
+ 69: m4_bmatch                                       ok
+ 70: m4_toupper and m4_tolower                       ok
+ 71: m4_bpatsubsts                                   ok
+ 72: m4_esyscmd_s                                    ok
+ 73: M4 loops                                        ok
+ 74: m4_map                                          ok
+ 75: m4_map_args and m4_curry                        ok
+ 76: m4_combine                                      ok
+ 77: m4_max and m4_min                               ok
+ 78: recursion                                       ok
+ 79: m4_set                                          ok
+ 80: __file__ and __line__                           ok
 
 M4sh.
 
- 80: No extra re-exec with CONFIG_SHELL              ok
- 81: Forced re-exec with CONFIG_SHELL                ok
- 82: Configure re-execs self with CONFIG_SHELL       ok
- 83: AS_WARN and AS_ERROR                            ok
- 84: LINENO                                          ok
- 85: LINENO stack                                    ok
- 86: AS_BOX                                          ok
- 87: AS_BASENAME                                     ok
- 88: AS_DIRNAME                                      ok
- 89: AS_SET_CATFILE                                  ok
- 90: AS_ECHO and AS_ECHO_N                           ok
- 91: obsolete $as_echo and $as_echo_n                ok
- 92: Redefining AS_ECHO internals                    ok
- 93: AS_EXECUTABLE_P                                 ok
- 94: AS_EXIT                                         ok
- 95: AS_MKDIR_P                                      ok
- 96: AS_VERSION_COMPARE                              ok
- 97: as_me                                           ok
- 98: Negated classes in globbing                     ok
- 99: Null variable substitution                      ok
-100: Functions Support                               ok
-101: Functions and return Support                    ok
-102: Nested AS_REQUIRE_SHELL_FN                      ok
-103: Nested AS_REQUIRE                               ok
-104: AS_REQUIRE_SHELL_FN and m4_require              ok
-105: AS_HELP_STRING                                  ok
-106: AS_IF and AS_CASE                               ok
-107: AS_FOR                                          ok
-108: AS_LITERAL_IF                                   ok
-109: AS_TR_SH and AS_TR_CPP                          ok
-110: AS_VAR basics                                   ok
-111: AS_VAR_APPEND                                   ok
-112: AS_VAR_ARITH                                    ok
-113: AS_INIT cleanup                                 ok
-114: AS_INIT basename __file__                       ok
-115: AS_INIT_GENERATED                               ok
-116: AS_MESSAGE_FD                                   ok
-117: _AS_CLEAN_DIR                                   ok
-118: ECHO_C                                          ok
+ 81: No extra re-exec with CONFIG_SHELL              ok
+ 82: Forced re-exec with CONFIG_SHELL                ok
+ 83: Configure re-execs self with CONFIG_SHELL       ok
+ 84: AS_WARN and AS_ERROR                            ok
+ 85: LINENO                                          ok
+ 86: LINENO stack                                    ok
+ 87: AS_BOX                                          ok
+ 88: AS_BASENAME                                     ok
+ 89: AS_DIRNAME                                      ok
+ 90: AS_SET_CATFILE                                  ok
+ 91: AS_ECHO and AS_ECHO_N                           ok
+ 92: obsolete $as_echo and $as_echo_n                ok
+ 93: Redefining AS_ECHO internals                    ok
+ 94: AS_EXECUTABLE_P                                 ok
+ 95: AS_EXIT                                         ok
+ 96: AS_MKDIR_P                                      ok
+ 97: AS_VERSION_COMPARE                              ok
+ 98: as_me                                           ok
+ 99: Negated classes in globbing                     ok
+100: Null variable substitution                      ok
+101: Functions Support                               ok
+102: Functions and return Support                    ok
+103: Nested AS_REQUIRE_SHELL_FN                      ok
+104: Nested AS_REQUIRE                               ok
+105: AS_REQUIRE_SHELL_FN and m4_require              ok
+106: AS_HELP_STRING                                  ok
+107: AS_IF and AS_CASE                               ok
+108: AS_FOR                                          ok
+109: AS_LITERAL_IF                                   ok
+110: AS_TR_SH and AS_TR_CPP                          ok
+111: AS_VAR basics                                   ok
+112: AS_VAR_APPEND                                   ok
+113: AS_VAR_ARITH                                    ok
+114: AS_INIT cleanup                                 ok
+115: AS_INIT basename __file__                       ok
+116: AS_INIT_GENERATED                               ok
+117: AS_MESSAGE_FD                                   ok
+118: _AS_CLEAN_DIR                                   ok
+119: ECHO_C                                          ok
 
 Autotest.
 
-119: AT_COPYRIGHT                                    ok
-120: AT_DATA                                         ok
-121: AT_DATA_UNQUOTED                                ok
-122: AT_PREPARE_TESTS                                ok
-123: AT_PREPARE_EACH_TEST                            ok
-124: AT_TEST_HELPER_FN                               ok
-125: Empty test suite                                ok
-126: Banner-only test suite                          ok
-127: Empty test                                      ok
-128: Empty check                                     ok
-129: AT_SETUP without AT_INIT                        ok
-130: AT_BANNER without AT_INIT                       ok
-131: AT_CLEANUP without AT_INIT                      ok
-132: Missing AT_CLEANUP                              ok
-133: AT_FAIL_IF without AT_SETUP                     ok
-134: AT_SKIP_IF without AT_SETUP                     ok
-135: AT_CHECK without AT_SETUP                       ok
-136: AT_DATA without AT_SETUP                        ok
-137: AT_XFAIL_IF without AT_SETUP                    ok
-138: AT_KEYWORDS without AT_SETUP                    ok
-139: AT_CLEANUP without AT_SETUP                     ok
-140: AT_BANNER inside AT_SETUP                       ok
-141: AT_SETUP inside AT_SETUP                        ok
-142: Multiple AT_INIT                                ok
-143: Invalid AT_TEST_HELPER_FN (spaces)              ok
-144: Invalid AT_TEST_HELPER_FN (substitutions)       ok
-145: Multiple AT_TEST_HELPER_FN                      ok
-146: Tested programs                                 ok
-147: Startup error messages                          ok
-148: Truth                                           ok
-149: Fallacy                                         ok
-150: Skip                                            ok
-151: Hard fail                                       ok
-152: AT_FAIL_IF                                      ok
-153: AT_SKIP_IF                                      ok
-154: Syntax error                                    ok
-155: errexit                                         ok
-156: at_status                                       ok
-157: AT_CHECK execution environment                  ok
-158: unquoted output                                 ok
-159: Trace output                                    ok
-160: Logging                                         ok
-161: Binary output                                   ok
-162: Cleanup                                         ok
-163: Literal multiline command                       ok
-164: Multiline parameter expansion                   ok
-165: Backquote command substitution                  ok
-166: Multiline backquote command substitution        ok
-167: Parenthetical command substitution              ok
-168: Multiline parenthetical command substitution    ok
-169: Shell comment in command                        ok
-170: Invalid brace-enclosed parameter expansion      ok
-171: Multiline command from M4 expansion             ok
-172: Double-M4-quoted command                        ok
-173: Metacharacters in command from M4 expansion     ok
-174: BS-newline in command                           ok
-175: ^BS-newline in command                          ok
-176: BSx641-newline in command                       ok
-177: BS-BS-newline in command                        ok
-178: BSx640-newline in command                       ok
-179: Newline-CODE-BS-newline in command              ok
-180: Single-quote-BS-newline in command              ok
-181: Single-quote-newline-BS-newline in command      ok
-182: Input from stdin                                ok
-183: Backquote in a test title                       ok
-184: Single-quote in a test title                    ok
-185: Double-quote in a test title                    ok
-186: Backslash in a test title                       ok
-187: Brackets in a test title                        ok
-188: Left bracket in a test title                    ok
-189: Right bracket in a test title                   ok
-190: Quoted pound in a test title                    ok
-191: Pound in a test title                           ok
-192: Quoted comma in a test title                    ok
-193: Comma in a test title                           ok
-194: Parentheses in a test title                     ok
-195: Left paren in a test title                      ok
-196: Right paren in a test title                     ok
-197: Quoted Macro in a test title                    ok
-198: Macro in a test title                           ok
-199: Macro with backquote in a test title            ok
-200: Macro with single-quote in a test title         ok
-201: Macro with double-quote in a test title         ok
-202: Macro with backslash in a test title            ok
-203: Macro echoing macro in a test title             ok
-204: Macro echoing single-quote in a test title      ok
-205: Long test title in a test title                 ok
-206: Longer test title in a test title               ok
-207: Long test source lines                          ok
-208: Huge testsuite                                  ok
-209: Debugging a successful test                     ok
-210: Debugging script and environment                ok
-211: Debugging a failed test                         ok
-212: Using atlocal                                   ok
-213: Choosing where testsuite is run                 ok
-214: recheck                                         ok
-215: Banners                                         ok
-216: Keywords and ranges                             ok
-217: Keyword wrapping                                ok
-218: AT_ARG_OPTION                                   ok
-219: AT_ARG_OPTION_ARG                               ok
-220: parallel test execution                         skipped (autotest.at:1514)
-221: parallel truth                                  skipped (autotest.at:1557)
-222: parallel fallacy                                skipped (autotest.at:1562)
-223: parallel skip                                   skipped (autotest.at:1567)
-224: parallel syntax error                           skipped (autotest.at:1572)
-225: parallel errexit                                skipped (autotest.at:1591)
-226: parallel autotest and signal handling           skipped (autotest.at:1609)
-227: parallel args but non-working mkfifo            skipped (autotest.at:1719)
-228: colored test results                            ok
-229: srcdir propagation                              ok
-230: whitespace in absolute testdir                  ok
-231: unusual file names                              ok
-232: C unit tests                                    ok
-233: C unit tests (EXEEXT)                           ok
-234: Erlang Eunit unit tests                         ok
+120: AT_COPYRIGHT                                    ok
+121: AT_DATA                                         ok
+122: AT_DATA_UNQUOTED                                ok
+123: AT_PREPARE_TESTS                                ok
+124: AT_PREPARE_EACH_TEST                            ok
+125: AT_TEST_HELPER_FN                               ok
+126: Empty test suite                                ok
+127: Banner-only test suite                          ok
+128: Empty test                                      ok
+129: Empty check                                     ok
+130: AT_SETUP without AT_INIT                        ok
+131: AT_BANNER without AT_INIT                       ok
+132: AT_CLEANUP without AT_INIT                      ok
+133: Missing AT_CLEANUP                              ok
+134: AT_FAIL_IF without AT_SETUP                     ok
+135: AT_SKIP_IF without AT_SETUP                     ok
+136: AT_CHECK without AT_SETUP                       ok
+137: AT_DATA without AT_SETUP                        ok
+138: AT_XFAIL_IF without AT_SETUP                    ok
+139: AT_KEYWORDS without AT_SETUP                    ok
+140: AT_CLEANUP without AT_SETUP                     ok
+141: AT_BANNER inside AT_SETUP                       ok
+142: AT_SETUP inside AT_SETUP                        ok
+143: Multiple AT_INIT                                ok
+144: Invalid AT_TEST_HELPER_FN (spaces)              ok
+145: Invalid AT_TEST_HELPER_FN (substitutions)       ok
+146: Multiple AT_TEST_HELPER_FN                      ok
+147: Tested programs                                 ok
+148: Startup error messages                          ok
+149: Truth                                           ok
+150: Fallacy                                         ok
+151: Skip                                            ok
+152: Hard fail                                       ok
+153: AT_FAIL_IF                                      ok
+154: AT_SKIP_IF                                      ok
+155: Syntax error                                    ok
+156: errexit                                         ok
+157: at_status                                       ok
+158: AT_CHECK execution environment                  ok
+159: unquoted output                                 ok
+160: Trace output                                    ok
+161: Logging                                         ok
+162: Binary output                                   ok
+163: Cleanup                                         ok
+164: Literal multiline command                       ok
+165: Multiline parameter expansion                   ok
+166: Backquote command substitution                  ok
+167: Multiline backquote command substitution        ok
+168: Parenthetical command substitution              ok
+169: Multiline parenthetical command substitution    ok
+170: Shell comment in command                        ok
+171: Invalid brace-enclosed parameter expansion      ok
+172: Multiline command from M4 expansion             ok
+173: Double-M4-quoted command                        ok
+174: Metacharacters in command from M4 expansion     ok
+175: BS-newline in command                           ok
+176: ^BS-newline in command                          ok
+177: BSx641-newline in command                       ok
+178: BS-BS-newline in command                        ok
+179: BSx640-newline in command                       ok
+180: Newline-CODE-BS-newline in command              ok
+181: Single-quote-BS-newline in command              ok
+182: Single-quote-newline-BS-newline in command      ok
+183: Input from stdin                                ok
+184: Backquote in a test title                       ok
+185: Single-quote in a test title                    ok
+186: Double-quote in a test title                    ok
+187: Backslash in a test title                       ok
+188: Brackets in a test title                        ok
+189: Left bracket in a test title                    ok
+190: Right bracket in a test title                   ok
+191: Quoted pound in a test title                    ok
+192: Pound in a test title                           ok
+193: Quoted comma in a test title                    ok
+194: Comma in a test title                           ok
+195: Parentheses in a test title                     ok
+196: Left paren in a test title                      ok
+197: Right paren in a test title                     ok
+198: Quoted Macro in a test title                    ok
+199: Macro in a test title                           ok
+200: Macro with backquote in a test title            ok
+201: Macro with single-quote in a test title         ok
+202: Macro with double-quote in a test title         ok
+203: Macro with backslash in a test title            ok
+204: Macro echoing macro in a test title             ok
+205: Macro echoing single-quote in a test title      ok
+206: Long test title in a test title                 ok
+207: Longer test title in a test title               ok
+208: Long test source lines                          ok
+209: Huge testsuite                                  ok
+210: Debugging a successful test                     ok
+211: Debugging script and environment                ok
+212: Debugging a failed test                         ok
+213: Using atlocal                                   ok
+214: Choosing where testsuite is run                 ok
+215: recheck                                         ok
+216: Banners                                         ok
+217: Keywords and ranges                             ok
+218: Keyword wrapping                                ok
+219: AT_ARG_OPTION                                   ok
+220: AT_ARG_OPTION_ARG                               ok
+221: parallel test execution                         skipped (autotest.at:1514)
+222: parallel truth                                  skipped (autotest.at:1557)
+223: parallel fallacy                                skipped (autotest.at:1562)
+224: parallel skip                                   skipped (autotest.at:1567)
+225: parallel syntax error                           skipped (autotest.at:1572)
+226: parallel errexit                                skipped (autotest.at:1591)
+227: parallel autotest and signal handling           skipped (autotest.at:1609)
+228: parallel args but non-working mkfifo            skipped (autotest.at:1719)
+229: colored test results                            ok
+230: srcdir propagation                              ok
+231: whitespace in absolute testdir                  ok
+232: unusual file names                              ok
+233: C unit tests                                    ok
+234: C unit tests (EXEEXT)                           ok
+235: Erlang Eunit unit tests                         ok
 
 Autoconf base layer.
 
-235: AC_REQUIRE: topological sort                    ok
-236: AC_REQUIRE: error message                       ok
-237: AC_REQUIRE & AC_DEFUN_ONCE: Require, expand     ok
-238: AC_REQUIRE & AC_DEFUN_ONCE: Expand, require     ok
-239: AC_REQUIRE & AC_PROVIDE                         ok
-240: AC_INIT                                         ok
-241: AC_INIT (obsolete invocation)                   ok
-242: AC_INIT with unusual version strings            ok
-243: AC_COPYRIGHT                                    ok
-244: AC_CACHE_CHECK                                  ok
-245: AC_CACHE_LOAD                                   ok
-246: AC_COMPUTE_INT                                  ok
-247: AC_TRY_COMMAND                                  ok
-248: Input/Output                                    ok
-249: configure arguments                             ok
-250: AC_ARG_ENABLE and AC_ARG_WITH                   ok
-251: configure directories                           ok
-252: AC_SUBST                                        ok
-253: configure with closed standard fds              ok
+236: AC_REQUIRE: topological sort                    ok
+237: AC_REQUIRE: error message                       ok
+238: AC_REQUIRE & AC_DEFUN_ONCE: Require, expand     ok
+239: AC_REQUIRE & AC_DEFUN_ONCE: Expand, require     ok
+240: AC_REQUIRE & AC_PROVIDE                         ok
+241: AC_INIT                                         ok
+242: AC_INIT (obsolete invocation)                   ok
+243: AC_INIT with unusual version strings            ok
+244: AC_COPYRIGHT                                    ok
+245: AC_CACHE_CHECK                                  ok
+246: AC_CACHE_LOAD                                   ok
+247: AC_COMPUTE_INT                                  ok
+248: AC_TRY_COMMAND                                  ok
+249: Input/Output                                    ok
+250: configure arguments                             ok
+251: AC_ARG_ENABLE and AC_ARG_WITH                   ok
+252: configure directories                           ok
+253: AC_SUBST                                        ok
+254: configure with closed standard fds              ok
 
 Testing config.status.
 
-254: AC_CONFIG_COMMANDS with empty commands          ok
-255: AC_CONFIG_COMMANDS with temporary directory     ok
-256: Multiple AC_CONFIG_FILES                        ok
-257: Parameterized AC_CONFIG_FILES                   ok
-258: AC_ARG_VAR                                      ok
-259: AC_CONFIG_FILES, HEADERS, LINKS and COMMANDS    ok
-260: Macro calls in AC_CONFIG_COMMANDS tags          ok
-261: Missing templates                               ok
-262: configure invocation                            ok
-263: --help and --version in unwritable directory    ok
-264: #define header templates                        ok
-265: Torturing config.status                         ok
-266: Substitute a 2000-byte string                   ok
-267: Define to a 2000-byte string                    ok
-268: Substitute and define special characters        ok
-269: Substitute a newline                            ok
-270: Define a newline                                ok
-271: AC_SUBST: variable name validation              ok
-272: datarootdir workaround                          ok
-273: srcdir                                          ok
-274: VPATH                                           ok
-275: Signal handling                                 ok
-276: AC_CONFIG_LINKS                                 ok
-277: AC_CONFIG_LINKS and identical files             ok
+255: AC_CONFIG_COMMANDS with empty commands          ok
+256: AC_CONFIG_COMMANDS with temporary directory     ok
+257: Multiple AC_CONFIG_FILES                        ok
+258: Parameterized AC_CONFIG_FILES                   ok
+259: AC_ARG_VAR                                      ok
+260: AC_CONFIG_FILES, HEADERS, LINKS and COMMANDS    FAILED (torture.at:324)
+261: Macro calls in AC_CONFIG_COMMANDS tags          ok
+262: Missing templates                               ok
+263: configure invocation                            ok
+264: --help and --version in unwritable directory    ok
+265: #define header templates                        ok
+266: Torturing config.status                         ok
+267: Substitute a 2000-byte string                   ok
+268: Define to a 2000-byte string                    ok
+269: Substitute and define special characters        ok
+270: Substitute a newline                            ok
+271: Define a newline                                ok
+272: AC_SUBST: variable name validation              ok
+273: datarootdir workaround                          ok
+274: srcdir                                          ok
+275: VPATH                                           ok
+276: Signal handling                                 ok
+277: AC_CONFIG_LINKS                                 ok
+278: AC_CONFIG_LINKS and identical files             ok
 
 autoreconf.
 
-278: Configuring subdirectories                      ok
-279: Deep Package                                    ok
-280: Non-Autoconf AC_CONFIG_SUBDIRS                  ok
-281: Non-literal AC_CONFIG_SUBDIRS                   ok
-282: Empty AC_CONFIG_SUBDIRS                         ok
-283: Empty directory                                 ok
-284: Unusual Automake input files                    ok
-285: Specific warnings options for autoreconf        ok
-286: Missing auxiliary files (config.*)              ok
-287: Missing auxiliary files (install-sh)            ok
-288: Missing auxiliary files (foreign)               ok
-289: Missing auxiliary files (--force)               ok
-290: Files clobbered by AC_OPENMP                    ok
+279: Configuring subdirectories                      ok
+280: Deep Package                                    ok
+281: Non-Autoconf AC_CONFIG_SUBDIRS                  ok
+282: Non-literal AC_CONFIG_SUBDIRS                   ok
+283: Empty AC_CONFIG_SUBDIRS                         ok
+284: Empty directory                                 ok
+285: Unusual Automake input files                    ok
+286: Specific warnings options for autoreconf        ok
+287: Missing auxiliary files (config.*)              ok
+288: Missing auxiliary files (install-sh)            ok
+289: Missing auxiliary files (foreign)               ok
+290: Missing auxiliary files (--force)               ok
+291: Files clobbered by AC_OPENMP                    ok
 
 Low level compiling/preprocessing macros.
 
-291: AC_LANG, AC_LANG_PUSH & AC_LANG_POP             ok
-292: AC_REQUIRE & AC_LANG                            ok
-293: AC_LANG_SOURCE                                  ok
-294: AC_LANG_SOURCE(C++)                             ok
-295: AC_LANG_SOURCE example                          ok
-296: AC_LANG_PROGRAM example                         ok
-297: AC_COMPILE_IFELSE                               ok
-298: AC_RUN_IFELSE                                   ok
-299: Order of user actions and cleanup               ok
-300: AC_TRY_LINK_FUNC                                ok
-301: Multiple languages                              ok
+292: AC_LANG, AC_LANG_PUSH & AC_LANG_POP             ok
+293: AC_REQUIRE & AC_LANG                            ok
+294: AC_LANG_SOURCE                                  ok
+295: AC_LANG_SOURCE(C++)                             ok
+296: AC_LANG_SOURCE example                          ok
+297: AC_LANG_PROGRAM example                         ok
+298: AC_COMPILE_IFELSE                               ok
+299: AC_RUN_IFELSE                                   ok
+300: Order of user actions and cleanup               ok
+301: AC_TRY_LINK_FUNC                                ok
+302: Multiple languages                              ok
 
 Testing autoconf/lang macros.
 
-302: AC_NO_EXECUTABLES                               ok
-303: AC_REQUIRE_CPP                                  ok
+303: AC_NO_EXECUTABLES                               ok
+304: AC_REQUIRE_CPP                                  ok
 
 C low level compiling/preprocessing macros.
 
-304: Object file extensions                          ok
-305: Broken/missing compilers                        ok
-306: C keywords                                      ok
-307: AC_PROG_CPP requires AC_PROG_CC                 ok
-308: AC_PROG_CPP with warnings                       ok
-309: AC_PROG_CPP without warnings                    ok
-310: AC_PROG_CPP via CC                              ok
-311: AC_NO_EXECUTABLES (working linker)              ok
-312: AC_NO_EXECUTABLES (broken linker)               ok
-313: AC_USE_SYSTEM_EXTENSIONS                        ok
-314: AC_C_RESTRICT and C++                           ok
-315: AC_OPENMP and C                                 ok
-316: AC_OPENMP and C++                               ok
+305: Object file extensions                          ok
+306: Broken/missing compilers                        ok
+307: C keywords                                      ok
+308: AC_PROG_CPP requires AC_PROG_CC                 ok
+309: AC_PROG_CPP with warnings                       ok
+310: AC_PROG_CPP without warnings                    ok
+311: AC_PROG_CPP via CC                              ok
+312: AC_NO_EXECUTABLES (working linker)              ok
+313: AC_NO_EXECUTABLES (broken linker)               ok
+314: AC_USE_SYSTEM_EXTENSIONS                        ok
+315: AC_C_RESTRICT and C++                           ok
+316: AC_OPENMP and C                                 ok
+317: AC_OPENMP and C++                               ok
 
 Testing autoconf/c macros.
 
-317: AC_C_BACKSLASH_A                                ok
-318: AC_C_BIGENDIAN                                  ok
-319: AC_C_CHAR_UNSIGNED                              ok
-320: AC_C_FLEXIBLE_ARRAY_MEMBER                      ok
-321: AC_C_INLINE                                     ok
-322: AC_C_PROTOTYPES                                 ok
-323: AC_C_RESTRICT                                   ok
-324: AC_C_STRINGIZE                                  ok
-325: AC_C_TYPEOF                                     ok
-326: AC_C_VARARRAYS                                  ok
-327: AC_C__GENERIC                                   ok
-328: AC_OPENMP                                       ok
-329: AC_PROG_CC_C_O                                  ok
-330: AC_PROG_CPP_WERROR                              ok
-331: AC_PROG_GCC_TRADITIONAL                         ok
-332: AC_LANG_C                                       ok
-333: autoupdating AC_LANG_C                          ok
-334: AC_LANG_CPLUSPLUS                               ok
-335: autoupdating AC_LANG_CPLUSPLUS                  ok
-336: AC_LANG_OBJC                                    ok
-337: autoupdating AC_LANG_OBJC                       ok
+318: AC_C_BACKSLASH_A                                ok
+319: AC_C_BIGENDIAN                                  ok
+320: AC_C_CHAR_UNSIGNED                              ok
+321: AC_C_FLEXIBLE_ARRAY_MEMBER                      ok
+322: AC_C_INLINE                                     ok
+323: AC_C_PROTOTYPES                                 ok
+324: AC_C_RESTRICT                                   ok
+325: AC_C_STRINGIZE                                  ok
+326: AC_C_TYPEOF                                     ok
+327: AC_C_VARARRAYS                                  ok
+328: AC_C__GENERIC                                   ok
+329: AC_OPENMP                                       ok
+330: AC_PROG_CC_C_O                                  ok
+331: AC_PROG_CPP_WERROR                              ok
+332: AC_PROG_GCC_TRADITIONAL                         ok
+333: AC_LANG_C                                       ok
+334: autoupdating AC_LANG_C                          ok
+335: AC_LANG_CPLUSPLUS                               ok
+336: autoupdating AC_LANG_CPLUSPLUS                  ok
+337: AC_LANG_OBJC                                    ok
+338: autoupdating AC_LANG_OBJC                       ok
 
 Fortran low level compiling/preprocessing macros.
 
-338: GNU Fortran 77                                  ok
-339: GNU Fortran                                     ok
-340: AC_OPENMP and Fortran 77                        ok
-341: AC_OPENMP and Fortran                           ok
-342: AC_F77_DUMMY_MAIN usage                         ok
-343: AC_FC_DUMMY_MAIN usage                          ok
-344: AC_F77_MAIN usage                               ok
-345: AC_FC_MAIN usage                                ok
-346: AC_F77_FUNC usage                               ok
-347: AC_FC_FUNC usage                                ok
-348: AC_FC_SRCEXT usage                              ok
-349: AC_FC_PP_SRCEXT usage                           ok
-350: AC_FC_FREEFORM                                  ok
-351: AC_FC_FREEFORM with AC_FC_SRCEXT                ok
-352: AC_FC_FIXEDFORM                                 ok
-353: AC_FC_FIXEDFORM with AC_FC_SRCEXT               ok
-354: AC_FC_LINE_LENGTH                               ok
-355: AC_FC_CHECK_BOUNDS                              ok
-356: AC_FC_MODULE_FLAG                               ok
+339: GNU Fortran 77                                  ok
+340: GNU Fortran                                     ok
+341: AC_OPENMP and Fortran 77                        ok
+342: AC_OPENMP and Fortran                           ok
+343: AC_F77_DUMMY_MAIN usage                         ok
+344: AC_FC_DUMMY_MAIN usage                          ok
+345: AC_F77_MAIN usage                               ok
+346: AC_FC_MAIN usage                                ok
+347: AC_F77_FUNC usage                               ok
+348: AC_FC_FUNC usage                                ok
+349: AC_FC_SRCEXT usage                              ok
+350: AC_FC_PP_SRCEXT usage                           ok
+351: AC_FC_FREEFORM                                  ok
+352: AC_FC_FREEFORM with AC_FC_SRCEXT                ok
+353: AC_FC_FIXEDFORM                                 ok
+354: AC_FC_FIXEDFORM with AC_FC_SRCEXT               ok
+355: AC_FC_LINE_LENGTH                               ok
+356: AC_FC_CHECK_BOUNDS                              ok
+357: AC_FC_MODULE_FLAG                               ok
 
 Testing autoconf/fortran macros.
 
-357: AC_F77_IMPLICIT_NONE                            ok
-358: AC_F77_MAIN                                     ok
-359: AC_F77_WRAPPERS                                 ok
-360: AC_FC_CHECK_BOUNDS                              ok
-361: AC_FC_FIXEDFORM                                 ok
-362: AC_FC_FREEFORM                                  ok
-363: AC_FC_IMPLICIT_NONE                             ok
-364: AC_FC_LINE_LENGTH                               ok
-365: AC_FC_MAIN                                      ok
-366: AC_FC_MODULE_EXTENSION                          ok
-367: AC_FC_MODULE_FLAG                               ok
-368: AC_FC_MODULE_OUTPUT_FLAG                        ok
-369: AC_FC_PP_DEFINE                                 ok
-370: AC_FC_WRAPPERS                                  ok
-371: AC_PROG_F77_C_O                                 ok
-372: AC_PROG_FC_C_O                                  ok
-373: AC_F77_NAME_MANGLING                            ok
-374: autoupdating AC_F77_NAME_MANGLING               ok
-375: AC_LANG_FORTRAN77                               ok
-376: autoupdating AC_LANG_FORTRAN77                  ok
+358: AC_F77_IMPLICIT_NONE                            ok
+359: AC_F77_MAIN                                     ok
+360: AC_F77_WRAPPERS                                 ok
+361: AC_FC_CHECK_BOUNDS                              ok
+362: AC_FC_FIXEDFORM                                 ok
+363: AC_FC_FREEFORM                                  ok
+364: AC_FC_IMPLICIT_NONE                             ok
+365: AC_FC_LINE_LENGTH                               ok
+366: AC_FC_MAIN                                      ok
+367: AC_FC_MODULE_EXTENSION                          ok
+368: AC_FC_MODULE_FLAG                               ok
+369: AC_FC_MODULE_OUTPUT_FLAG                        ok
+370: AC_FC_PP_DEFINE                                 ok
+371: AC_FC_WRAPPERS                                  ok
+372: AC_PROG_F77_C_O                                 ok
+373: AC_PROG_FC_C_O                                  ok
+374: AC_F77_NAME_MANGLING                            ok
+375: autoupdating AC_F77_NAME_MANGLING               ok
+376: AC_LANG_FORTRAN77                               ok
+377: autoupdating AC_LANG_FORTRAN77                  ok
 
 Erlang low level compiling and utility macros.
 
-377: Erlang basic compilation                        skipped (erlang.at:36)
-378: AC_ERLANG_CHECK_LIB                             skipped (erlang.at:66)
-379: AC_ERLANG_SUBST_ROOT_DIR                        skipped (erlang.at:82)
-380: AC_ERLANG_SUBST_LIB_DIR                         skipped (erlang.at:95)
-381: AC_ERLANG_SUBST_INSTALL_LIB_SUBDIR              ok
+378: Erlang basic compilation                        skipped (erlang.at:36)
+379: AC_ERLANG_CHECK_LIB                             skipped (erlang.at:66)
+380: AC_ERLANG_SUBST_ROOT_DIR                        skipped (erlang.at:82)
+381: AC_ERLANG_SUBST_LIB_DIR                         skipped (erlang.at:95)
+382: AC_ERLANG_SUBST_INSTALL_LIB_SUBDIR              ok
 
 Testing autoconf/erlang macros.
 
-382: AC_ERLANG_PATH_ERL                              ok
-383: AC_ERLANG_PATH_ERLC                             ok
-384: AC_ERLANG_SUBST_ERTS_VER                        skipped (acerlang.at:10)
-385: AC_ERLANG_SUBST_LIB_DIR                         skipped (acerlang.at:11)
-386: AC_LANG_ERLANG                                  ok
-387: autoupdating AC_LANG_ERLANG                     ok
+383: AC_ERLANG_PATH_ERL                              ok
+384: AC_ERLANG_PATH_ERLC                             ok
+385: AC_ERLANG_SUBST_ERTS_VER                        skipped (acerlang.at:10)
+386: AC_ERLANG_SUBST_LIB_DIR                         skipped (acerlang.at:11)
+387: AC_LANG_ERLANG                                  ok
+388: autoupdating AC_LANG_ERLANG                     ok
 
 Go low level compiling and utility macros.
 
-388: Go                                              ok
+389: Go                                              ok
 
 Testing autoconf/go macros.
 
-389: AC_LANG_GO                                      ok
-390: autoupdating AC_LANG_GO                         ok
+390: AC_LANG_GO                                      ok
+391: autoupdating AC_LANG_GO                         ok
 
 Semantics.
 
-391: AC_CHECK_LIB                                    ok
-392: AC_SEARCH_LIBS (needed)                         ok
-393: AC_SEARCH_LIBS (none needed)                    ok
-394: AC_CHECK_DECLS                                  ok
-395: AC_CHECK_FUNCS                                  ok
-396: AC_REPLACE_FUNCS                                ok
-397: AC_CHECK_HEADERS                                ok
-398: AC_CHECK_HEADERS (preprocessor test)            ok
-399: AC_CHECK_HEADERS (compiler test)                ok
-400: AC_CHECK_MEMBER                                 ok
-401: AC_CHECK_MEMBERS                                ok
-402: AC_CHECK_ALIGNOF                                ok
-403: AC_CHECK_ALIGNOF struct                         ok
-404: AC_CHECK_SIZEOF                                 ok
-405: AC_CHECK_SIZEOF struct                          ok
-406: AC_CHECK_TYPES                                  ok
-407: AC_CHECK_TYPES: backward compatibility          ok
-408: AC_CHECK_FILES                                  ok
-409: AC_CHECK_PROG & AC_CHECK_PROGS                  ok
-410: AC_C_BIGENDIAN                                  ok
-411: AC_PATH_PROG & AC_PATH_PROGS                    ok
-412: AC_PATH_PROGS_FEATURE_CHECK                     ok
-413: AC_PATH_XTRA                                    ok
-414: AC_SYS_RESTARTABLE_SYSCALLS                     ok
-415: AC_FUNC_SETVBUF_REVERSED                        ok
-416: AC_FUNC_WAIT3                                   ok
-417: AC_TRY_CPP                                      ok
-418: autoupdating AC_TRY_CPP                         ok
-419: AC_TRY_COMPILE                                  ok
-420: autoupdating AC_TRY_COMPILE                     ok
-421: AC_TRY_LINK                                     ok
-422: autoupdating AC_TRY_LINK                        ok
-423: AC_COMPILE_CHECK                                ok
-424: autoupdating AC_COMPILE_CHECK                   ok
-425: AC_TRY_RUN                                      ok
-426: autoupdating AC_TRY_RUN                         ok
-427: AC_HAVE_LIBRARY                                 ok
-428: autoupdating AC_HAVE_LIBRARY                    ok
-429: Macro expansion in AC_CHECK_FUNCS (literal)     ok
-430: Macro expansion in AC_CHECK_FUNCS (variable)    ok
-431: Macro expansion in AC_CHECK_FUNCS_ONCE          ok
-432: Macro expansion in AC_REPLACE_FUNCS (literal)   ok
-433: Macro expansion in AC_REPLACE_FUNCS (variable)  ok
-434: Macro expansion in AC_CHECK_HEADERS (literal)   ok
-435: Macro expansion in AC_CHECK_HEADERS (variable)  ok
-436: Macro expansion in AC_CHECK_HEADERS_ONCE        ok
-437: Macro expansion in AC_CHECK_FILES               ok
-438: Macro expansion in AC_CONFIG_MACRO_DIRS         ok
-439: Macro expansion in AC_CONFIG_SUBDIRS            ok
-440: AC_PROG_LEX with noyywrap                       ok
-441: AC_PROG_LEX with yywrap                         ok
-442: AC_PROG_LEX in legacy mode                      ok
-443: Invalid arguments to AC_PROG_LEX                ok
+392: AC_CHECK_LIB                                    ok
+393: AC_SEARCH_LIBS (needed)                         ok
+394: AC_SEARCH_LIBS (none needed)                    ok
+395: AC_CHECK_DECLS                                  ok
+396: AC_CHECK_FUNCS                                  ok
+397: AC_REPLACE_FUNCS                                ok
+398: AC_CHECK_HEADERS                                ok
+399: AC_CHECK_HEADERS (preprocessor test)            ok
+400: AC_CHECK_HEADERS (compiler test)                ok
+401: AC_CHECK_MEMBER                                 ok
+402: AC_CHECK_MEMBERS                                ok
+403: AC_CHECK_ALIGNOF                                ok
+404: AC_CHECK_ALIGNOF struct                         ok
+405: AC_CHECK_SIZEOF                                 ok
+406: AC_CHECK_SIZEOF struct                          ok
+407: AC_CHECK_TYPES                                  ok
+408: AC_CHECK_TYPES: backward compatibility          ok
+409: AC_CHECK_FILES                                  ok
+410: AC_CHECK_PROG & AC_CHECK_PROGS                  ok
+411: AC_C_BIGENDIAN                                  ok
+412: AC_PATH_PROG & AC_PATH_PROGS                    ok
+413: AC_PATH_PROGS_FEATURE_CHECK                     ok
+414: AC_PATH_XTRA                                    ok
+415: AC_SYS_RESTARTABLE_SYSCALLS                     ok
+416: AC_FUNC_SETVBUF_REVERSED                        ok
+417: AC_FUNC_WAIT3                                   ok
+418: AC_TRY_CPP                                      ok
+419: autoupdating AC_TRY_CPP                         ok
+420: AC_TRY_COMPILE                                  ok
+421: autoupdating AC_TRY_COMPILE                     ok
+422: AC_TRY_LINK                                     ok
+423: autoupdating AC_TRY_LINK                        ok
+424: AC_COMPILE_CHECK                                ok
+425: autoupdating AC_COMPILE_CHECK                   ok
+426: AC_TRY_RUN                                      ok
+427: autoupdating AC_TRY_RUN                         ok
+428: AC_HAVE_LIBRARY                                 ok
+429: autoupdating AC_HAVE_LIBRARY                    ok
+430: Macro expansion in AC_CHECK_FUNCS (literal)     ok
+431: Macro expansion in AC_CHECK_FUNCS (variable)    ok
+432: Macro expansion in AC_CHECK_FUNCS_ONCE          ok
+433: Macro expansion in AC_REPLACE_FUNCS (literal)   ok
+434: Macro expansion in AC_REPLACE_FUNCS (variable)  ok
+435: Macro expansion in AC_CHECK_HEADERS (literal)   ok
+436: Macro expansion in AC_CHECK_HEADERS (variable)  ok
+437: Macro expansion in AC_CHECK_HEADERS_ONCE        ok
+438: Macro expansion in AC_CHECK_FILES               ok
+439: Macro expansion in AC_CONFIG_MACRO_DIRS         ok
+440: Macro expansion in AC_CONFIG_SUBDIRS            ok
+441: AC_PROG_LEX with noyywrap                       ok
+442: AC_PROG_LEX with yywrap                         ok
+443: AC_PROG_LEX in legacy mode                      ok
+444: Invalid arguments to AC_PROG_LEX                ok
 
 Testing autoconf/general macros.
 
-444: AC_ARG_ENABLE                                   ok
-445: AC_ARG_PROGRAM                                  ok
-446: AC_ARG_WITH                                     ok
-447: AC_CHECK_DECLS_ONCE                             ok
-448: AC_EGREP_CPP                                    ok
-449: AC_EGREP_HEADER                                 ok
-450: AC_LIBOBJ                                       ok
-451: AC_LIBSOURCES                                   ok
-452: AC_PREFIX_DEFAULT                               ok
-453: AC_REQUIRE_AUX_FILE                             ok
-454: AC_CHECKING                                     ok
-455: autoupdating AC_CHECKING                        ok
-456: AC_ENABLE                                       ok
-457: autoupdating AC_ENABLE                          ok
-458: AC_MSG_RESULT_UNQUOTED                          ok
-459: autoupdating AC_MSG_RESULT_UNQUOTED             ok
-460: AC_VALIDATE_CACHED_SYSTEM_TUPLE                 ok
-461: autoupdating AC_VALIDATE_CACHED_SYSTEM_TUPLE    ok
-462: AC_WITH                                         ok
-463: autoupdating AC_WITH                            ok
-464: _AC_COMPUTE_INT                                 ok
-465: autoupdating _AC_COMPUTE_INT                    ok
+445: AC_ARG_ENABLE                                   ok
+446: AC_ARG_PROGRAM                                  ok
+447: AC_ARG_WITH                                     ok
+448: AC_CHECK_DECLS_ONCE                             ok
+449: AC_EGREP_CPP                                    ok
+450: AC_EGREP_HEADER                                 ok
+451: AC_LIBOBJ                                       ok
+452: AC_LIBSOURCES                                   ok
+453: AC_PREFIX_DEFAULT                               ok
+454: AC_REQUIRE_AUX_FILE                             ok
+455: AC_CHECKING                                     ok
+456: autoupdating AC_CHECKING                        ok
+457: AC_ENABLE                                       ok
+458: autoupdating AC_ENABLE                          ok
+459: AC_MSG_RESULT_UNQUOTED                          ok
+460: autoupdating AC_MSG_RESULT_UNQUOTED             ok
+461: AC_VALIDATE_CACHED_SYSTEM_TUPLE                 ok
+462: autoupdating AC_VALIDATE_CACHED_SYSTEM_TUPLE    ok
+463: AC_WITH                                         ok
+464: autoupdating AC_WITH                            ok
+465: _AC_COMPUTE_INT                                 ok
+466: autoupdating _AC_COMPUTE_INT                    ok
 
 Testing autoconf/status macros.
 
-466: AC_OUTPUT_COMMANDS                              ok
-467: autoupdating AC_OUTPUT_COMMANDS                 ok
+467: AC_OUTPUT_COMMANDS                              ok
+468: autoupdating AC_OUTPUT_COMMANDS                 ok
 
 Testing autoconf/specific macros.
 
-468: AC_SYS_INTERPRETER                              ok
-469: AC_SYS_LARGEFILE                                ok
-470: AC_SYS_LONG_FILE_NAMES                          ok
-471: AC_SYS_POSIX_TERMIOS                            ok
-472: AC_AIX                                          ok
-473: autoupdating AC_AIX                             ok
-474: AC_ARG_ARRAY                                    ok
-475: autoupdating AC_ARG_ARRAY                       ok
-476: AC_DECL_SYS_SIGLIST                             ok
-477: autoupdating AC_DECL_SYS_SIGLIST                ok
-478: AC_DYNIX_SEQ                                    ok
-479: autoupdating AC_DYNIX_SEQ                       ok
-480: AC_HAVE_POUNDBANG                               ok
-481: autoupdating AC_HAVE_POUNDBANG                  ok
-482: AC_IRIX_SUN                                     ok
-483: autoupdating AC_IRIX_SUN                        ok
-484: AC_ISC_POSIX                                    ok
-485: autoupdating AC_ISC_POSIX                       ok
-486: AC_MINIX                                        ok
-487: autoupdating AC_MINIX                           ok
-488: AC_SCO_INTL                                     ok
-489: autoupdating AC_SCO_INTL                        ok
-490: AC_XENIX_DIR                                    ok
-491: autoupdating AC_XENIX_DIR                       ok
+469: AC_SYS_INTERPRETER                              ok
+470: AC_SYS_LARGEFILE                                ok
+471: AC_SYS_LONG_FILE_NAMES                          ok
+472: AC_SYS_POSIX_TERMIOS                            ok
+473: AC_AIX                                          ok
+474: autoupdating AC_AIX                             ok
+475: AC_ARG_ARRAY                                    ok
+476: autoupdating AC_ARG_ARRAY                       ok
+477: AC_DECL_SYS_SIGLIST                             ok
+478: autoupdating AC_DECL_SYS_SIGLIST                ok
+479: AC_DYNIX_SEQ                                    ok
+480: autoupdating AC_DYNIX_SEQ                       ok
+481: AC_HAVE_POUNDBANG                               ok
+482: autoupdating AC_HAVE_POUNDBANG                  ok
+483: AC_IRIX_SUN                                     ok
+484: autoupdating AC_IRIX_SUN                        ok
+485: AC_ISC_POSIX                                    ok
+486: autoupdating AC_ISC_POSIX                       ok
+487: AC_MINIX                                        ok
+488: autoupdating AC_MINIX                           ok
+489: AC_SCO_INTL                                     ok
+490: autoupdating AC_SCO_INTL                        ok
+491: AC_XENIX_DIR                                    ok
+492: autoupdating AC_XENIX_DIR                       ok
 
 Testing autoconf/programs macros.
 
-492: AC_PROG_AWK                                     ok
-493: AC_PROG_FGREP                                   ok
-494: AC_PROG_INSTALL                                 ok
-495: AC_PROG_LN_S                                    ok
-496: AC_PROG_MAKE_SET                                ok
-497: AC_PROG_MKDIR_P                                 ok
-498: AC_PROG_RANLIB                                  ok
-499: AC_PROG_SED                                     ok
-500: AC_PROG_YACC                                    ok
-501: AC_CHECK_TOOL_PREFIX                            ok
-502: autoupdating AC_CHECK_TOOL_PREFIX               ok
-503: AC_DECL_YYTEXT                                  ok
-504: autoupdating AC_DECL_YYTEXT                     ok
-505: AC_RSH                                          ok
-506: autoupdating AC_RSH                             ok
+493: AC_PROG_AWK                                     ok
+494: AC_PROG_FGREP                                   ok
+495: AC_PROG_INSTALL                                 ok
+496: AC_PROG_LN_S                                    ok
+497: AC_PROG_MAKE_SET                                ok
+498: AC_PROG_MKDIR_P                                 ok
+499: AC_PROG_RANLIB                                  ok
+500: AC_PROG_SED                                     ok
+501: AC_PROG_YACC                                    ok
+502: AC_CHECK_TOOL_PREFIX                            ok
+503: autoupdating AC_CHECK_TOOL_PREFIX               ok
+504: AC_DECL_YYTEXT                                  ok
+505: autoupdating AC_DECL_YYTEXT                     ok
+506: AC_RSH                                          ok
+507: autoupdating AC_RSH                             ok
 
 Testing autoconf/headers macros.
 
-507: AC_CHECK_HEADERS_ONCE                           ok
-508: AC_CHECK_HEADER_STDBOOL                         ok
-509: AC_HEADER_ASSERT                                ok
-510: AC_HEADER_MAJOR                                 ok
-511: AC_HEADER_RESOLV                                ok
-512: AC_HEADER_STAT                                  ok
-513: AC_HEADER_STDBOOL                               ok
-514: AC_HEADER_TIOCGWINSZ                            ok
-515: AC_DIR_HEADER                                   ok
-516: autoupdating AC_DIR_HEADER                      ok
-517: AC_HEADER_STDC                                  ok
-518: autoupdating AC_HEADER_STDC                     ok
-519: AC_HEADER_TIME                                  ok
-520: autoupdating AC_HEADER_TIME                     ok
-521: AC_MEMORY_H                                     ok
-522: autoupdating AC_MEMORY_H                        ok
-523: AC_UNISTD_H                                     ok
-524: autoupdating AC_UNISTD_H                        ok
-525: AC_USG                                          ok
-526: autoupdating AC_USG                             ok
-527: _AC_CHECK_HEADER_MONGREL                        ok
-528: autoupdating _AC_CHECK_HEADER_MONGREL           ok
+508: AC_CHECK_HEADERS_ONCE                           ok
+509: AC_CHECK_HEADER_STDBOOL                         ok
+510: AC_HEADER_ASSERT                                ok
+511: AC_HEADER_MAJOR                                 ok
+512: AC_HEADER_RESOLV                                ok
+513: AC_HEADER_STAT                                  ok
+514: AC_HEADER_STDBOOL                               ok
+515: AC_HEADER_TIOCGWINSZ                            ok
+516: AC_DIR_HEADER                                   ok
+517: autoupdating AC_DIR_HEADER                      ok
+518: AC_HEADER_STDC                                  ok
+519: autoupdating AC_HEADER_STDC                     ok
+520: AC_HEADER_TIME                                  ok
+521: autoupdating AC_HEADER_TIME                     ok
+522: AC_MEMORY_H                                     ok
+523: autoupdating AC_MEMORY_H                        ok
+524: AC_UNISTD_H                                     ok
+525: autoupdating AC_UNISTD_H                        ok
+526: AC_USG                                          ok
+527: autoupdating AC_USG                             ok
+528: _AC_CHECK_HEADER_MONGREL                        ok
+529: autoupdating _AC_CHECK_HEADER_MONGREL           ok
 
 Testing autoconf/types macros.
 
-529: AC_STRUCT_DIRENT_D_INO                          ok
-530: AC_STRUCT_DIRENT_D_TYPE                         ok
-531: AC_STRUCT_ST_BLOCKS                             ok
-532: AC_STRUCT_TIMEZONE                              ok
-533: AC_TYPE_INT16_T                                 ok
-534: AC_TYPE_INT32_T                                 ok
-535: AC_TYPE_INT64_T                                 ok
-536: AC_TYPE_INT8_T                                  ok
-537: AC_TYPE_INTMAX_T                                FAILED (actypes.at:16)
-538: AC_TYPE_INTPTR_T                                ok
-539: AC_TYPE_LONG_DOUBLE                             ok
-540: AC_TYPE_LONG_DOUBLE_WIDER                       ok
-541: AC_TYPE_MODE_T                                  ok
-542: AC_TYPE_OFF_T                                   ok
-543: AC_TYPE_SSIZE_T                                 ok
-544: AC_TYPE_UINT16_T                                ok
-545: AC_TYPE_UINT32_T                                ok
-546: AC_TYPE_UINT64_T                                ok
-547: AC_TYPE_UINT8_T                                 ok
-548: AC_TYPE_UINTMAX_T                               ok
-549: AC_TYPE_UINTPTR_T                               ok
-550: AC_C_LONG_DOUBLE                                ok
-551: autoupdating AC_C_LONG_DOUBLE                   ok
-552: AC_INT_16_BITS                                  ok
-553: autoupdating AC_INT_16_BITS                     ok
-554: AC_LONG_64_BITS                                 ok
-555: autoupdating AC_LONG_64_BITS                    ok
-556: AC_STRUCT_ST_BLKSIZE                            ok
-557: autoupdating AC_STRUCT_ST_BLKSIZE               ok
-558: AC_STRUCT_ST_RDEV                               ok
-559: autoupdating AC_STRUCT_ST_RDEV                  ok
-560: AC_TYPE_SIGNAL                                  ok
-561: autoupdating AC_TYPE_SIGNAL                     ok
-562: AM_TYPE_PTRDIFF_T                               ok
-563: autoupdating AM_TYPE_PTRDIFF_T                  ok
+530: AC_STRUCT_DIRENT_D_INO                          ok
+531: AC_STRUCT_DIRENT_D_TYPE                         ok
+532: AC_STRUCT_ST_BLOCKS                             ok
+533: AC_STRUCT_TIMEZONE                              ok
+534: AC_TYPE_INT16_T                                 ok
+535: AC_TYPE_INT32_T                                 ok
+536: AC_TYPE_INT64_T                                 ok
+537: AC_TYPE_INT8_T                                  ok
+538: AC_TYPE_INTMAX_T                                ok
+539: AC_TYPE_INTPTR_T                                ok
+540: AC_TYPE_LONG_DOUBLE                             ok
+541: AC_TYPE_LONG_DOUBLE_WIDER                       ok
+542: AC_TYPE_MODE_T                                  ok
+543: AC_TYPE_OFF_T                                   ok
+544: AC_TYPE_SSIZE_T                                 ok
+545: AC_TYPE_UINT16_T                                ok
+546: AC_TYPE_UINT32_T                                ok
+547: AC_TYPE_UINT64_T                                ok
+548: AC_TYPE_UINT8_T                                 ok
+549: AC_TYPE_UINTMAX_T                               ok
+550: AC_TYPE_UINTPTR_T                               ok
+551: AC_C_LONG_DOUBLE                                ok
+552: autoupdating AC_C_LONG_DOUBLE                   ok
+553: AC_INT_16_BITS                                  ok
+554: autoupdating AC_INT_16_BITS                     ok
+555: AC_LONG_64_BITS                                 ok
+556: autoupdating AC_LONG_64_BITS                    ok
+557: AC_STRUCT_ST_BLKSIZE                            ok
+558: autoupdating AC_STRUCT_ST_BLKSIZE               ok
+559: AC_STRUCT_ST_RDEV                               ok
+560: autoupdating AC_STRUCT_ST_RDEV                  ok
+561: AC_TYPE_SIGNAL                                  ok
+562: autoupdating AC_TYPE_SIGNAL                     ok
+563: AM_TYPE_PTRDIFF_T                               ok
+564: autoupdating AM_TYPE_PTRDIFF_T                  ok
 
 Testing autoconf/functions macros.
 
-564: AC_CHECK_FUNCS_ONCE                             ok
-565: AC_FUNC_CHOWN                                   ok
-566: AC_FUNC_CLOSEDIR_VOID                           ok
-567: AC_FUNC_ERROR_AT_LINE                           ok
-568: AC_FUNC_FNMATCH                                 ok
-569: AC_FUNC_FORK                                    ok
-570: AC_FUNC_FSEEKO                                  ok
-571: AC_FUNC_GETGROUPS                               ok
-572: AC_FUNC_GETMNTENT                               ok
-573: AC_FUNC_GETPGRP                                 ok
-574: AC_FUNC_LSTAT                                   ok
-575: AC_FUNC_MALLOC                                  ok
-576: AC_FUNC_MBRTOWC                                 ok
-577: AC_FUNC_MEMCMP                                  ok
-578: AC_FUNC_MKTIME                                  ok
-579: AC_FUNC_MMAP                                    ok
-580: AC_FUNC_OBSTACK                                 ok
-581: AC_FUNC_REALLOC                                 ok
-582: AC_FUNC_SELECT_ARGTYPES                         ok
-583: AC_FUNC_SETPGRP                                 ok
-584: AC_FUNC_STAT                                    ok
-585: AC_FUNC_STRCOLL                                 ok
-586: AC_FUNC_STRERROR_R                              ok
-587: AC_FUNC_STRFTIME                                ok
-588: AC_FUNC_STRNLEN                                 ok
-589: AC_FUNC_STRTOD                                  ok
-590: AC_FUNC_STRTOLD                                 ok
-591: AC_FUNC_UTIME_NULL                              ok
-592: AC_FUNC_VPRINTF                                 ok
+565: AC_CHECK_FUNCS_ONCE                             ok
+566: AC_FUNC_CHOWN                                   ok
+567: AC_FUNC_CLOSEDIR_VOID                           ok
+568: AC_FUNC_ERROR_AT_LINE                           ok
+569: AC_FUNC_FNMATCH                                 ok
+570: AC_FUNC_FORK                                    ok
+571: AC_FUNC_FSEEKO                                  ok
+572: AC_FUNC_GETGROUPS                               ok
+573: AC_FUNC_GETMNTENT                               ok
+574: AC_FUNC_GETPGRP                                 ok
+575: AC_FUNC_LSTAT                                   ok
+576: AC_FUNC_MALLOC                                  ok
+577: AC_FUNC_MBRTOWC                                 ok
+578: AC_FUNC_MEMCMP                                  ok
+579: AC_FUNC_MKTIME                                  ok
+580: AC_FUNC_MMAP                                    ok
+581: AC_FUNC_OBSTACK                                 ok
+582: AC_FUNC_REALLOC                                 ok
+583: AC_FUNC_SELECT_ARGTYPES                         ok
+584: AC_FUNC_SETPGRP                                 ok
+585: AC_FUNC_STAT                                    ok
+586: AC_FUNC_STRCOLL                                 ok
+587: AC_FUNC_STRERROR_R                              ok
+588: AC_FUNC_STRFTIME                                ok
+589: AC_FUNC_STRNLEN                                 ok
+590: AC_FUNC_STRTOD                                  ok
+591: AC_FUNC_STRTOLD                                 ok
+592: AC_FUNC_UTIME_NULL                              ok
+593: AC_FUNC_VPRINTF                                 ok
 
 Compatibility with external tools and macros.
 
-593: Libtool                                         ok
-594: shtool                                          skipped (foreign.at:130)
-595: AX_PROG_CC_FOR_BUILD                            ok
-596: AX_PROG_CXX_FOR_BUILD                           ok
+594: Libtool                                         ok
+595: shtool                                          skipped (foreign.at:130)
+596: AX_PROG_CC_FOR_BUILD                            ok
+597: AX_PROG_CXX_FOR_BUILD                           ok
+598: gnulib-std-gnu11.m4                             ok
 
 Autoscan.
 
-597: autoscan                                        ok
+599: autoscan                                        ok
 
 ## ------------- ##
 ## Test results. ##
 ## ------------- ##
 
-ERROR: 582 tests were run,
+ERROR: 584 tests were run,
 5 failed (4 expected failures).
 15 tests were skipped.
 ## -------------------------- ##
@@ -694,12 +696,12 @@ ERROR: 582 tests were run,
 Please send `tests/testsuite.log' and all information you think might help:
 
    To: <bug-autoconf@gnu.org>
-   Subject: [GNU Autoconf 2.70] testsuite: 537 failed
+   Subject: [GNU Autoconf 2.71] testsuite: 260 failed
 
 You may investigate any problem if you feel able to do so, in which
 case the test suite provides a good starting point.  Its output may
 be found below `tests/testsuite.dir'.
 
-gmake[2]: *** [Makefile:2275: check-local] Error 1
-gmake[1]: *** [Makefile:1776: check-am] Error 2
-gmake: *** [Makefile:1778: check] Error 2
+gmake[2]: *** [Makefile:2282: check-local] Error 1
+gmake[1]: *** [Makefile:1783: check-am] Error 2
+gmake: *** [Makefile:1785: check] Error 2

--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -153,7 +153,7 @@ library/ncurses					6	require
 library/nghttp2					1	require
 library/nspr					4	require
 library/pcre					8	require
-library/python-3/setuptools-39			52	require
+library/python-3/setuptools-39			53	require
 library/readline				8.1	require
 library/security/openssl			1.1	require
 library/security/tcp-wrapper			7.6	require

--- a/build/glib/build.sh
+++ b/build/glib/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=glib
-VER=2.66.6
+VER=2.66.7
 PKG=library/glib2
 SUMMARY="GNOME utility library"
 DESC="The GNOME general-purpose utility library"

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -87,6 +87,7 @@ library/python-3/pytz-39		2021
 library/python-3/rapidjson-39		1
 library/python-3/semantic-version-39	2
 library/python-3/setuptools-39		53
+library/python-3/setuptools-rust-39	0
 library/python-3/six-39			1
 library/python-3/tempora-39		4
 library/python-3/zc.lockfile-39		2

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -85,6 +85,7 @@ library/python-3/pyopenssl-39		20
 library/python-3/pyrsistent-39		0.17
 library/python-3/pytz-39		2021
 library/python-3/rapidjson-39		1
+library/python-3/semantic-version-39	2
 library/python-3/setuptools-39		53
 library/python-3/six-39			1
 library/python-3/tempora-39		4

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -83,7 +83,7 @@ library/python-3/pycparser-39		2
 library/python-3/pycurl-39		7.43
 library/python-3/pyopenssl-39		20
 library/python-3/pyrsistent-39		0.17
-library/python-3/pytz-39		2020
+library/python-3/pytz-39		2021
 library/python-3/rapidjson-39		1
 library/python-3/setuptools-39		53
 library/python-3/six-39			1

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -85,7 +85,7 @@ library/python-3/pyopenssl-39		20
 library/python-3/pyrsistent-39		0.17
 library/python-3/pytz-39		2020
 library/python-3/rapidjson-39		1
-library/python-3/setuptools-39		52
+library/python-3/setuptools-39		53
 library/python-3/six-39			1
 library/python-3/tempora-39		4
 library/python-3/zc.lockfile-39		2

--- a/build/jeos/omnios-userland.pkg
+++ b/build/jeos/omnios-userland.pkg
@@ -17,7 +17,7 @@ compress/zstd				1.4
 data/iso-codes				4
 database/sqlite-3			3
 developer/as				0.5.11
-developer/build/autoconf		2.70
+developer/build/autoconf		2
 developer/build/automake		1.16
 developer/build/gnu-make		4.3
 developer/build/libtool			2.4

--- a/build/meta/omnios-build-tools.p5m
+++ b/build/meta/omnios-build-tools.p5m
@@ -40,6 +40,8 @@ depend fmri=pkg://@PKGPUBLISHER@/library/pcre2 type=require
 depend fmri=pkg://@PKGPUBLISHER@/library/python-3/coverage-39 type=require
 depend fmri=pkg://@PKGPUBLISHER@/library/python-3/meson-39 type=require
 depend fmri=pkg://@PKGPUBLISHER@/library/python-3/pip-39 type=require
+depend fmri=pkg://@PKGPUBLISHER@/library/python-3/setuptools-rust-39 \
+    type=require
 depend fmri=pkg://@PKGPUBLISHER@/library/security/openssl type=require
 depend fmri=pkg://@PKGPUBLISHER@/library/zlib type=require
 depend fmri=pkg://@PKGPUBLISHER@/network/rsync type=require

--- a/build/python39/README
+++ b/build/python39/README
@@ -15,6 +15,8 @@ pkg
 		zc.lockfile
 		jaraco
 	cryptography
+		setuptools-rust
+			semantic-version
 		six
 		cffi
 			pycparser

--- a/build/python39/cffi/build.sh
+++ b/build/python39/cffi/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/functions.sh
 
 PKG=library/python-3/cffi-39
 PROG=cffi
-VER=1.14.4
+VER=1.14.5
 SUMMARY="cffi"
 DESC="Foreign Function Interface for Python calling C code"
 

--- a/build/python39/cryptography/build.sh
+++ b/build/python39/cryptography/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/cryptography-39
 PROG=cryptography
-VER=3.3.1
+VER=3.4.4
 SUMMARY="Cryptographic recipes and primitives"
 DESC="$SUMMARY"
 
@@ -30,6 +30,12 @@ RUN_DEPENDS_IPS+="
     library/python-$PYMVER/asn1crypto-$SPYVER
     library/python-$PYMVER/idna-$SPYVER
 "
+
+# As of version 3.4, the cryptography module includes Rust code
+BUILD_DEPENDS_IPS+="
+    library/python-$PYMVER/setuptools-rust-$SPYVER
+"
+PATH+=:$OOCEBIN
 
 init
 download_source pymodules/$PROG $PROG $VER

--- a/build/python39/jaraco/build.sh
+++ b/build/python39/jaraco/build.sh
@@ -26,9 +26,9 @@ DESC="A bundle of jaraco python modules"
 
 typeset -A packages
 packages[classes]=3.2.0
-packages[collections]=3.1.0
-packages[functools]=3.1.0
-packages[text]=3.4.0
+packages[collections]=3.2.0
+packages[functools]=3.2.0
+packages[text]=3.5.0
 
 init
 prep_build

--- a/build/python39/more-itertools/build.sh
+++ b/build/python39/more-itertools/build.sh
@@ -13,13 +13,13 @@
 #
 # }}}
 
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/functions.sh
 
 PKG=library/python-3/more-itertools-39
 PROG=more-itertools
-VER=8.6.0
+VER=8.7.0
 SUMMARY="More routines for operating on iterables"
 DESC="$SUMMARY, beyond itertools"
 

--- a/build/python39/orjson/build.sh
+++ b/build/python39/orjson/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/orjson-39
 PROG=orjson
-VER=3.4.7
+VER=3.4.8
 # orjson requries rust nightly. check https://github.com/ijl/orjson
 # for which version has been tested
 RUSTVER=2021-01-11

--- a/build/python39/pip/build.sh
+++ b/build/python39/pip/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/pip-39
 PROG=pip
-VER=21.0
+VER=21.0.1
 SUMMARY="Tool for installing Python packages"
 DESC="$PROG is the standard package installer for Python"
 

--- a/build/python39/pytz/build.sh
+++ b/build/python39/pytz/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/functions.sh
 
 PKG=library/python-3/pytz-39
 PROG=pytz
-VER=2020.5
+VER=2021.1
 SUMMARY="Python world timezone definitons"
 DESC="$SUMMARY, modern and historical"
 

--- a/build/python39/semantic-version/build.sh
+++ b/build/python39/semantic-version/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../../lib/functions.sh
+
+PKG=library/python-3/semantic-version-39
+PROG=semantic_version
+VER=2.8.5
+SUMMARY="A library implementing the 'SemVer' scheme."
+DESC="This small python library provides a few tools to handle SemVer in "
+DESC+="Python. It follows strictly the 2.0.0 version of the SemVer scheme."
+
+. $SRCDIR/../common.sh
+
+init
+download_source pymodules/$PROG $PROG $VER
+patch_source
+prep_build
+python_build
+make_package $SRCDIR/../common.mog
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/python39/semantic-version/local.mog
+++ b/build/python39/semantic-version/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=simplified-BSD
+

--- a/build/python39/setuptools-rust/build.sh
+++ b/build/python39/setuptools-rust/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../../lib/functions.sh
+
+PKG=library/python-3/setuptools-rust-39
+PROG=setuptools-rust
+VER=0.11.6
+SUMMARY="Python setuptools rust extension plugin"
+DESC="Compile and distribute Python extensions written in rust as easily "
+DESC+="as if they were written in C."
+
+. $SRCDIR/../common.sh
+
+RUN_DEPENDS_IPS+="
+    library/python-$PYMVER/setuptools-$SPYVER
+    library/python-$PYMVER/semantic-version-$SPYVER
+"
+
+init
+download_source pymodules/$PROG $PROG $VER
+patch_source
+prep_build
+python_build -noflatten
+make_package $SRCDIR/../common.mog
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/python39/setuptools-rust/local.mog
+++ b/build/python39/setuptools-rust/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+

--- a/build/python39/setuptools/build.sh
+++ b/build/python39/setuptools/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-39
 PROG=setuptools
-VER=52.0.0
+VER=53.0.0
 SUMMARY="Python package management"
 DESC="Easily download, build, install, upgrade, and uninstall Python packages"
 

--- a/doc/baseline
+++ b/doc/baseline
@@ -408,6 +408,7 @@ omnios library/python-3/semantic-version-39
 omnios library/python-3/setuptools-35 o
 omnios library/python-3/setuptools-37 o
 omnios library/python-3/setuptools-39
+omnios library/python-3/setuptools-rust-39
 omnios library/python-3/simplejson-35 o
 omnios library/python-3/simplejson-37 o
 omnios library/python-3/six-35 o

--- a/doc/baseline
+++ b/doc/baseline
@@ -404,6 +404,7 @@ omnios library/python-3/pytz-37 o
 omnios library/python-3/pytz-39
 omnios library/python-3/rapidjson-37 o
 omnios library/python-3/rapidjson-39
+omnios library/python-3/semantic-version-39
 omnios library/python-3/setuptools-35 o
 omnios library/python-3/setuptools-37 o
 omnios library/python-3/setuptools-39

--- a/doc/licences
+++ b/doc/licences
@@ -26,6 +26,6 @@ BSD			Redistribution and use in source and binary forms, with or without(?s).*mo
 # The modified 3-clause BSD licence
 modified-BSD		Redistribution and use in source and binary forms, with or without(?s).*modification,.*are(?-s) permitted provided that the following(?s).*conditions.*are.*met:.*(?-s)[1\*#]?\.? ?Redistributions of source code must retain(?s:.)*[2\*#]?\.? ?Redistributions in binary form must reproduce(?s:.)*[3\*#]?\.? ?(Neither )?[Tt]he names? of (?s).*prior.*written.*permission\. *(?-s)\n.*\n.*THIS SOFTWARE
 # The simplified 2-clause BSD licence
-simplified-BSD		Redistribution and use in source and binary forms, with or without(?s).*modification,.*are(?-s) permitted provided that the following(?s).*conditions.*are.*met:.*(?-s)[1\*#]\.? Redistributions of source code must retain(?s:.)*[2\*#]\.? Redistributions in binary form must reproduce(?s).*provided.*(by|with).*the.* distribution\.(?-s)\n.*\n.*THIS SOFTWARE
+simplified-BSD		Redistribution and use in source and binary forms, with or without(?s).*modification,.*are(?-s) permitted provided that the following(?s).*conditions.*are.*met:.*(?-s)[1\*#]\.? Redistributions of source code must retain\s*(?s:.)*[2\*#]\.? Redistributions in binary form must reproduce(?s).*provided.*(by|with).*the.* distribution\.\s*(?-s)\n.*\n.*THIS SOFTWARE
 # Artistic License
 Artistic		The "Artistic License"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -147,7 +147,7 @@
 | library/python-3/pyrsistent-39	| 0.17.3		| https://pypi.org/project/pyrsistent
 | library/python-3/pytz-39		| 2020.5		| https://pypi.org/project/pytz
 | library/python-3/rapidjson-39		| 1.0			| https://pypi.org/project/python-rapidjson
-| library/python-3/setuptools-39	| 52.0.0		| https://pypi.org/project/setuptools
+| library/python-3/setuptools-39	| 53.0.0		| https://pypi.org/project/setuptools
 | library/python-3/six-39		| 1.15.0		| https://pypi.org/project/six
 | library/python-3/tempora-39		| 4.0.1			| https://pypi.org/project/tempora
 | library/python-3/wcwidth-39		| 0.2.5			| https://pypi.org/project/wcwidth

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -125,9 +125,9 @@
 | library/python-3/cryptography-39	| 3.3.1			| https://pypi.org/project/cryptography
 | library/python-3/idna-39		| 3.1			| https://pypi.org/project/idna
 | library/python-3/jaraco.classes-39	| 3.2.0			| https://pypi.org/project/jaraco.classes
-| library/python-3/jaraco.collections-39 | 3.1.0		| https://pypi.org/project/jaraco.collections
-| library/python-3/jaraco.functools-39	| 3.1.0			| https://pypi.org/project/jaraco.functools
-| library/python-3/jaraco.text-39	| 3.4.0			| https://pypi.org/project/jaraco.text
+| library/python-3/jaraco.collections-39 | 3.2.0		| https://pypi.org/project/jaraco.collections
+| library/python-3/jaraco.functools-39	| 3.2.0			| https://pypi.org/project/jaraco.functools
+| library/python-3/jaraco.text-39	| 3.5.0			| https://pypi.org/project/jaraco.text
 | library/python-3/js-regex-39		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-39	| 0.4.2			| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-39	| 3.2.0			| https://pypi.org/project/jsonschema

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -134,7 +134,7 @@
 | library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
 | library/python-3/meson-39		| 0.56.2		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.7.0			| https://pypi.org/project/more-itertools
-| library/python-3/orjson-39		| 3.4.7			| https://github.com/ijl/orjson/releases
+| library/python-3/orjson-39		| 3.4.8			| https://github.com/ijl/orjson/releases
 | library/python-3/pip-39		| 21.0.1		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.0			| https://pypi.org/project/portend

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -145,7 +145,7 @@
 | library/python-3/pycurl-39		| 7.43.0.6		| https://pypi.org/project/pycurl
 | library/python-3/pyopenssl-39		| 20.0.1		| https://pypi.org/project/pyOpenSSL
 | library/python-3/pyrsistent-39	| 0.17.3		| https://pypi.org/project/pyrsistent
-| library/python-3/pytz-39		| 2020.5		| https://pypi.org/project/pytz
+| library/python-3/pytz-39		| 2021.1		| https://pypi.org/project/pytz
 | library/python-3/rapidjson-39		| 1.0			| https://pypi.org/project/python-rapidjson
 | library/python-3/setuptools-39	| 53.0.0		| https://pypi.org/project/setuptools
 | library/python-3/six-39		| 1.15.0		| https://pypi.org/project/six

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -122,7 +122,7 @@
 | library/python-3/cheroot-39		| 8.5.2			| https://pypi.org/project/cheroot
 | library/python-3/cherrypy-39		| 18.6.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/coverage-39		| 5.4			| https://pypi.org/project/coverage
-| library/python-3/cryptography-39	| 3.3.1			| https://pypi.org/project/cryptography
+| library/python-3/cryptography-39	| 3.4.4			| https://pypi.org/project/cryptography
 | library/python-3/idna-39		| 3.1			| https://pypi.org/project/idna
 | library/python-3/jaraco.classes-39	| 3.2.0			| https://pypi.org/project/jaraco.classes
 | library/python-3/jaraco.collections-39 | 3.2.0		| https://pypi.org/project/jaraco.collections

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -12,7 +12,7 @@
 | compress/zstd				| 1.4.8			| https://github.com/facebook/zstd/releases
 | data/iso-codes			| 4.5.0			| https://salsa.debian.org/iso-codes-team/iso-codes/tags
 | database/sqlite-3			| 3340100		| https://www.sqlite.org/download.html
-| developer/build/autoconf		| 2.70			| https://ftp.gnu.org/gnu/autoconf/
+| developer/build/autoconf		| 2.71			| https://ftp.gnu.org/gnu/autoconf/
 | developer/build/automake		| 1.16.3		| https://ftp.gnu.org/gnu/automake/
 | developer/build/gnu-make		| 4.3			| https://ftp.gnu.org/gnu/make/
 | developer/build/libtool		| 2.4.6			| https://www.gnu.org/software/libtool/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -133,7 +133,7 @@
 | library/python-3/jsonschema-39	| 3.2.0			| https://pypi.org/project/jsonschema
 | library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
 | library/python-3/meson-39		| 0.56.2		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
-| library/python-3/more-itertools-39	| 8.6.0			| https://pypi.org/project/more-itertools
+| library/python-3/more-itertools-39	| 8.7.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.4.7			| https://github.com/ijl/orjson/releases
 | library/python-3/pip-39		| 21.0.1		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -109,7 +109,7 @@
 | text/less				| 563			| http://www.greenwoodsoftware.com/less/download.html
 | web/curl				| 7.75.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.21.1		| https://ftp.gnu.org/gnu/wget/
-| library/glib2				| 2.66.6		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
+| library/glib2				| 2.66.7		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
 | developer/gnu-binutils		| 2.36.1		| https://ftp.gnu.org/gnu/binutils
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
 | system/virtualization/azure-agent	| 2.2.46		| https://github.com/Azure/WALinuxAgent/releases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -149,6 +149,7 @@
 | library/python-3/rapidjson-39		| 1.0			| https://pypi.org/project/python-rapidjson
 | library/python-3/semantic-version-39	| 2.8.5			| https://pypi.org/project/semantic-version
 | library/python-3/setuptools-39	| 53.0.0		| https://pypi.org/project/setuptools
+| library/python-3/setuptools-rust-39	| 0.11.6		| https://pypi.org/project/setuptools-rust
 | library/python-3/six-39		| 1.15.0		| https://pypi.org/project/six
 | library/python-3/tempora-39		| 4.0.1			| https://pypi.org/project/tempora
 | library/python-3/wcwidth-39		| 0.2.5			| https://pypi.org/project/wcwidth

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -147,6 +147,7 @@
 | library/python-3/pyrsistent-39	| 0.17.3		| https://pypi.org/project/pyrsistent
 | library/python-3/pytz-39		| 2021.1		| https://pypi.org/project/pytz
 | library/python-3/rapidjson-39		| 1.0			| https://pypi.org/project/python-rapidjson
+| library/python-3/semantic-version-39	| 2.8.5			| https://pypi.org/project/semantic-version
 | library/python-3/setuptools-39	| 53.0.0		| https://pypi.org/project/setuptools
 | library/python-3/six-39		| 1.15.0		| https://pypi.org/project/six
 | library/python-3/tempora-39		| 4.0.1			| https://pypi.org/project/tempora

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -135,7 +135,7 @@
 | library/python-3/meson-39		| 0.56.2		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.6.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.4.7			| https://github.com/ijl/orjson/releases
-| library/python-3/pip-39		| 21.0			| https://pypi.org/project/pip
+| library/python-3/pip-39		| 21.0.1		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.0			| https://pypi.org/project/portend
 | library/python-3/prettytable-39	| 2.0.0			| https://pypi.org/project/PrettyTable

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -118,7 +118,7 @@
 | library/security/trousers		| 0.3.15		| https://sourceforge.net/projects/trousers/files/trousers
 | library/python-3/asn1crypto-39	| 1.4.0			| https://pypi.org/project/asn1crypto
 | library/python-3/attrs-39		| 20.3.0		| https://pypi.org/project/attrs
-| library/python-3/cffi-39		| 1.14.4		| https://pypi.org/project/cffi
+| library/python-3/cffi-39		| 1.14.5		| https://pypi.org/project/cffi
 | library/python-3/cheroot-39		| 8.5.2			| https://pypi.org/project/cheroot
 | library/python-3/cherrypy-39		| 18.6.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/coverage-39		| 5.4			| https://pypi.org/project/coverage


### PR DESCRIPTION
The new `cryptography` module includes rust components, so brings in a requirement for `setuptools-rust`
