### PR TITLE
Switch default time sync service to chrony

### DIFF
--- a/build/chrony/local.mog
+++ b/build/chrony/local.mog
@@ -22,9 +22,6 @@ user ftpuser=false username=$(PROG) uid=23 group=$(PROG) \
 <transform dir path=var/lib/$(PROG)$ -> set owner $(PROG)>
 <transform dir path=var/lib/$(PROG)$ -> set group $(PROG)>
 
-# Allow installation in GZ only
-set name=variant.opensolaris.zone value=global
-
 # Restart chrony on binary change
 <transform file path=usr/sbin/chronyd$ -> \
     set restart_fmri svc:/network/chrony:default>

--- a/build/entire/entire.pkg
+++ b/build/entire/entire.pkg
@@ -238,8 +238,8 @@ release/notices
 security/sudo						O
 service/file-system/nfs
 service/hal						F
+service/network/chrony					O
 service/network/network-clients
-service/network/ntpsec					O
 service/network/smtp/dma				F
 service/storage/removable-media				OSZ
 shell/bash						O


### PR DESCRIPTION
This affects fresh installations only. Anyone upgrading keeps `ntpsec`.