### PR TITLE
openssh: fix for CVE-2021-28041 (r151036)

### DIFF
--- a/build/openssh/patches/CVE-2021-28041.patch
+++ b/build/openssh/patches/CVE-2021-28041.patch
@@ -1,0 +1,11 @@
+diff -wpruN '--exclude=*.orig' a~/ssh-agent.c a/ssh-agent.c
+--- a~/ssh-agent.c	1970-01-01 00:00:00
++++ a/ssh-agent.c	1970-01-01 00:00:00
+@@ -581,6 +581,7 @@ process_add_identity(SocketEntry *e)
+ 				goto err;
+ 			}
+ 			free(ext_name);
++			ext_name = NULL;
+ 			break;
+ 		default:
+ 			error("%s: Unknown constraint %d", __func__, ctype);

--- a/build/openssh/patches/series
+++ b/build/openssh/patches/series
@@ -24,3 +24,4 @@ revert-dscp.patch
 test.patch
 gssapi.patch
 ssh-copy-id.patch
+CVE-2021-28041.patch


### PR DESCRIPTION
openssh: fix for CVE-2021-28041 (r151036)
