### PR TITLE
fix p7zip truncates password to 8 chars

### DIFF
--- a/build/p7zip/patches/gcc11.patch
+++ b/build/p7zip/patches/gcc11.patch
@@ -1,6 +1,7 @@
---- p7zip_16.02~/CPP/7zip/Archive/Wim/WimHandler.cpp	2021-05-10 20:45:07.336655375 +0000
-+++ p7zip_16.02/CPP/7zip/Archive/Wim/WimHandler.cpp	2021-05-10 20:46:35.079619989 +0000
-@@ -298,14 +298,14 @@
+diff -wpruN '--exclude=*.orig' a~/CPP/7zip/Archive/Wim/WimHandler.cpp a/CPP/7zip/Archive/Wim/WimHandler.cpp
+--- a~/CPP/7zip/Archive/Wim/WimHandler.cpp	1970-01-01 00:00:00
++++ a/CPP/7zip/Archive/Wim/WimHandler.cpp	1970-01-01 00:00:00
+@@ -298,14 +298,14 @@ STDMETHODIMP CHandler::GetArchivePropert
  
        AString res;
  
@@ -17,7 +18,7 @@
          }
        }
  
-@@ -315,10 +315,10 @@
+@@ -315,10 +315,10 @@ STDMETHODIMP CHandler::GetArchivePropert
          ConvertUInt32ToString(methodUnknown, temp);
          res.Add_Space_if_NotEmpty();
          res += temp;

--- a/build/p7zip/patches/getpassphrase.patch
+++ b/build/p7zip/patches/getpassphrase.patch
@@ -1,0 +1,35 @@
+patch taken from: https://sourceforge.net/p/p7zip/bugs/230/#c36e
+
+       The getpassphrase() function is identical to getpass(), except that it
+       reads and returns a string of up to 257 characters in length.
+...
+       Upon successful completion, getpass() returns a pointer to a null-
+       terminated string of at most 9 bytes that were read from the terminal
+       device. If an error is encountered, the terminal state is restored and
+       a null pointer is returned.
+
+diff -wpruN '--exclude=*.orig' a~/CPP/7zip/UI/Console/UserInputUtils.cpp a/CPP/7zip/UI/Console/UserInputUtils.cpp
+--- a~/CPP/7zip/UI/Console/UserInputUtils.cpp	1970-01-01 00:00:00
++++ a/CPP/7zip/UI/Console/UserInputUtils.cpp	1970-01-01 00:00:00
+@@ -89,12 +89,21 @@ UString GetPassword(CStdOutStream *outSt
+     outStream->Flush();
+   }
+ #ifdef ENV_HAVE_GETPASS
++#if defined(__illumos__)
++  AString oemPassword = getpassphrase("");
++#else
+   AString oemPassword = getpass("");
++#endif
++
+   if ( (verify) && (outStream) )
+   {
+     (*outStream) << "Verify password (will not be echoed) :";
+     outStream->Flush();
++#if defined(__illumos__)
++    AString oemPassword2 = getpassphrase("");
++#else
+     AString oemPassword2 = getpass("");
++#endif
+     if (oemPassword != oemPassword2) throw "password verification failed";
+   }
+   return MultiByteToUnicodeString(oemPassword, CP_OEMCP);

--- a/build/p7zip/patches/series
+++ b/build/p7zip/patches/series
@@ -7,3 +7,4 @@ CVE-2018-10115.patch
 gcc10.patch
 stublibs.patch
 gcc11.patch
+getpassphrase.patch

--- a/build/p7zip/testsuite.log
+++ b/build/p7zip/testsuite.log
@@ -418,7 +418,7 @@ Items to compress: 6
 
 
 Files read from disk: 3
-Archive size: 955370 bytes (933 KiB)
+Archive size: 933834 bytes (912 KiB)
 Everything is Ok
 
 7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21


### PR DESCRIPTION
fixes: https://github.com/omniosorg/omnios-build/issues/2457