### PR TITLE
ntpsec python libraries installed in wrong place

### DIFF
--- a/build/ntpsec/build.sh
+++ b/build/ntpsec/build.sh
@@ -44,7 +44,7 @@ CONFIGURE_OPTS="
     --pyshebang=$PYTHON
     --pythondir=$PYTHONVENDOR
     --pythonarchdir=$PYTHONVENDOR
-    --libdir=$PYTHONVENDOR
+    --libdir=$PYTHONVENDOR/ntp
     --enable-manpage --disable-doc
     --nopyc --nopyo --nopycache
     --enable-debug-gdb


### PR DESCRIPTION
Fixes https://github.com/omniosorg/omnios-build/issues/2411

Became broken in version 1.2.1 after upstream change: https://github.com/ntpsec/ntpsec/commit/2c81d1cba0ccf59593d2c154a099fa1e766838ac