### PR TITLE
gcc4 PCH generation sporadically crashes

### DIFF
--- a/build/gcc44/patches/pch1.patch
+++ b/build/gcc44/patches/pch1.patch
@@ -1,0 +1,76 @@
+From 88d0b1d04fea17ae8173054d439f8c620af78654 Mon Sep 17 00:00:00 2001
+From: Rainer Orth <ro@CeBiTec.Uni-Bielefeld.DE>
+Date: Wed, 2 Jun 2010 17:28:24 +0000
+Subject: [PATCH] backport: re PR pch/14940 (PCH largefile test fails on
+ various platforms)
+
+	Backport from mainline:
+	2010-03-01  Rainer Orth  <ro@CeBiTec.Uni-Bielefeld.DE>
+
+	PR pch/14940
+	* config/host-solaris.c (HOST_HOOKS_GT_PCH_GET_ADDRESS): Redefine
+	to sol_gt_pch_get_address.
+	(TRY_EMPTY_VM_SPACE): Define for all combinations of 32 and
+	64-bit, SPARC and x86.
+	(sol_gt_pch_get_address): New function.
+
+From-SVN: r160176
+diff -wpruN '--exclude=*.orig' a~/gcc/config/host-solaris.c a/gcc/config/host-solaris.c
+--- a~/gcc/config/host-solaris.c	1970-01-01 00:00:00
++++ a/gcc/config/host-solaris.c	1970-01-01 00:00:00
+@@ -1,5 +1,5 @@
+ /* Solaris host-specific hook definitions.
+-   Copyright (C) 2004, 2007, 2008 Free Software Foundation, Inc.
++   Copyright (C) 2004, 2007, 2008, 2010 Free Software Foundation, Inc.
+ 
+    This file is part of GCC.
+ 
+@@ -25,9 +25,48 @@
+ #include "hosthooks-def.h"
+ 
+ 
++#undef HOST_HOOKS_GT_PCH_GET_ADDRESS
++#define HOST_HOOKS_GT_PCH_GET_ADDRESS sol_gt_pch_get_address
+ #undef HOST_HOOKS_GT_PCH_USE_ADDRESS
+ #define HOST_HOOKS_GT_PCH_USE_ADDRESS sol_gt_pch_use_address
+ 
++/* For various ports, try to guess a fixed spot in the vm space
++   that's probably free.  Based on McDougall, Mauro, Solaris Internals, 2nd
++   ed., p.460-461, fig. 9-3, 9-4, 9-5.  */
++#if defined(__sparcv9__)
++/* This low to avoid VA hole on UltraSPARC I/II.  */
++# define TRY_EMPTY_VM_SPACE	0x70000000000
++#elif defined(__sparc__)
++# define TRY_EMPTY_VM_SPACE	0x80000000
++#elif defined(__x86_64__)
++# define TRY_EMPTY_VM_SPACE	0x8000000000000000
++#elif defined(__i386__)
++# define TRY_EMPTY_VM_SPACE	0xB0000000
++#else
++# define TRY_EMPTY_VM_SPACE	0
++#endif
++
++/* Determine a location where we might be able to reliably allocate
++   SIZE bytes.  FD is the PCH file, though we should return with the
++   file unmapped.  */
++
++static void *
++sol_gt_pch_get_address (size_t size, int fd)
++{
++  void *addr;
++
++  addr = mmap ((caddr_t) TRY_EMPTY_VM_SPACE, size, PROT_READ | PROT_WRITE,
++	       MAP_PRIVATE, fd, 0);
++
++  /* If we failed the map, that means there's *no* free space.  */
++  if (addr == (void *) MAP_FAILED)
++    return NULL;
++  /* Unmap the area before returning.  */
++  munmap ((caddr_t) addr, size);
++
++  return addr;
++}
++
+ /* Map SIZE bytes of FD+OFFSET at BASE.  Return 1 if we succeeded at 
+    mapping the data at BASE, -1 if we couldn't.  */
+ 

--- a/build/gcc44/patches/pch2.patch
+++ b/build/gcc44/patches/pch2.patch
@@ -1,0 +1,109 @@
+From 5773523d624ce718b5f5131ecd01387fff063efd Mon Sep 17 00:00:00 2001
+From: Rainer Orth <ro@CeBiTec.Uni-Bielefeld.DE>
+Date: Tue, 13 Jul 2010 09:07:18 +0000
+Subject: [PATCH] backport: re PR pch/14940 (PCH largefile test fails on
+ various platforms)
+
+	Backport from mainline:
+	2010-07-12  Rainer Orth  <ro@CeBiTec.Uni-Bielefeld.DE>
+
+	PR pch/14940
+	* config/host-solaris.c (mmap_fixed): New function.
+	(sol_gt_pch_get_address): Use it.
+	(sol_gt_pch_use_address): Likewise.
+
+From-SVN: r162128
+
+diff -wpruN '--exclude=*.orig' a~/gcc/config/host-solaris.c a/gcc/config/host-solaris.c
+--- a~/gcc/config/host-solaris.c	1970-01-01 00:00:00
++++ a/gcc/config/host-solaris.c	1970-01-01 00:00:00
+@@ -30,6 +30,41 @@
+ #undef HOST_HOOKS_GT_PCH_USE_ADDRESS
+ #define HOST_HOOKS_GT_PCH_USE_ADDRESS sol_gt_pch_use_address
+ 
++/* Before Solaris 11, the mmap ADDR parameter is mostly ignored without
++   MAP_FIXED set.  Before we give up, search the desired address space with
++   mincore to see if the space is really free.  */
++
++static void *
++mmap_fixed (void *addr, size_t len, int prot, int flags, int fd, off_t off)
++{
++  void *base;
++
++  base = mmap ((caddr_t) addr, len, prot, flags, fd, off);
++  
++  if (base != addr)
++    {
++      size_t page_size = getpagesize();
++      char one_byte;
++      size_t i;
++
++      if (base != (void *) MAP_FAILED)
++	munmap ((caddr_t) base, len);
++
++      errno = 0;
++      for (i = 0; i < len; i += page_size)
++	if (mincore ((char *)addr + i, page_size, (char *) &one_byte) == -1
++	    && errno == ENOMEM)
++	  continue; /* The page is not mapped.  */
++	else
++	  break;
++
++      if (i >= len)
++	base = mmap ((caddr_t) addr, len, prot, flags | MAP_FIXED, fd, off);
++    }
++
++  return base;
++}
++
+ /* For various ports, try to guess a fixed spot in the vm space
+    that's probably free.  Based on McDougall, Mauro, Solaris Internals, 2nd
+    ed., p.460-461, fig. 9-3, 9-4, 9-5.  */
+@@ -55,8 +90,8 @@ sol_gt_pch_get_address (size_t size, int
+ {
+   void *addr;
+ 
+-  addr = mmap ((caddr_t) TRY_EMPTY_VM_SPACE, size, PROT_READ | PROT_WRITE,
+-	       MAP_PRIVATE, fd, 0);
++  addr = mmap_fixed ((caddr_t) TRY_EMPTY_VM_SPACE, size,
++		     PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+ 
+   /* If we failed the map, that means there's *no* free space.  */
+   if (addr == (void *) MAP_FAILED)
+@@ -81,34 +116,8 @@ sol_gt_pch_use_address (void *base, size
+   if (size == 0)
+     return -1;
+ 
+-  addr = mmap ((caddr_t) base, size, PROT_READ | PROT_WRITE, MAP_PRIVATE,
+-	       fd, offset);
+-
+-  /* Solaris isn't good about honoring the mmap START parameter
+-     without MAP_FIXED set.  Before we give up, search the desired
+-     address space with mincore to see if the space is really free.  */
+-  if (addr != base)
+-    {
+-      size_t page_size = getpagesize();
+-      char one_byte;
+-      size_t i;
+-
+-      if (addr != (void *) MAP_FAILED)
+-	munmap ((caddr_t) addr, size);
+-
+-      errno = 0;
+-      for (i = 0; i < size; i += page_size)
+-	if (mincore ((char *)base + i, page_size, (char *) &one_byte) == -1
+-	    && errno == ENOMEM)
+-	  continue; /* The page is not mapped.  */
+-	else
+-	  break;
+-
+-      if (i >= size)
+-	addr = mmap ((caddr_t) base, size, 
+-		     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
+-		     fd, offset);
+-    }
++  addr = mmap_fixed ((caddr_t) base, size,
++		     PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, offset);
+ 
+   return addr == base ? 1 : -1;
+ }

--- a/build/gcc44/patches/series
+++ b/build/gcc44/patches/series
@@ -1,2 +1,4 @@
 64bit.patch
 fcerror.patch
+pch1.patch
+pch2.patch


### PR DESCRIPTION
This manifests occasionally in a full userland build as something like this
in the build log. With these patches from upstream I have not been able to replicate it.

```
xgcc: Internal error: Segmentation Fault (program cc1plus)
Please submit a full bug report.
See <http://gcc.gnu.org/bugs.html> for instructions.
gmake[2]: *** [Makefile:1513: i386-pc-solaris2.11/bits/stdtr1c++.h.gch/O2g.gch] Error 1
```

```
Loading modules: [ libc.so.1 ld.so.1 ]
> ::status
debugging core file of cc1plus (32-bit) from bloody
file: /data/omnios-build/omniosorg/bloody/_build/gcc-4.4.4/gcc-gcc-4.4.4-il-4/host-i386-pc-solaris2.11/gcc/cc1plus
initial argv: /data/omnios-build/omniosorg/bloody/_build/gcc-4.4.4/gcc-gcc-4.4.4-il-4/host-i3
threading model: native threads
status: process terminated by SIGSEGV (Segmentation Fault), addr=fbc075dc
> $C
08043298 linemap_lookup+0xc(88da4c0, 0, 0, 0, 0, 0)
08043308 cp_diagnostic_starter+0x18(88da4c0, 80433a8, 8043358, fc817daa, 0, 8804c01)
08043388 diagnostic_report_diagnostic+0xc5(88da4c0, 80433a8, fef91a00)
080433d8 internal_error+0x34(8804c01, fc8890d0, fe80d068, fc850070, fc850070, fc8ec000)
080433f8 0x8395c1e(b, 0, 80434bc, fc8ec000, fc8ec000, fc8ec000)
08043418 libc.so.1`__sighndlr+0x15(b, 0, 80434bc, 8395bd0, 0, fc8f1c00)
08043478 libc.so.1`call_user_handler+0x1e9(b, 0, 80434bc)
080434a8 libc.so.1`sigacthandler+0xdf(b, 0, 80434bc)
080436f8 linemap_lookup+0xc(88da4c0, 0, 0, 0, 0, 0)
08043768 cp_diagnostic_starter+0x18(88da4c0, 8043808, 80437b8, fc817daa, 0, 880d339)
080437e8 diagnostic_report_diagnostic+0xc5(88da4c0, 8043808, 8043818)
08043838 fatal_error+0x34(880d339, c, 1, 89231d0, 8f18288, 8ec5d70)
08043888 0x82ad391(89231d0, ec9, 605efdcb, 23736fa3, 605efdcb, 23736fa3)
080438e8 c_common_read_pch+0x123(8ec5d70, 8f190d8, 6, 8ef72b0, 8ec5d70, 8f179a0)
08043948 _cpp_stack_file+0x4d(8ec5d70, 8f19010, 0, 0)
08043978 do_include_common+0x89(8ec5d70, 0, 0, 8ec5d70)
08043998 do_include+0x10(8ec5d70, 8ecf17c, 8ec5e60, 8ec6040)
080439d8 _cpp_handle_directive+0xa0(8ec5d70, 0, fc8ec000, fc8f5de4)
08043a08 _cpp_lex_token+0xbf(8ec5d70, d8, 8043a58, fc7fc1ce, fc8ec7cc, 8ebdc70)
08043a58 cpp_get_token+0xb1(8ec5d70, d3, 8043a98, 15, 8043b64, 8043b68)
08043a78 cpp_get_token_with_location+0x18(8ec5d70, 8043b68, 8043ab8, fc8490de, 8ef71d0, 1)
08043b18 c_lex_with_flags+0x27(8043b6c, 8043b68, 8043b66, 0, 8ea8168, 0)
08043b38 cp_lexer_get_preprocessor_token+0x27(0, 8043b64, 8043b88, 81c7dad, 8ec5d70, 89231c0)
08043b88 c_parse_file+0x2b(0, 8044411, 8043bf8, 8397867, 0, 0)
08043b98 c_common_parse_file+0x74(0, 0, 8043bf8, 8397829)
08043bf8 toplev_main+0xa53(1f, 8043c80, 8043c28, 870d990)
08043c18 main+0x1b(8043c1c, fc8f9648, 8043c58, 8103e9b)
08043c58 _start_crt+0x9a(1f, 8043c80, fefcfe4f, 0, 0, 0)
08043c74 _start+0x1a(1f, 8044044, 80440b1, 80440b8, 80440c4, 804414b)
> 880d339/s
0x880d339:      had to relocate PCH
```