### PR TITLE
Fix python 3.10 tests

### DIFF
--- a/build/python310/patches/series
+++ b/build/python310/patches/series
@@ -29,4 +29,5 @@ test-vmlimit.patch
 test-processgroup.patch
 test-zipfile.patch
 test-pkgutil.patch
+test-metadata.patch
 revert-makedirs.patch

--- a/build/python310/patches/test-metadata.patch
+++ b/build/python310/patches/test-metadata.patch
@@ -1,0 +1,16 @@
+
+The importlib test checks that there is no package called 'pkg', which is not
+true on OmniOS.
+
+diff -wpruN '--exclude=*.orig' a~/Lib/test/test_importlib/test_metadata_api.py a/Lib/test/test_importlib/test_metadata_api.py
+--- a~/Lib/test/test_importlib/test_metadata_api.py	1970-01-01 00:00:00
++++ a/Lib/test/test_importlib/test_metadata_api.py	1970-01-01 00:00:00
+@@ -56,7 +56,7 @@ class APITests(
+                 assert distribution(name).metadata['Name'] == 'pkg.dot'
+ 
+     def test_prefix_not_matched(self):
+-        prefixes = 'p', 'pkg', 'pkg.'
++        prefixes = 'q', 'qkg', 'qkg.'
+         for prefix in prefixes:
+             with self.subTest(prefix):
+                 with self.assertRaises(PackageNotFoundError):

--- a/build/python310/testsuite.log
+++ b/build/python310/testsuite.log
@@ -1,7 +1,7 @@
 402 tests OK.
 
-1 test failed:
-    test_pkgutil
+1 test altered the execution environment:
+    test_ftplib
 
 24 tests skipped:
     test_dbm_gnu test_epoll test_gdb test_idle test_kqueue test_msilib
@@ -11,5 +11,4 @@
     test_winconsoleio test_winreg test_winsound test_xmlrpc_net
     test_zipfile64
 
-Tests result: FAILURE
-gmake: *** [Makefile:1224: test] Error 2
+Tests result: SUCCESS


### PR DESCRIPTION

This leaves just one warning:

```
1 test altered the execution environment:
    test_ftplib
```

which appears to be related to using openssl 3, it does not appear with openssl 1.1.

This is a test that sets up a dummy FTP server and tests connecting to it and gets an unexpected exception during a TLS handshake. The test is most likely using a deprecated cipher or algorithm. More investigation is required.

```
  File "/data/omnios-build/omniosorg/bloody/_build/Python-3.10.0/Python-3.10.0/Lib/test/test_ftplib.py", line 344, in _do_ssl_handshake
    self.socket.do_handshake()
  File "/data/omnios-build/omniosorg/bloody/_build/Python-3.10.0/Python-3.10.0/Lib/ssl.py", line 1341, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLZeroReturnError: TLS/SSL connection has been closed (EOF) (_ssl.c:997)
```