### PR TITLE
openjdk updates

### DIFF
--- a/build/openjdk11/build.sh
+++ b/build/openjdk11/build.sh
@@ -18,8 +18,8 @@
 
 PROG=openjdk
 VER=11
-UPDATE=14
-BUILD=9
+UPDATE=15
+BUILD=10
 PKG=runtime/java/openjdk11
 SUMMARY="openjdk $VER"
 DESC="Open-source implementation of the eleventh edition of the "

--- a/build/openjdk17/build.sh
+++ b/build/openjdk17/build.sh
@@ -18,8 +18,8 @@
 
 PROG=openjdk
 VER=17
-UPDATE=2
-BUILD=8
+UPDATE=3
+BUILD=7
 PKG=runtime/java/openjdk17
 SUMMARY="openjdk $VER"
 DESC="Open-source implementation of the seventeenth edition of the "

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -72,7 +72,7 @@
 | network/socat				| 1.7.4.3		| http://www.dest-unreach.org/socat/download/
 | network/test/iperf			| 3.1.3			| https://iperf.fr/iperf-download.php#source
 | network/test/netperf			| 2.7.0			| https://github.com/HewlettPackard/netperf/tags
-| runtime/java/openjdk11		| 11.0.14+9		| https://github.com/openjdk/jdk11u/tags
+| runtime/java/openjdk11		| 11.0.15+10		| https://github.com/openjdk/jdk11u/tags
 | runtime/java/openjdk17		| 17.0.3+7		| https://github.com/openjdk/jdk17u/tags
 | runtime/java/openjdk8			| 1.8.312-07		| https://hg.openjdk.java.net/jdk8u/jdk8u/tags
 | runtime/perl				| 5.34.1		| https://www.cpan.org/src/README.html

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -73,7 +73,7 @@
 | network/test/iperf			| 3.1.3			| https://iperf.fr/iperf-download.php#source
 | network/test/netperf			| 2.7.0			| https://github.com/HewlettPackard/netperf/tags
 | runtime/java/openjdk11		| 11.0.14+9		| https://github.com/openjdk/jdk11u/tags
-| runtime/java/openjdk17		| 17.0.2+8		| https://github.com/openjdk/jdk17u/tags
+| runtime/java/openjdk17		| 17.0.3+7		| https://github.com/openjdk/jdk17u/tags
 | runtime/java/openjdk8			| 1.8.312-07		| https://hg.openjdk.java.net/jdk8u/jdk8u/tags
 | runtime/perl				| 5.34.1		| https://www.cpan.org/src/README.html
 | runtime/python-27			| 2.7.18		| https://www.python.org/downloads/source/


### PR DESCRIPTION
deferring `openjdk8` update since `-ga` tag is not there, yet.