### PR TITLE
python310 - update from 3.10.5 to 3.10.6

### DIFF
--- a/build/python310/build.sh
+++ b/build/python310/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=Python
-VER=3.10.5
+VER=3.10.6
 PKG=runtime/python-310
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"

--- a/build/python310/patches/enable-ossaudiodev.patch
+++ b/build/python310/patches/enable-ossaudiodev.patch
@@ -1,49 +1,12 @@
-This patch is needed to make Python understand it can build the OSS plugin.
-Some OSS ioctls are not supported on illumos, so they are ifdef'd out.
-
-diff -wpruN '--exclude=*.orig' a~/Modules/ossaudiodev.c a/Modules/ossaudiodev.c
---- a~/Modules/ossaudiodev.c	1970-01-01 00:00:00
-+++ a/Modules/ossaudiodev.c	1970-01-01 00:00:00
-@@ -1210,6 +1210,7 @@ PyInit_ossaudiodev(void)
-     _EXPORT_INT(m, SOUND_MIXER_MONITOR);
- #endif
- 
-+#ifndef __illumos__
-     /* Expose all the ioctl numbers for masochists who like to do this
-        stuff directly. */
-     _EXPORT_INT(m, SNDCTL_COPR_HALT);
-@@ -1222,6 +1223,7 @@ PyInit_ossaudiodev(void)
-     _EXPORT_INT(m, SNDCTL_COPR_SENDMSG);
-     _EXPORT_INT(m, SNDCTL_COPR_WCODE);
-     _EXPORT_INT(m, SNDCTL_COPR_WDATA);
-+#endif /* !__illumos__ */
- #ifdef SNDCTL_DSP_BIND_CHANNEL
-     _EXPORT_INT(m, SNDCTL_DSP_BIND_CHANNEL);
- #endif
-@@ -1268,6 +1270,7 @@ PyInit_ossaudiodev(void)
-     _EXPORT_INT(m, SNDCTL_DSP_STEREO);
-     _EXPORT_INT(m, SNDCTL_DSP_SUBDIVIDE);
-     _EXPORT_INT(m, SNDCTL_DSP_SYNC);
-+#ifndef __illumos__
-     _EXPORT_INT(m, SNDCTL_FM_4OP_ENABLE);
-     _EXPORT_INT(m, SNDCTL_FM_LOAD_INSTR);
-     _EXPORT_INT(m, SNDCTL_MIDI_INFO);
-@@ -1309,5 +1312,6 @@ PyInit_ossaudiodev(void)
-     _EXPORT_INT(m, SNDCTL_TMR_STOP);
-     _EXPORT_INT(m, SNDCTL_TMR_TEMPO);
-     _EXPORT_INT(m, SNDCTL_TMR_TIMEBASE);
-+#endif /* !__illumos__ */
-     return m;
- }
 diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
 --- a~/setup.py	1970-01-01 00:00:00
 +++ a/setup.py	1970-01-01 00:00:00
-@@ -1682,7 +1682,7 @@ class PyBuildExt(build_ext):
+@@ -1681,7 +1681,7 @@ class PyBuildExt(build_ext):
              self.missing.extend(['resource', 'termios'])
  
          # Platform-specific libraries
 -        if HOST_PLATFORM.startswith(('linux', 'freebsd', 'gnukfreebsd')):
 +        if HOST_PLATFORM.startswith(('sunos5', 'linux', 'freebsd', 'gnukfreebsd')):
              self.add(Extension('ossaudiodev', ['ossaudiodev.c']))
-         elif not AIX:
-             self.missing.append('ossaudiodev')
+         elif HOST_PLATFORM.startswith(('netbsd')):
+             self.add(Extension('ossaudiodev', ['ossaudiodev.c'],

--- a/build/python310/patches/mod-socket-xpg6.patch
+++ b/build/python310/patches/mod-socket-xpg6.patch
@@ -5,7 +5,7 @@ needs to be built in an XPG6 environment.
 diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
 --- a~/setup.py	1970-01-01 00:00:00
 +++ a/setup.py	1970-01-01 00:00:00
-@@ -1262,6 +1262,10 @@ class PyBuildExt(build_ext):
+@@ -1261,6 +1261,10 @@ class PyBuildExt(build_ext):
          if MACOS:
              # Issue #35569: Expose RFC 3542 socket options.
              kwargs['extra_compile_args'] = ['-D__APPLE_USE_RFC_3542']

--- a/build/python310/patches/module-dlpi.patch
+++ b/build/python310/patches/module-dlpi.patch
@@ -1339,7 +1339,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/dlpimodule.c a/Modules/dlpimodule.c
 diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
 --- a~/setup.py	1970-01-01 00:00:00
 +++ a/setup.py	1970-01-01 00:00:00
-@@ -1922,6 +1922,7 @@ class PyBuildExt(build_ext):
+@@ -1924,6 +1924,7 @@ class PyBuildExt(build_ext):
              self.missing.append('_tkinter')
          self.detect_uuid()
          self.detect_ucred()
@@ -1347,7 +1347,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
  
  ##         # Uncomment these lines if you want to play with xxmodule.c
  ##         self.add(Extension('xx', ['xxmodule.c']))
-@@ -2463,6 +2464,13 @@ class PyBuildExt(build_ext):
+@@ -2465,6 +2466,13 @@ class PyBuildExt(build_ext):
              return
          self.add(Extension('ucred', ['ucred.c'], libraries = ['tsol']))
  

--- a/build/python310/patches/module-priv-rbac.patch
+++ b/build/python310/patches/module-priv-rbac.patch
@@ -1283,7 +1283,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/userattr.c a/Modules/userattr.c
 diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
 --- a~/setup.py	1970-01-01 00:00:00
 +++ a/setup.py	1970-01-01 00:00:00
-@@ -1923,6 +1923,7 @@ class PyBuildExt(build_ext):
+@@ -1925,6 +1925,7 @@ class PyBuildExt(build_ext):
          self.detect_uuid()
          self.detect_ucred()
          self.detect_dlpi()
@@ -1291,7 +1291,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
  
  ##         # Uncomment these lines if you want to play with xxmodule.c
  ##         self.add(Extension('xx', ['xxmodule.c']))
-@@ -2471,6 +2472,24 @@ class PyBuildExt(build_ext):
+@@ -2473,6 +2474,24 @@ class PyBuildExt(build_ext):
              return
          self.add(Extension('dlpi', ['dlpimodule.c'], libraries = ['dlpi']))
  

--- a/build/python310/patches/module-ucred.patch
+++ b/build/python310/patches/module-ucred.patch
@@ -462,7 +462,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/ucred.c a/Modules/ucred.c
 diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
 --- a~/setup.py	1970-01-01 00:00:00
 +++ a/setup.py	1970-01-01 00:00:00
-@@ -1921,6 +1921,7 @@ class PyBuildExt(build_ext):
+@@ -1923,6 +1923,7 @@ class PyBuildExt(build_ext):
          if not self.detect_tkinter():
              self.missing.append('_tkinter')
          self.detect_uuid()
@@ -470,7 +470,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
  
  ##         # Uncomment these lines if you want to play with xxmodule.c
  ##         self.add(Extension('xx', ['xxmodule.c']))
-@@ -2454,6 +2455,14 @@ class PyBuildExt(build_ext):
+@@ -2456,6 +2457,14 @@ class PyBuildExt(build_ext):
                             sources=sources,
                             depends=depends))
  

--- a/build/python310/patches/setup.patch
+++ b/build/python310/patches/setup.patch
@@ -9,7 +9,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
  VXWORKS = ('vxworks' in HOST_PLATFORM)
  CC = os.environ.get("CC")
  if not CC:
-@@ -826,7 +827,7 @@ class PyBuildExt(build_ext):
+@@ -825,7 +826,7 @@ class PyBuildExt(build_ext):
          # Ensure that /usr/local is always used, but the local build
          # directories (i.e. '.' and 'Include') must be first.  See issue
          # 10520.
@@ -18,7 +18,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
              add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
              add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
          # only change this for cross builds for 3.3, issues on Mageia
-@@ -1150,6 +1151,14 @@ class PyBuildExt(build_ext):
+@@ -1149,6 +1150,14 @@ class PyBuildExt(build_ext):
                                                       ['/usr/lib/termcap'],
                                                       'termcap'):
                  readline_libs.append('termcap')
@@ -33,7 +33,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
              self.add(Extension('readline', ['readline.c'],
                                 library_dirs=['/usr/lib/termcap'],
                                 extra_link_args=readline_extra_link_args,
-@@ -1184,6 +1193,12 @@ class PyBuildExt(build_ext):
+@@ -1183,6 +1192,12 @@ class PyBuildExt(build_ext):
  
          curses_enabled = True
          if curses_library.startswith('ncurses'):
@@ -46,7 +46,7 @@ diff -wpruN '--exclude=*.orig' a~/setup.py a/setup.py
              curses_libs = [curses_library]
              self.add(Extension('_curses', ['_cursesmodule.c'],
                                 extra_compile_args=['-DPy_BUILD_CORE_MODULE'],
-@@ -1213,10 +1228,15 @@ class PyBuildExt(build_ext):
+@@ -1212,10 +1227,15 @@ class PyBuildExt(build_ext):
          skip_curses_panel = True if AIX else False
          if (curses_enabled and not skip_curses_panel and
                  self.compiler.find_library_file(self.lib_dirs, panel_library)):

--- a/build/python310/patches/test-shutil.patch
+++ b/build/python310/patches/test-shutil.patch
@@ -4,7 +4,7 @@ On illumos, sendfile(fd1, fd1) succeeds without raising an exception
 diff -wpruN '--exclude=*.orig' a~/Lib/test/test_shutil.py a/Lib/test/test_shutil.py
 --- a~/Lib/test/test_shutil.py	1970-01-01 00:00:00
 +++ a/Lib/test/test_shutil.py	1970-01-01 00:00:00
-@@ -2396,7 +2396,7 @@ class _ZeroCopyFileTest(object):
+@@ -2411,7 +2411,7 @@ class _ZeroCopyFileTest(object):
      def test_same_file(self):
          self.addCleanup(self.reset)
          with self.get_files() as (src, dst):

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -79,7 +79,7 @@
 | runtime/perl				| 5.36.0		| https://www.cpan.org/src/README.html
 | runtime/python-27			| 2.7.18		| https://www.python.org/downloads/source/
 | runtime/python-39			| 3.9.13		| https://www.python.org/downloads/source/
-| runtime/python-310			| 3.10.5		| https://www.python.org/downloads/source/
+| runtime/python-310			| 3.10.6		| https://www.python.org/downloads/source/
 | security/sudo				| 1.9.11p3		| https://www.sudo.ws/
 | service/network/chrony		| 4.2			| https://download.tuxfamily.org/chrony/
 | service/network/ntpsec		| 1.2.1			| https://github.com/ntpsec/ntpsec/tags https://blog.ntpsec.org/


### PR DESCRIPTION
Python testsuite output is unchanged, IPS tests all match baseline.

```
# Ran 1066 tests in 1860.029s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================
```