### PR TITLE
python39 - update from 3.9.13 to 3.9.14 (r151040)

### DIFF
--- a/build/python39/build.sh
+++ b/build/python39/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=Python
-VER=3.9.13
+VER=3.9.14
 PKG=runtime/python-39
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"

--- a/build/python39/patches/module-py_db.patch
+++ b/build/python39/patches/module-py_db.patch
@@ -29,7 +29,7 @@ diff -wpruN '--exclude=*.orig' a~/Makefile.pre.in a/Makefile.pre.in
  
  Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) $(EXPORTSYMS)
  	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
-@@ -1248,7 +1257,7 @@ multisslcompile: build_all
+@@ -1249,7 +1258,7 @@ multisslcompile: build_all
  multissltest: build_all
  	$(RUNSHARED) ./$(BUILDPYTHON) Tools/ssl/multissltests.py
  


### PR DESCRIPTION
python39 - update from 3.9.13 to 3.9.14 (r151040)
