### PR TITLE
Prefer PEP518 python builds

### DIFF
--- a/build/python310/setuptools/build.sh
+++ b/build/python310/setuptools/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-310
 PROG=setuptools
-VER=60.2.0
+VER=60.5.0
 SUMMARY="Python package management"
 DESC="Easily download, build, install, upgrade, and uninstall Python packages"
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -156,7 +156,7 @@
 | library/python-3/pyyaml-310		| 6.0			| https://pypi.org/project/PyYAML
 | library/python-3/rapidjson-310	| 1.5			| https://pypi.org/project/python-rapidjson
 | library/python-3/semantic-version-310	| 2.8.5			| https://pypi.org/project/semantic-version
-| library/python-3/setuptools-310	| 60.2.0		| https://pypi.org/project/setuptools
+| library/python-3/setuptools-310	| 60.5.0		| https://pypi.org/project/setuptools
 | library/python-3/setuptools-rust-310	| 1.1.2			| https://pypi.org/project/setuptools-rust
 | library/python-3/six-310		| 1.16.0		| https://pypi.org/project/six
 | library/python-3/tempora-310		| 4.1.2			| https://pypi.org/project/tempora

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2465,24 +2465,43 @@ python_setuppy() {
         || logerr "--- install failed"
 }
 
+python_backend() {
+    typeset backend=
+
+    if [ -n "$PYTHON_BUILD_BACKEND" ]; then
+        backend=$PYTHON_BUILD_BACKEND
+    elif [ -f pyproject.toml ]; then
+        backend=pep518
+        # Warn if the project has both in case we wish to force one or the
+        # other.
+        [ -f setup.py ] && \
+            logmsg -n "Project has both pyproject.toml and setup.py," \
+            "using PEP518"
+    elif [ -f setup.py ]; then
+        backend=setuppy
+    else
+        logerr "-- Could not determine python build backend to use"
+    fi
+
+    python_$backend "$@"
+}
+
 python_build32() {
     export ISALIST=i386
     pre_python_32
-    [ -f setup.py ] && backend=setuppy || backend=pep518
     CFLAGS="$CFLAGS $CFLAGS32" LDFLAGS="$LDFLAGS $LDFLAGS32" \
         PYBUILDOPTS="$PYBUILDOPTS $PYBUILDOPTS32" \
         PYINSTOPTS="$PYINSTOPTS $PYINST32OPTS" \
-        python_$backend
+        python_backend
 }
 
 python_build64() {
     export ISALIST="amd64 i386"
     pre_python_64
-    [ -f setup.py ] && backend=setuppy || backend=pep518
     CFLAGS="$CFLAGS $CFLAGS64" LDFLAGS="$LDFLAGS $LDFLAGS64" \
         PYBUILDOPTS="$PYBUILDOPTS $PYBUILDOPTS64" \
         PYINSTOPTS="$PYINSTOPTS $PYINST64OPTS" \
-        python_$backend
+        python_backend
 }
 
 python_build() {


### PR DESCRIPTION
With the latest version of setuptools, some legacy builds ends up with modules thinking they have a version number of 0.0.0.
When projects ship both, prefer the newer build system.