### PR TITLE
Python 3.5 _ctypes module broken (r151030)

### DIFF
--- a/build/python35/patches/CVE-2021-3177.patch
+++ b/build/python35/patches/CVE-2021-3177.patch
@@ -1,18 +1,27 @@
-From e92381a0a6a3e1f000956e1f1e70e543b9c2bcd5 Mon Sep 17 00:00:00 2001
-From: Benjamin Peterson <benjamin@python.org>
-Date: Mon, 18 Jan 2021 14:47:05 -0600
-Subject: [PATCH] [3.6] closes bpo-42938: Replace snprintf with Python unicode
- formatting in ctypes param reprs. (24239). (cherry picked from commit
- 916610ef90a0d0761f08747f7b0905541f0977c7)
+Fixes CVE-2021-3177.
+Desc:
+  Python 3.x through 3.9.1 has a buffer overflow in PyCArg_repr in
+  _ctypes/callproc.c, which may lead to remote code execution in certain
+  Python applications that accept floating-point numbers as untrusted input,
+  as demonstrated by a 1e300 argument to c_double.from_param. This occurs
+  because sprintf is used unsafely.
 
-Co-authored-by: Benjamin Peterson <benjamin@python.org>
- Modules/_ctypes/callproc.c                    | 55 +++++++------------
+Upstream bug: https://bugs.python.org/issue42938
 
-diff --git a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
-index d1c190f359108..2bb289bce043f 100644
---- a/Modules/_ctypes/callproc.c
-+++ b/Modules/_ctypes/callproc.c
-@@ -451,54 +451,50 @@
+Backported from upstream:
+https://github.com/python/cpython/pull/24239
+
+--- src~/Modules/_ctypes/callproc.c	2020-09-05 07:22:07.000000000 +0000
++++ src/Modules/_ctypes/callproc.c	2021-02-24 23:48:40.002170967 +0000
+@@ -448,57 +448,60 @@
+     PyObject_Del(self);
+ }
+ 
++/* maximum number of characters required for output of %lld or %p.
++   We need at most ceil(log10(256)*SIZEOF_LONG_LONG) digits,
++   plus 1 for the sign.  53/22 is an upper bound for log10(256). */
++#define MAX_LONG_LONG_CHARS (2 + (SIZEOF_LONG_LONG*53-1) / 22)
++
  static PyObject *
  PyCArg_repr(PyCArgObject *self)
  {
@@ -45,16 +54,20 @@ index d1c190f359108..2bb289bce043f 100644
  
  #ifdef HAVE_LONG_LONG
      case 'q':
-     case 'Q':
+-    case 'Q':
 -        sprintf(buffer,
--#ifdef MS_WIN32
--            "<cparam '%c' (%I64d)>",
--#else
--            "<cparam '%c' (%qd)>",
--#endif
-+        return PyUnicode_FromFormat("<cparam '%c' (%lld)>",
++    case 'Q': {
++        char buffer[MAX_LONG_LONG_CHARS + 15];
++        snprintf(buffer, MAX_LONG_LONG_CHARS + 15,
+ #ifdef MS_WIN32
+             "<cparam '%c' (%I64d)>",
+ #else
+             "<cparam '%c' (%qd)>",
+ #endif
              self->tag, self->value.q);
 -        break;
++        return PyUnicode_FromString(buffer);
++    }
  #endif
      case 'd':
 -        sprintf(buffer, "<cparam '%c' (%f)>",
@@ -76,20 +89,13 @@ index d1c190f359108..2bb289bce043f 100644
  
      case 'c':
 -        sprintf(buffer, "<cparam '%c' (%c)>",
--            self->tag, self->value.c);
++        return PyUnicode_FromFormat("<cparam '%c' ('%c')>",
+             self->tag, self->value.c);
 -        break;
-+         if (is_literal_char((unsigned char)self->value.c)) {
-+            return PyUnicode_FromFormat("<cparam '%c' ('%c')>",
-+                 self->tag, self->value.c);
-+         }
-+         else {
-+            return PyUnicode_FromFormat("<cparam '%c' ('\\x%02x')>",
-+                 self->tag, (unsigned char)self->value.c);
-+         }
  
  /* Hm, are these 'z' and 'Z' codes useful at all?
     Shouldn't they be replaced by the functionality of c_string
-@@ -507,16 +503,18 @@
+@@ -507,16 +509,13 @@
      case 'z':
      case 'Z':
      case 'P':
@@ -100,15 +106,9 @@ index d1c190f359108..2bb289bce043f 100644
  
      default:
 -        sprintf(buffer, "<cparam '%c' at %p>",
--            self->tag, self);
++        return PyUnicode_FromFormat("<cparam '%c' at %p>",
+             self->tag, self);
 -        break;
-+         if (is_literal_char((unsigned char)self->tag)) {
-+            return PyUnicode_FromFormat("<cparam '%c' at %p>",
-+                (unsigned char)self->tag, (void *)self);
-+         } else {
-+            return PyUnicode_FromFormat("<cparam 0x%02x at %p>",
-+                (unsigned char)self->tag, (void *)self);
-+         }
      }
 -    return PyUnicode_FromString(buffer);
  }


### PR DESCRIPTION
Python 3.5 _ctype module broken (r151030)
