### PR TITLE
python39 - update from 3.9.12 to 3.9.13 (r151040)

### DIFF
--- a/build/python39/build.sh
+++ b/build/python39/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=Python
-VER=3.9.12
+VER=3.9.13
 PKG=runtime/python-39
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"

--- a/build/python39/patches/enable-ossaudiodev.patch
+++ b/build/python39/patches/enable-ossaudiodev.patch
@@ -21,20 +21,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/ossaudiodev.c a/Modules/ossaudiodev.c
  #ifdef SNDCTL_DSP_BIND_CHANNEL
      _EXPORT_INT(m, SNDCTL_DSP_BIND_CHANNEL);
  #endif
-@@ -1243,8 +1245,12 @@ PyInit_ossaudiodev(void)
-     _EXPORT_INT(m, SNDCTL_DSP_GETSPDIF);
- #endif
-     _EXPORT_INT(m, SNDCTL_DSP_GETTRIGGER);
-+#ifdef SNDCTL_DSP_MAPINBUF
-     _EXPORT_INT(m, SNDCTL_DSP_MAPINBUF);
-+#endif
-+#ifdef SNDCTL_DSP_MAPOUTBUF
-     _EXPORT_INT(m, SNDCTL_DSP_MAPOUTBUF);
-+#endif
-     _EXPORT_INT(m, SNDCTL_DSP_NONBLOCK);
-     _EXPORT_INT(m, SNDCTL_DSP_POST);
- #ifdef SNDCTL_DSP_PROFILE
-@@ -1264,6 +1270,7 @@ PyInit_ossaudiodev(void)
+@@ -1268,6 +1270,7 @@ PyInit_ossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_DSP_STEREO);
      _EXPORT_INT(m, SNDCTL_DSP_SUBDIVIDE);
      _EXPORT_INT(m, SNDCTL_DSP_SYNC);
@@ -42,7 +29,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/ossaudiodev.c a/Modules/ossaudiodev.c
      _EXPORT_INT(m, SNDCTL_FM_4OP_ENABLE);
      _EXPORT_INT(m, SNDCTL_FM_LOAD_INSTR);
      _EXPORT_INT(m, SNDCTL_MIDI_INFO);
-@@ -1305,5 +1312,6 @@ PyInit_ossaudiodev(void)
+@@ -1309,5 +1312,6 @@ PyInit_ossaudiodev(void)
      _EXPORT_INT(m, SNDCTL_TMR_STOP);
      _EXPORT_INT(m, SNDCTL_TMR_TEMPO);
      _EXPORT_INT(m, SNDCTL_TMR_TIMEBASE);

--- a/build/python39/patches/mod-posix-sched_priority.patch
+++ b/build/python39/patches/mod-posix-sched_priority.patch
@@ -7,7 +7,7 @@ However, -1 alongside EINVAL represents an error.
 diff -wpruN '--exclude=*.orig' a~/Modules/posixmodule.c a/Modules/posixmodule.c
 --- a~/Modules/posixmodule.c	1970-01-01 00:00:00
 +++ a/Modules/posixmodule.c	1970-01-01 00:00:00
-@@ -6713,7 +6713,11 @@ os_sched_get_priority_max_impl(PyObject
+@@ -6723,7 +6723,11 @@ os_sched_get_priority_max_impl(PyObject
      int max;
  
      max = sched_get_priority_max(policy);
@@ -19,7 +19,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/posixmodule.c a/Modules/posixmodule.c
          return posix_error();
      return PyLong_FromLong(max);
  }
-@@ -6732,7 +6736,11 @@ os_sched_get_priority_min_impl(PyObject
+@@ -6742,7 +6746,11 @@ os_sched_get_priority_min_impl(PyObject
  /*[clinic end generated code: output=7595c1138cc47a6d input=21bc8fa0d70983bf]*/
  {
      int min = sched_get_priority_min(policy);

--- a/build/python39/patches/revert-makedirs.patch
+++ b/build/python39/patches/revert-makedirs.patch
@@ -28,7 +28,7 @@ diff -wpruN '--exclude=*.orig' a~/Lib/os.py a/Lib/os.py
 diff -wpruN '--exclude=*.orig' a~/Lib/test/test_os.py a/Lib/test/test_os.py
 --- a~/Lib/test/test_os.py	1970-01-01 00:00:00
 +++ a/Lib/test/test_os.py	1970-01-01 00:00:00
-@@ -1434,12 +1434,12 @@ class MakedirTests(unittest.TestCase):
+@@ -1435,12 +1435,12 @@ class MakedirTests(unittest.TestCase):
              base = support.TESTFN
              parent = os.path.join(base, 'dir1')
              path = os.path.join(parent, 'dir2')


### PR DESCRIPTION
python39 - update from 3.9.12 to 3.9.13 (r151040)
