### PR TITLE
nss/nspr - update to 3.68/4.32

### DIFF
--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -18,9 +18,9 @@
 . ../../lib/functions.sh
 
 PROG=nss
-VER=3.65
+VER=3.68
 # Include NSPR version since we're downloading a combined tarball.
-NSPRVER=4.30
+NSPRVER=4.32
 # But set BUILDDIR to just be the NSS version.
 set_builddir "$PROG-$VER"
 PKG=$PROG ##IGNORE##

--- a/build/mozilla-nss-nspr/patches/nss-modernize.patch
+++ b/build/mozilla-nss-nspr/patches/nss-modernize.patch
@@ -51,7 +51,7 @@ diff -wpruN '--exclude=*.orig' a~/nss/coreconf/SunOS5.mk a/nss/coreconf/SunOS5.m
 diff -wpruN '--exclude=*.orig' a~/nss/lib/freebl/Makefile a/nss/lib/freebl/Makefile
 --- a~/nss/lib/freebl/Makefile	1970-01-01 00:00:00
 +++ a/nss/lib/freebl/Makefile	1970-01-01 00:00:00
-@@ -538,6 +538,8 @@ else
+@@ -570,6 +570,8 @@ else
   	ifndef NS_USE_GCC
   	   MPCPU_SRCS =
   	   ASFILES += mpcpucache_x86.s

--- a/build/mozilla-nss-nspr/patches/pkcs11v3.patch
+++ b/build/mozilla-nss-nspr/patches/pkcs11v3.patch
@@ -13,7 +13,7 @@ CK_GENERATOR_FUNCTION is just CK_ULONG, so replace it in the header file.
 diff -wpruN '--exclude=*.orig' a~/nss/lib/pk11wrap/pk11pub.h a/nss/lib/pk11wrap/pk11pub.h
 --- a~/nss/lib/pk11wrap/pk11pub.h	1970-01-01 00:00:00
 +++ a/nss/lib/pk11wrap/pk11pub.h	1970-01-01 00:00:00
-@@ -812,7 +812,7 @@ SECStatus PK11_AEADRawOp(PK11Context *co
+@@ -845,7 +845,7 @@ SECStatus PK11_AEADRawOp(PK11Context *co
                           unsigned char *out, int *outlen,
                           int maxout, const unsigned char *in, int inlen);
  /* NSS builds the mechanism specific params */

--- a/build/mozilla-nss-nspr/patches/shadowing.patch
+++ b/build/mozilla-nss-nspr/patches/shadowing.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/nss/lib/softoken/pkcs11.c a/nss/lib/softoken/pkcs11.c
 --- a~/nss/lib/softoken/pkcs11.c	1970-01-01 00:00:00
 +++ a/nss/lib/softoken/pkcs11.c	1970-01-01 00:00:00
-@@ -3350,8 +3350,8 @@ nsc_CommonInitialize(CK_VOID_PTR pReserv
+@@ -3369,8 +3369,8 @@ nsc_CommonInitialize(CK_VOID_PTR pReserv
          char buf[200];
          int major = 0, minor = 0;
  

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -49,8 +49,8 @@
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.2			| https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.44.0		| https://github.com/nghttp2/nghttp2/releases
-| library/nss				| 3.65			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
-| library/nspr				| 4.30			| http://archive.mozilla.org/pub/nspr/releases/
+| library/nss				| 3.68			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
+| library/nspr				| 4.32			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.45			| https://ftp.pcre.org/pub/pcre/
 | library/pcre2				| 10.37			| https://ftp.pcre.org/pub/pcre/
 | library/perl-5/xml-parser		| 2.46			| https://metacpan.org/pod/XML::Parser


### PR DESCRIPTION
Updating these packages causes the illumos build to fail. 

https://www.illumos.org/issues/13930

Once this is integrated to gate and illumos-omnios, this can be re-tested and merged.