### PR TITLE
bhyve-fw: resolve licence checksum conflict

### DIFF
--- a/build/bhyve-fw/local.mog
+++ b/build/bhyve-fw/local.mog
@@ -10,7 +10,7 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 license $(FWDIR)/LICENCE.$(UEFITAG).BhyvePkg license=BSD-2-Clause-Patent
-license $(FWDIR)/LICENCE.$(UEFITAG).OvmfPkg license=BSD-2-Clause-Patent
+license $(FWDIR)/LICENCE.$(UEFITAG).OvmfPkg license=ovmf/BSD-2-Clause-Patent
 license $(FWDIR)/LICENCE.$(UEFITAG).OvmfPkg license=MIT
 
 license $(FWDIR)/LICENCE.$(CSMTAG).OvmfPkg license=simplified-BSD


### PR DESCRIPTION
With two licences in this package with the same name but different content, `pkg verify` persistently shows:
```
bloody% pkg verify bhyve/firmware
PACKAGE                                                                 STATUS
pkg://omnios/system/bhyve/firmware                                       ERROR
        license: BSD-2-Clause-Patent
                ERROR: Hash: 'a5b1a4b5fa7e60af4de6df861c0b631058f418d6fdb189fed6dae59e7380484e' should be 'b3b3c895f7bb88d94a8cf991f70e12c1e17d8c801a2b8e5c304b7375ce2bcd4c'
```