### PR TITLE
Add runtime/java/runtime64 package

### DIFF
--- a/build/obsolete/runtime-java-runtime64.p5m
+++ b/build/obsolete/runtime-java-runtime64.p5m
@@ -1,0 +1,10 @@
+# The system/dtrace/tests package in illumos-gate has a dependency on
+# runtime/java and runtime/java/runtime64.
+# This renamed package exists to make it easier to onu to gate with the
+# dtrace tests package installed, or to install that tests package in a gate
+# onu.
+# It's a straight rename to runtime/java, which is itself a rename to a
+# particular version of openjdk.
+set name=pkg.fmri value=pkg://@PKGPUBLISHER@/runtime/java/runtime64@1.8.0.999,@SUNOSVER@-@PVER@
+set name=pkg.renamed value=true
+depend fmri=pkg:/runtime/java type=require

--- a/build/obsolete/runtime-java.p5m
+++ b/build/obsolete/runtime-java.p5m
@@ -1,3 +1,3 @@
-set name=pkg.fmri value=pkg://@PKGPUBLISHER@/runtime/java@1.8.0.202.20190219,@SUNOSVER@-@PVER@
+set name=pkg.fmri value=pkg://@PKGPUBLISHER@/runtime/java@1.8.0.999,@SUNOSVER@-@PVER@
 set name=pkg.renamed value=true
 depend fmri=pkg:/runtime/java/openjdk8 type=require

--- a/doc/baseline
+++ b/doc/baseline
@@ -511,6 +511,7 @@ omnios print/lp/print-manager/legacy
 omnios release/name
 omnios release/notices
 omnios runtime/java r
+omnios runtime/java/runtime64 r
 omnios runtime/java/jexec
 omnios runtime/java/openjdk11
 omnios runtime/java/openjdk17


### PR DESCRIPTION
The illumos-gate dtrace test package has a dependency on `runtime/java/runtime64` - to make it easier for people running gate pieces to install or update the dtrace tests, add a renamed package entry for this to OmniOS.