### PR TITLE
core package updates

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=bind
-VER=9.16.19
+VER=9.16.20
 PKG=network/dns/bind
 SUMMARY="BIND DNS tools"
 DESC="Client utilities for DNS lookups"

--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -19,7 +19,7 @@
 . ../../lib/functions.sh
 
 PROG=git
-VER=2.32.0
+VER=2.33.0
 PKG=developer/versioning/git
 SUMMARY="$PROG - distributed version control system"
 DESC="Git is a free and open source distributed version control system "

--- a/build/git/testsuite.log
+++ b/build/git/testsuite.log
@@ -93,6 +93,8 @@
 # passed all 8 test(s)
 *** t0068-for-each-repo.sh ***
 # passed all 2 test(s)
+*** t0069-oidtree.sh ***
+# passed all 2 test(s)
 *** t0070-fundamental.sh ***
 # passed all 8 test(s)
 *** t0090-cache-tree.sh ***

--- a/build/glib/build.sh
+++ b/build/glib/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=glib
-VER=2.68.3
+VER=2.68.4
 PKG=library/glib2
 SUMMARY="GNOME utility library"
 DESC="The GNOME general-purpose utility library"

--- a/build/glib/testsuite.log
+++ b/build/glib/testsuite.log
@@ -260,8 +260,8 @@ glib:gio / converter-stream                FAIL   killed by signal 11 SIGSEGV
 glib:gio / defaultvalue                    FAIL   killed by signal 6 SIGABRT
 glib:gio / desktop-app-info                FAIL   killed by signal 5 SIGTRAP
 glib:gio / g-file-info                     FAIL   killed by signal 6 SIGABRT
-glib:gio / appmonitor                      FAIL   killed by signal 6 SIGABRT
 glib:gio / gsettings                       FAIL   killed by signal 5 SIGTRAP
+glib:gio / appmonitor                      FAIL   killed by signal 6 SIGABRT
 glib:gio+slow+flaky / testfilemonitor      FAIL   killed by signal 6 SIGABRT
 glib:glib / mapping-test                   FAIL   killed by signal 16 SIGUSR1
 glib:glib / unicode-encoding               FAIL   exit status 1

--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/functions.sh
 
 PROG=nss
-VER=3.68
+VER=3.69
 # Include NSPR version since we're downloading a combined tarball.
 NSPRVER=4.32
 # But set BUILDDIR to just be the NSS version.

--- a/build/python39/jaraco/build.sh
+++ b/build/python39/jaraco/build.sh
@@ -26,9 +26,9 @@ DESC="A bundle of jaraco python modules"
 
 typeset -A packages
 packages[classes]=3.2.1
-packages[collections]=3.3.0
+packages[collections]=3.4.0
 packages[functools]=3.3.0
-packages[text]=3.5.0
+packages[text]=3.5.1
 
 init
 prep_build

--- a/build/python39/mako/build.sh
+++ b/build/python39/mako/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/mako-39
 PROG=Mako
-VER=1.1.4
+VER=1.1.5
 SUMMARY="Mako - a python templating language"
 DESC="$SUMMARY"
 

--- a/build/python39/meson/build.sh
+++ b/build/python39/meson/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/meson-39
 PROG=meson
-VER=0.58.0
+VER=0.59.1
 SUMMARY="The Meson Build system"
 DESC="An open source build system meant to be both extremely fast, "
 DESC+="and, even more importantly, as user friendly as possible"

--- a/build/python39/meson/patches/compiler_def_static_linker.patch
+++ b/build/python39/meson/patches/compiler_def_static_linker.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild/compilers/compilers.py
 --- a~/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
 +++ a/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
-@@ -1025,7 +1025,7 @@ class Compiler(metaclass=abc.ABCMeta):
+@@ -1036,7 +1036,7 @@ class Compiler(HoldableObject, metaclass
  
      def get_largefile_args(self) -> T.List[str]:
          '''Enable transparent large-file-support for 32-bit UNIX systems'''
@@ -10,15 +10,15 @@ diff -wpruN '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild
              # Enable large-file support unconditionally on all platforms other
              # than macOS and MSVC. macOS is now 64-bit-only so it doesn't
              # need anything special, and MSVC doesn't have automatic LFS.
-diff -wpruN '--exclude=*.orig' a~/mesonbuild/environment.py a/mesonbuild/environment.py
---- a~/mesonbuild/environment.py	1970-01-01 00:00:00
-+++ a/mesonbuild/environment.py	1970-01-01 00:00:00
-@@ -732,7 +732,7 @@ class Environment:
-         self.default_rust = ['rustc']
-         self.default_swift = ['swiftc']
-         self.default_vala = ['valac']
--        self.default_static_linker = ['ar', 'gar']
-+        self.default_static_linker = ['gar', 'ar']
-         self.default_strip = ['strip']
-         self.vs_static_linker = ['lib']
-         self.clang_cl_static_linker = ['llvm-lib']
+diff -wpruN '--exclude=*.orig' a~/mesonbuild/linkers/detect.py a/mesonbuild/linkers/detect.py
+--- a~/mesonbuild/linkers/detect.py	1970-01-01 00:00:00
++++ a/mesonbuild/linkers/detect.py	1970-01-01 00:00:00
+@@ -40,7 +40,7 @@ if T.TYPE_CHECKING:
+     from ..compilers import Compiler
+ 
+ defaults: T.Dict[str, T.List[str]] = {}
+-defaults['static_linker'] = ['ar', 'gar']
++defaults['static_linker'] = ['gar', 'ar']
+ defaults['vs_static_linker'] = ['lib']
+ defaults['clang_cl_static_linker'] = ['llvm-lib']
+ defaults['cuda_static_linker'] = ['nvlink']

--- a/build/python39/orjson/build.sh
+++ b/build/python39/orjson/build.sh
@@ -18,16 +18,13 @@
 
 PKG=library/python-3/orjson-39
 PROG=orjson
-VER=3.5.3
-# orjson requries rust nightly. check https://github.com/ijl/orjson
-# for which version has been tested
-RUSTVER=2021-06-24
+VER=3.6.3
 SUMMARY="orjson"
 DESC="A fast, correct JSON library for Python."
 
 . $SRCDIR/../common.sh
 
-RUST=rust-nightly-x86_64-unknown-illumos
+export PATH=$PATH:$OOCEBIN
 
 install() {
     logmsg "Installing"
@@ -41,19 +38,7 @@ install() {
     popd >/dev/null
 }
 
-get_rust_nightly() {
-    BUILDDIR=$RUST download_source rust/nightly/$RUSTVER $RUST
-
-    logmsg "Installing rust nightly [$RUSTVER]"
-    logcmd $TMPDIR/$RUST/install.sh \
-        --prefix=$TMPDIR/_rust || logerr "installing rust"
-
-    CARGO="$TMPDIR/_rust/bin/cargo"
-    export PATH="$TMPDIR/_rust/bin:$PATH"
-}
-
 init
-get_rust_nightly
 download_source pymodules/$PROG $VER
 patch_source
 prep_build

--- a/build/python39/pip/build.sh
+++ b/build/python39/pip/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/pip-39
 PROG=pip
-VER=21.1.3
+VER=21.2.4
 SUMMARY="Tool for installing Python packages"
 DESC="$PROG is the standard package installer for Python"
 

--- a/build/python39/pycurl/build.sh
+++ b/build/python39/pycurl/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/functions.sh
 
 PKG=library/python-3/pycurl-39
 PROG=pycurl
-VER=7.43.0.6
+VER=7.44.1
 SUMMARY="Python bindings for libcurl"
 DESC="PycURL provides a thin layer of Python bindings on top of libcurl."
 

--- a/build/python39/setuptools/build.sh
+++ b/build/python39/setuptools/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-39
 PROG=setuptools
-VER=57.0.0
+VER=57.4.0
 SUMMARY="Python package management"
 DESC="Easily download, build, install, upgrade, and uninstall Python packages"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -63,7 +63,7 @@
 | library/xxhash			| 0.8.0			| https://github.com/Cyan4973/xxHash/releases | Currently used solely by rsync
 | library/zlib				| 1.2.11		| http://www.zlib.net/
 | meta/data/microcode			| 20210608		| https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases
-| network/dns/bind			| 9.16.19		| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/
+| network/dns/bind			| 9.16.20		| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/
 | network/openssh			| 8.7p1			| https://www.mirrorservice.org/pub/OpenBSD/OpenSSH/portable/
 | network/rsync				| 3.2.3			| https://rsync.samba.org/
 | network/service/isc-dhcp		| 4.4.2-P1			| https://ftp.isc.org/isc/dhcp/ https://www.isc.org/downloads/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -136,7 +136,7 @@
 | library/python-3/meson-39		| 0.59.1		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.6.3			| https://github.com/ijl/orjson/releases
-| library/python-3/pip-39		| 21.1.3		| https://pypi.org/project/pip
+| library/python-3/pip-39		| 21.2.4		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.1			| https://pypi.org/project/portend
 | library/python-3/prettytable-39	| 2.1.0			| https://pypi.org/project/PrettyTable

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -143,7 +143,7 @@
 | library/python-3/pybonjour-39		| 1.1.1			| https://pypi.org/project/pybonjour
 | library/python-3/pycodestyle-39	| 2.7.0			| https://pypi.org/project/pycodestyle/
 | library/python-3/pycparser-39		| 2.20			| https://pypi.org/project/pycparser
-| library/python-3/pycurl-39		| 7.43.0.6		| https://pypi.org/project/pycurl
+| library/python-3/pycurl-39		| 7.44.1		| https://pypi.org/project/pycurl
 | library/python-3/pyopenssl-39		| 20.0.1		| https://pypi.org/project/pyOpenSSL
 | library/python-3/pyrsistent-39	| 0.18.0		| https://pypi.org/project/pyrsistent
 | library/python-3/pytz-39		| 2021.1		| https://pypi.org/project/pytz

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -132,7 +132,7 @@
 | library/python-3/js-regex-39		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-39	| 0.4.2			| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-39	| 3.2.0			| https://pypi.org/project/jsonschema
-| library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
+| library/python-3/mako-39		| 1.1.5			| https://pypi.org/project/Mako
 | library/python-3/meson-39		| 0.59.1		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.6.3			| https://github.com/ijl/orjson/releases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -150,7 +150,7 @@
 | library/python-3/pyyaml-39		| 5.4.1			| https://pypi.org/project/PyYAML
 | library/python-3/rapidjson-39		| 1.4			| https://pypi.org/project/python-rapidjson
 | library/python-3/semantic-version-39	| 2.8.5			| https://pypi.org/project/semantic-version
-| library/python-3/setuptools-39	| 57.0.0		| https://pypi.org/project/setuptools
+| library/python-3/setuptools-39	| 57.4.0		| https://pypi.org/project/setuptools
 | library/python-3/setuptools-rust-39	| 0.12.1		| https://pypi.org/project/setuptools-rust
 | library/python-3/six-39		| 1.16.0		| https://pypi.org/project/six
 | library/python-3/tempora-39		| 4.1.1			| https://pypi.org/project/tempora

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -49,7 +49,7 @@
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/ncurses			| 6.2			| https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.44.0		| https://github.com/nghttp2/nghttp2/releases
-| library/nss				| 3.68			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
+| library/nss				| 3.69			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.32			| http://archive.mozilla.org/pub/nspr/releases/
 | library/pcre				| 8.45			| https://ftp.pcre.org/pub/pcre/
 | library/pcre2				| 10.37			| https://ftp.pcre.org/pub/pcre/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -135,7 +135,7 @@
 | library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
 | library/python-3/meson-39		| 0.58.0		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
-| library/python-3/orjson-39		| 3.5.3			| https://github.com/ijl/orjson/releases
+| library/python-3/orjson-39		| 3.6.3			| https://github.com/ijl/orjson/releases
 | library/python-3/pip-39		| 21.1.3		| https://pypi.org/project/pip
 | library/python-3/ply-39		| 3.11			| https://pypi.org/project/ply
 | library/python-3/portend-39		| 2.7.1			| https://pypi.org/project/portend

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -25,7 +25,7 @@
 | developer/nasm			| 2.15.05		| http://www.nasm.us/pub/nasm/releasebuilds
 | developer/parser/bison		| 3.7.6			| https://ftp.gnu.org/gnu/bison/
 | developer/pkg-config			| 0.29.2		| https://pkg-config.freedesktop.org/releases
-| developer/versioning/git		| 2.32.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
+| developer/versioning/git		| 2.33.0		| https://www.kernel.org/pub/software/scm/git https://git-scm.com/
 | developer/versioning/mercurial	| 5.8.1			| https://www.mercurial-scm.org/release/?M=D https://www.mercurial-scm.org/wiki/WhatsNew
 | developer/versioning/sccs		| 5.09			| https://sourceforge.net/projects/sccs/files/
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/releases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -133,7 +133,7 @@
 | library/python-3/jsonrpclib-39	| 0.4.2			| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-39	| 3.2.0			| https://pypi.org/project/jsonschema
 | library/python-3/mako-39		| 1.1.4			| https://pypi.org/project/Mako
-| library/python-3/meson-39		| 0.58.0		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
+| library/python-3/meson-39		| 0.59.1		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/more-itertools-39	| 8.8.0			| https://pypi.org/project/more-itertools
 | library/python-3/orjson-39		| 3.6.3			| https://github.com/ijl/orjson/releases
 | library/python-3/pip-39		| 21.1.3		| https://pypi.org/project/pip

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -126,9 +126,9 @@
 | library/python-3/cryptography-39	| 3.4.7			| https://pypi.org/project/cryptography
 | library/python-3/idna-39		| 3.2			| https://pypi.org/project/idna
 | library/python-3/jaraco.classes-39	| 3.2.1			| https://pypi.org/project/jaraco.classes
-| library/python-3/jaraco.collections-39 | 3.3.0		| https://pypi.org/project/jaraco.collections
+| library/python-3/jaraco.collections-39 | 3.4.0		| https://pypi.org/project/jaraco.collections
 | library/python-3/jaraco.functools-39	| 3.3.0			| https://pypi.org/project/jaraco.functools
-| library/python-3/jaraco.text-39	| 3.5.0			| https://pypi.org/project/jaraco.text
+| library/python-3/jaraco.text-39	| 3.5.1			| https://pypi.org/project/jaraco.text
 | library/python-3/js-regex-39		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-39	| 0.4.2			| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-39	| 3.2.0			| https://pypi.org/project/jsonschema

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -110,7 +110,7 @@
 | text/less				| 590			| http://www.greenwoodsoftware.com/less/download.html
 | web/curl				| 7.78.0		| https://curl.haxx.se/download.html
 | web/wget				| 1.21.1		| https://ftp.gnu.org/gnu/wget/
-| library/glib2				| 2.68.3		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
+| library/glib2				| 2.68.4		| https://download.gnome.org/sources/glib/cache.json https://download.gnome.org/sources/glib/ | Odd minor versions are dev/unstable
 | developer/gnu-binutils		| 2.37		| https://ftp.gnu.org/gnu/binutils
 | media/cdrtools			| 3.01			| https://sourceforge.net/projects/cdrtools/files
 | system/virtualization/azure-agent	| 2.2.54		| https://github.com/Azure/WALinuxAgent/releases


### PR DESCRIPTION
`pkt5` test suite matches baseline but one failing `pkglint` test which is not caused by the updated python modules but the test needs to be fixed in `pkg(5)`

i rebuilt `glib2`, `sigcpp`, `dav1d` and `pango` following the `meson` update.