### PR TITLE
illumos-closed delivers unreadable files

### DIFF
--- a/build/illumos-closed/build.sh
+++ b/build/illumos-closed/build.sh
@@ -25,6 +25,11 @@ DESC="Closed-source binaries required to build an illumos distribution."
 
 BUILDDIR=closed
 
+# These old closed binaries generate a lot of expected warnings for these
+# checks, and there is nothing we can do about it.
+SKIP_RTIME_CHECK=1
+SKIP_SSP_CHECK=1
+
 HARDLINK_TARGETS="
     opt/onbld/closed/root_i386/usr/xpg4/bin/alias
     opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias

--- a/build/illumos-closed/local.mog
+++ b/build/illumos-closed/local.mog
@@ -1,4 +1,3 @@
-# {{{ CDDL HEADER
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
@@ -8,9 +7,14 @@
 # A full copy of the text of the CDDL should have accompanied this
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-# }}}
-
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+#
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 license opt/onbld/closed/BINARYLICENSE.txt license="Sun Binary License"
 <transform file path=opt/onbld/closed/.* -> set pkg.depend.bypass-generate .*>
+
+# A small number of files in the archive are only readable by root.
+# Since we are installing these files under /opt/onbld/closed/ to be used
+# during illumos-gate builds by normal users, make them world readable.
+<transform file mode=(\d+)00$ -> set mode %<1>44>
+


### PR DESCRIPTION
```
% pkg contents -m illumos-closed | grep mode= | sed 's/.*mode=\([^ ]*\).*/\1/' | sort | uniq -c
   2 0400
   2 0600
   4 0744
  56 0444
  90 0555
 909 0644
 970 0755
```

```diff
--- Comparing old package with new

-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings owner=root group=bin mode=0400
+file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings owner=root group=bin mode=0444
-file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf owner=root group=bin mode=0600
+file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf owner=root group=bin mode=0644
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings owner=root group=bin mode=0400
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings owner=root group=bin mode=0444
-file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf owner=root group=bin mode=0600
+file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf owner=root group=bin mode=0644
```
