### PR TITLE
Update baseline

### DIFF
--- a/doc/baseline
+++ b/doc/baseline
@@ -132,6 +132,7 @@ omnios driver/network/e1000g
 omnios driver/network/efe
 omnios driver/network/elxl
 omnios driver/network/emlxs
+omnios driver/network/ena
 omnios driver/network/eoib
 omnios driver/network/fcip
 omnios driver/network/fcoe


### PR DESCRIPTION
Adds only drivers/network/ena, which was added to entire in [PR-2608][] for master and [PR-2631][] for r151038.

[PR-2608]: https://github.com/omniosorg/omnios-build/pull/2608
[PR-2631]: https://github.com/omniosorg/omnios-build/pull/2631