### PR TITLE
Python module updates

### DIFF
--- a/build/python39/idna/build.sh
+++ b/build/python39/idna/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/idna-39
 PROG=idna
-VER=3.1
+VER=3.2
 SUMMARY="Internationalized Domain Names in Applications (IDNA)"
 DESC="Support for the Internationalised Domain Names in Applications (IDNA) "
 DESC+="protocol as specified in RFC 5891"

--- a/build/python39/orjson/build.sh
+++ b/build/python39/orjson/build.sh
@@ -18,10 +18,10 @@
 
 PKG=library/python-3/orjson-39
 PROG=orjson
-VER=3.5.2
+VER=3.5.3
 # orjson requries rust nightly. check https://github.com/ijl/orjson
 # for which version has been tested
-RUSTVER=2021-01-11
+RUSTVER=2021-06-24
 SUMMARY="orjson"
 DESC="A fast, correct JSON library for Python."
 

--- a/build/python39/pip/build.sh
+++ b/build/python39/pip/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/pip-39
 PROG=pip
-VER=21.1.2
+VER=21.1.3
 SUMMARY="Tool for installing Python packages"
 DESC="$PROG is the standard package installer for Python"
 

--- a/build/python39/rapidjson/build.sh
+++ b/build/python39/rapidjson/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../../lib/functions.sh
 
 PKG=library/python-3/rapidjson-39
 PROG=rapidjson
-VER=1.0
+VER=1.4
 SUMMARY="rapidjson - Python interface to RapidJSON"
 DESC="RapidJSON is an extremely fast C++ JSON parser and serialization library"
 DESC+="; this module wraps it into a Python 3 extension"

--- a/build/python39/tempora/build.sh
+++ b/build/python39/tempora/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/tempora-39
 PROG=tempora
-VER=4.0.2
+VER=4.1.1
 SUMMARY="Objects and routines pertaining to date and time"
 DESC="$SUMMARY"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -135,7 +135,7 @@
 | library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
 | library/python-3/meson-39		| 0.58.0		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
-| library/python-3/orjson-39		| 3.5.2			| https://github.com/ijl/orjson/releases
+| library/python-3/orjson-39		| 3.5.3			| https://github.com/ijl/orjson/releases
 | library/python-3/pip-39		| 21.1.2		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.1			| https://pypi.org/project/portend

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -152,7 +152,7 @@
 | library/python-3/setuptools-39	| 57.0.0		| https://pypi.org/project/setuptools
 | library/python-3/setuptools-rust-39	| 0.12.1		| https://pypi.org/project/setuptools-rust
 | library/python-3/six-39		| 1.16.0		| https://pypi.org/project/six
-| library/python-3/tempora-39		| 4.0.2			| https://pypi.org/project/tempora
+| library/python-3/tempora-39		| 4.1.1			| https://pypi.org/project/tempora
 | library/python-3/wcwidth-39		| 0.2.5			| https://pypi.org/project/wcwidth
 | library/python-3/zc.lockfile-39	| 2.0			| https://pypi.org/project/zc.lockfile
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -124,7 +124,7 @@
 | library/python-3/cherrypy-39		| 18.6.0		| https://pypi.org/project/cherrypy http://docs.cherrypy.org/en/latest/history.html
 | library/python-3/coverage-39		| 5.5			| https://pypi.org/project/coverage
 | library/python-3/cryptography-39	| 3.4.7			| https://pypi.org/project/cryptography
-| library/python-3/idna-39		| 3.1			| https://pypi.org/project/idna
+| library/python-3/idna-39		| 3.2			| https://pypi.org/project/idna
 | library/python-3/jaraco.classes-39	| 3.2.1			| https://pypi.org/project/jaraco.classes
 | library/python-3/jaraco.collections-39 | 3.3.0		| https://pypi.org/project/jaraco.collections
 | library/python-3/jaraco.functools-39	| 3.3.0			| https://pypi.org/project/jaraco.functools

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -136,7 +136,7 @@
 | library/python-3/meson-39		| 0.58.0		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.5.3			| https://github.com/ijl/orjson/releases
-| library/python-3/pip-39		| 21.1.2		| https://pypi.org/project/pip
+| library/python-3/pip-39		| 21.1.3		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.1			| https://pypi.org/project/portend
 | library/python-3/prettytable-39	| 2.1.0			| https://pypi.org/project/PrettyTable

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -147,7 +147,7 @@
 | library/python-3/pyopenssl-39		| 20.0.1		| https://pypi.org/project/pyOpenSSL
 | library/python-3/pyrsistent-39	| 0.17.3		| https://pypi.org/project/pyrsistent
 | library/python-3/pytz-39		| 2021.1		| https://pypi.org/project/pytz
-| library/python-3/rapidjson-39		| 1.0			| https://pypi.org/project/python-rapidjson
+| library/python-3/rapidjson-39		| 1.4			| https://pypi.org/project/python-rapidjson
 | library/python-3/semantic-version-39	| 2.8.5			| https://pypi.org/project/semantic-version
 | library/python-3/setuptools-39	| 57.0.0		| https://pypi.org/project/setuptools
 | library/python-3/setuptools-rust-39	| 0.12.1		| https://pypi.org/project/setuptools-rust


### PR DESCRIPTION
The rapidjson update here noticeably reduces memory utilisation in `pkg` so should be considered as a backport for r38.

```
# Ran 1067 tests in 1572.191s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================
```