### PR TITLE
python39 - update from 3.9.8 to 3.9.9 (r151038)

### DIFF
--- a/build/python39/build.sh
+++ b/build/python39/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=Python
-VER=3.9.8
+VER=3.9.9
 PKG=runtime/python-39
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"


### PR DESCRIPTION
python39 - update from 3.9.8 to 3.9.9 (r151038)
