### PR TITLE
libltdl from libtool has the wrong 64-bit search path

### DIFF
--- a/build/libtool/build.sh
+++ b/build/libtool/build.sh
@@ -33,6 +33,13 @@ CONFIGURE_OPTS="
     --disable-static
 "
 
+# The libltdl library encodes a search path for library files that is correct
+# for 32-bit processes, but needs to be amended for 64-bit processes so that it
+# matches the system default.
+CONFIGURE_OPTS_64+="
+    LT_SYS_LIBRARY_PATH=/lib/$ISAPART64:/usr/lib/$ISAPART64
+"
+
 build_manifests() {
     manifest_start $TMPDIR/manifest.libltdl
     manifest_add_dir $PREFIX/lib $ISAPART64


### PR DESCRIPTION
Fixes #2799 

```
build:omnios:libtool% strings tmp/pkg/usr/lib/libltdl.so | grep usr/lib
/lib:/usr/lib
build:omnios:libtool% strings tmp/pkg/usr/lib/amd64/libltdl.so | grep usr/lib
/lib/amd64:/usr/lib/amd64
```