### PR TITLE
OpenSSH: patch CVE-2021-41617.patch (r151038)

### DIFF
--- a/build/openssh/patches/CVE-2021-41617.patch
+++ b/build/openssh/patches/CVE-2021-41617.patch
@@ -1,0 +1,25 @@
+From f3cbe43e28fe71427d41cfe3a17125b972710455 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 26 Sep 2021 14:01:03 +0000
+Subject: [PATCH] upstream: need initgroups() before setresgid(); reported by
+ anton@,
+
+ok deraadt@
+
+OpenBSD-Commit-ID: 6aa003ee658b316960d94078f2a16edbc25087ce
+diff -wpruN '--exclude=*.orig' a~/misc.c a/misc.c
+--- a~/misc.c	1970-01-01 00:00:00
++++ a/misc.c	1970-01-01 00:00:00
+@@ -2629,6 +2629,12 @@ subprocess(const char *tag, const char *
+ 		}
+ 		closefrom(STDERR_FILENO + 1);
+ 
++		if (geteuid() == 0 &&
++		    initgroups(pw->pw_name, pw->pw_gid) == -1) {
++			error("%s: initgroups(%s, %u): %s", tag,
++			    pw->pw_name, (u_int)pw->pw_gid, strerror(errno));
++			_exit(1);
++		}
+ 		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
+ 			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,
+ 			    strerror(errno));

--- a/build/openssh/patches/series
+++ b/build/openssh/patches/series
@@ -22,3 +22,4 @@ sshd_config.patch
 0031-Restore-tcpwrappers-libwrap-support.patch
 revert-dscp.patch
 test.patch
+CVE-2021-41617.patch


### PR DESCRIPTION
OpenSSH: patch CVE-2021-41617.patch (r151038)
