### PR TITLE
OpenSSH: patch CVE-2021-41617.patch (r151030)

### DIFF
--- a/build/openssh/patches/CVE-2021-41617.patch
+++ b/build/openssh/patches/CVE-2021-41617.patch
@@ -1,0 +1,26 @@
+From f3cbe43e28fe71427d41cfe3a17125b972710455 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Sun, 26 Sep 2021 14:01:03 +0000
+Subject: [PATCH] upstream: need initgroups() before setresgid(); reported by
+ anton@,
+
+ok deraadt@
+
+OpenBSD-Commit-ID: 6aa003ee658b316960d94078f2a16edbc25087ce
+diff -wpruN '--exclude=*.orig' a~/auth.c a/auth.c
+--- a~/auth.c	1970-01-01 00:00:00
++++ a/auth.c	1970-01-01 00:00:00
+@@ -854,6 +854,13 @@ subprocess(const char *tag, struct passw
+ 		}
+ 		closefrom(STDERR_FILENO + 1);
+ 
++		if (geteuid() == 0 &&
++		    initgroups(pw->pw_name, pw->pw_gid) == -1) {
++			error("%s: initgroups(%s, %u): %s", tag,
++			    pw->pw_name, (u_int)pw->pw_gid, strerror(errno));
++			_exit(1);
++		}
++
+ 		/* Don't use permanently_set_uid() here to avoid fatal() */
+ 		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
+ 			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,

--- a/build/openssh/patches/series
+++ b/build/openssh/patches/series
@@ -24,3 +24,4 @@ sshd_config.patch
 openssl11-local.patch
 revert-dscp.patch
 scp-name-validator.patch
+CVE-2021-41617.patch


### PR DESCRIPTION
OpenSSH: patch CVE-2021-41617.patch (r151030)
