### PR TITLE
curl: Fix regression in 7.82.0

### DIFF
--- a/build/curl/patches/openssl-cn-bug.patch
+++ b/build/curl/patches/openssl-cn-bug.patch
@@ -1,0 +1,22 @@
+
+Regression introduced in curl 7.82.0, see
+
+https://github.com/curl/curl/issues/8559
+https://github.com/curl/curl/issues/8582
+
+affects the pkg test suite.
+
+Should be fixed in the next release, but they do not seem in a rush
+to do that.
+
+diff -wpruN '--exclude=*.orig' a~/lib/vtls/openssl.c a/lib/vtls/openssl.c
+--- a~/lib/vtls/openssl.c	1970-01-01 00:00:00
++++ a/lib/vtls/openssl.c	1970-01-01 00:00:00
+@@ -1808,6 +1808,7 @@ CURLcode Curl_ossl_verifyhost(struct Cur
+               memcpy(peer_CN, ASN1_STRING_get0_data(tmp), peerlen);
+               peer_CN[peerlen] = '\0';
+             }
++            else
+             result = CURLE_OUT_OF_MEMORY;
+           }
+         }

--- a/build/curl/patches/series
+++ b/build/curl/patches/series
@@ -1,1 +1,2 @@
 tests.patch
+openssl-cn-bug.patch


### PR DESCRIPTION
Fix a regression in curl 7.82.0 which causes pkg test suite failures, see

https://github.com/curl/curl/issues/8559
https://github.com/curl/curl/issues/8582