### PR TITLE
Core package updates

### DIFF
--- a/build/binutils/build.sh
+++ b/build/binutils/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=binutils
-VER=2.36.1
+VER=2.37
 PKG=developer/gnu-binutils
 SUMMARY="GNU binary utilities"
 DESC="A set of programming tools for creating and managing binary programs, "

--- a/build/binutils/patches/x86ld64so.patch
+++ b/build/binutils/patches/x86ld64so.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/gold/x86_64.cc a/gold/x86_64.cc
 --- a~/gold/x86_64.cc	1970-01-01 00:00:00
 +++ a/gold/x86_64.cc	1970-01-01 00:00:00
-@@ -1407,7 +1407,11 @@ const Target::Target_info Target_x86_64<
+@@ -1411,7 +1411,11 @@ const Target::Target_info Target_x86_64<
    true,			// is_default_stack_executable
    true,			// can_icf_inline_merge_sections
    '\0',			// wrap_char

--- a/build/nghttp2/build.sh
+++ b/build/nghttp2/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=nghttp2
-VER=1.43.0
+VER=1.44.0
 PKG=library/nghttp2
 SUMMARY="nghttp2: HTTP/2 C Library"
 DESC="An implementation of the Hypertext Transfer Protocol version 2 in C"
@@ -28,6 +28,8 @@ BUILD_DEPENDS_IPS="ooce/developer/cunit"
 CONFIGURE_OPTS="
     --enable-lib-only
     --disable-silent-rules
+    --without-systemd
+    --with-openssl
 "
 
 export ZLIB_CFLAGS="$CFLAGS -I/usr/include"

--- a/build/nghttp2/testsuite.log
+++ b/build/nghttp2/testsuite.log
@@ -5,7 +5,7 @@ Making check in src
 Making check in includes
 Making all in includes
 ============================================================================
-Testsuite summary for nghttp2 1.43.0
+Testsuite summary for nghttp2 1.44.0
 ============================================================================
 # TOTAL: 0
 # PASS:  0
@@ -22,7 +22,7 @@ Making check in testdata
 PASS: main
 PASS: failmalloc
 ============================================================================
-Testsuite summary for nghttp2 1.43.0
+Testsuite summary for nghttp2 1.44.0
 ============================================================================
 # TOTAL: 2
 # PASS:  2

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -111,7 +111,7 @@
 | web/curl				| 7.77.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.21.1		| https://ftp.gnu.org/gnu/wget/
 | library/glib2				| 2.68.3		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
-| developer/gnu-binutils		| 2.36.1		| https://ftp.gnu.org/gnu/binutils
+| developer/gnu-binutils		| 2.37		| https://ftp.gnu.org/gnu/binutils
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
 | system/virtualization/azure-agent	| 2.2.54		| https://github.com/Azure/WALinuxAgent/releases
 | system/virtualization/open-vm-tools	| 11.3.0		| https://github.com/vmware/open-vm-tools/releases https://docs.vmware.com/en/VMware-Tools/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -48,7 +48,7 @@
 | library/libxml2			| 2.9.12		| https://github.com/GNOME/libxml2/releases http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.2			| https://ftp.gnu.org/gnu/ncurses/
-| library/nghttp2			| 1.43.0		| https://github.com/nghttp2/nghttp2/releases
+| library/nghttp2			| 1.44.0		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.65			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.30			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.45			| https://ftp.pcre.org/pub/pcre/


### PR DESCRIPTION
Building gate with the updated binutils results in:

```
../../i86pc/ml/kpti_trampolines.s:278: Warning: no instruction mnemonic suffix given and no register operands; using default for `sysexit'
```

The fix for this is going into illumos-omnios via https://github.com/omniosorg/illumos-omnios/pull/1028