### PR TITLE
Core package updates

### DIFF
--- a/build/bind/build.sh
+++ b/build/bind/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=bind
-VER=9.18.6
+VER=9.18.7
 PKG=network/dns/bind
 SUMMARY="BIND DNS tools"
 DESC="Client utilities for DNS lookups"

--- a/build/expat/build.sh
+++ b/build/expat/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=expat
-VER=2.4.8
+VER=2.4.9
 PKG=library/expat
 SUMMARY="XML parser library"
 DESC="Fast streaming XML parser written in C"

--- a/build/expat/patches/manpage.patch
+++ b/build/expat/patches/manpage.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/doc/Makefile.in a/doc/Makefile.in
 --- a~/doc/Makefile.in	1970-01-01 00:00:00
 +++ a/doc/Makefile.in	1970-01-01 00:00:00
-@@ -340,7 +340,7 @@ target_alias = @target_alias@
+@@ -341,7 +341,7 @@ target_alias = @target_alias@
  top_build_prefix = @top_build_prefix@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@

--- a/build/expat/patches/no_link_libm.patch
+++ b/build/expat/patches/no_link_libm.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/m4/libtool.m4 a/m4/libtool.m4
 --- a~/m4/libtool.m4	1970-01-01 00:00:00
 +++ a/m4/libtool.m4	1970-01-01 00:00:00
-@@ -3867,7 +3867,7 @@ case $host in
+@@ -3887,7 +3887,7 @@ case $host in
    AC_CHECK_LIB(m, cos, LIBM="$LIBM -lm")
    ;;
  *)

--- a/build/libffi/build.sh
+++ b/build/libffi/build.sh
@@ -13,12 +13,12 @@
 # }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=libffi
-VER=3.4.2
+VER=3.4.3
 PKG=library/libffi
 SUMMARY="A Portable Foreign Function Interface Library"
 DESC="$PROG - $SUMMARY"
@@ -30,6 +30,8 @@ SKIP_LICENCES=libffi
 PVERS="3.2.1 3.3"
 
 LDFLAGS+=" $SSPFLAGS"
+
+export MAKE
 
 # libffi has historically been linked with libtool's -nostdlib.
 # The exact reason for this unclear but historic commit messages indicate that
@@ -61,18 +63,18 @@ init
 prep_build
 
 # Build previous versions
+save_variables BUILDDIR EXTRACTED_SRC
 for pver in $PVERS; do
     note -n "Building previous version: $pver"
-    save_variable BUILDDIR
-    BUILDDIR=$PROG-$pver
+    set_builddir $PROG-$pver
     download_source -dependency $PROG $PROG $pver
-    patch_source $PROG-`echo $pver | cut -d. -f1-2`
+    patch_source patches-`echo $pver | cut -d. -f1-2`
     if ((EXTRACT_MODE == 0)); then
         build
         tests
     fi
-    restore_variable BUILDDIR
 done
+restore_variables BUILDDIR EXTRACTED_SRC
 
 note -n "Building current version: $VER"
 download_source $PROG $PROG $VER

--- a/build/libffi/local.mog
+++ b/build/libffi/local.mog
@@ -7,9 +7,13 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 
+# Remove include files that the old 3.2 version installs under usr/lib
 <transform path=usr/lib/(?:amd64/)?libffi-3\.2 -> drop>
+
+# Remove static libraries
+<transform path=.*\.a$ -> drop>
 
 license LICENSE license=libffi
 

--- a/build/libffi/patches-3.3/unwind-instead-of-exceptions.patch
+++ b/build/libffi/patches-3.3/unwind-instead-of-exceptions.patch
@@ -1,7 +1,7 @@
-diff -ru libffi-3.1-orig/configure libffi-3.1/configure
---- libffi-3.1-orig/configure	Mon May 19 09:44:03 2014
-+++ libffi-3.1/configure	Tue Aug 12 20:18:42 2014
-@@ -16944,7 +16944,7 @@
+diff -wpruN '--exclude=*.orig' a~/configure a/configure
+--- a~/configure	1970-01-01 00:00:00
++++ a/configure	1970-01-01 00:00:00
+@@ -17396,7 +17396,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
  fi
  
  if test "x$GCC" = "xyes"; then
@@ -10,7 +10,7 @@ diff -ru libffi-3.1-orig/configure libffi-3.1/configure
  fi
  
  cat > local.exp <<EOF
-@@ -18661,7 +18661,7 @@
+@@ -18547,7 +18547,7 @@ else
  
    	libffi_cv_ro_eh_frame=no
    	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c
@@ -18,4 +18,4 @@ diff -ru libffi-3.1-orig/configure libffi-3.1/configure
 +  	if $CC $CFLAGS -c -fpic -funwind-tables -o conftest.o conftest.c > /dev/null 2>&1; then
  	    objdump -h conftest.o > conftest.dump 2>&1
  	    libffi_eh_frame_line=`grep -n eh_frame conftest.dump | cut -d: -f 1`
- 	    libffi_test_line=`expr $libffi_eh_frame_line + 1`p
+ 	    if test "x$libffi_eh_frame_line" != "x"; then

--- a/build/libffi/patches/unwind-instead-of-exceptions.patch
+++ b/build/libffi/patches/unwind-instead-of-exceptions.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/configure a/configure
 --- a~/configure	1970-01-01 00:00:00
 +++ a/configure	1970-01-01 00:00:00
-@@ -17502,7 +17502,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+@@ -18628,7 +18628,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
  fi
  
  if test "x$GCC" = "xyes"; then
@@ -10,7 +10,7 @@ diff -wpruN '--exclude=*.orig' a~/configure a/configure
  fi
  
  cat > local.exp <<EOF
-@@ -18758,7 +18758,7 @@ else
+@@ -19826,7 +19826,7 @@ else $as_nop
  
    	libffi_cv_ro_eh_frame=yes
    	echo 'extern void foo (void); void bar (void) { foo (); foo (); }' > conftest.c

--- a/build/mozilla-nss-nspr/build.sh
+++ b/build/mozilla-nss-nspr/build.sh
@@ -18,9 +18,9 @@
 . ../../lib/build.sh
 
 PROG=nss
-VER=3.82
+VER=3.83
 # Include NSPR version since we're downloading a combined tarball.
-NSPRVER=4.34
+NSPRVER=4.34.1
 # But set BUILDDIR to just be the NSS version.
 set_builddir "$PROG-$VER"
 PKG=$PROG ##IGNORE##

--- a/build/mozilla-nss-nspr/patches/nss-modernize.patch
+++ b/build/mozilla-nss-nspr/patches/nss-modernize.patch
@@ -51,7 +51,7 @@ diff -wpruN '--exclude=*.orig' a~/nss/coreconf/SunOS5.mk a/nss/coreconf/SunOS5.m
 diff -wpruN '--exclude=*.orig' a~/nss/lib/freebl/Makefile a/nss/lib/freebl/Makefile
 --- a~/nss/lib/freebl/Makefile	1970-01-01 00:00:00
 +++ a/nss/lib/freebl/Makefile	1970-01-01 00:00:00
-@@ -570,6 +570,8 @@ else
+@@ -552,6 +552,8 @@ else
   	ifndef NS_USE_GCC
   	   MPCPU_SRCS =
   	   ASFILES += mpcpucache_x86.s

--- a/build/nghttp2/build.sh
+++ b/build/nghttp2/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=nghttp2
-VER=1.49.0
+VER=1.50.0
 PKG=library/nghttp2
 SUMMARY="nghttp2: HTTP/2 C Library"
 DESC="An implementation of the Hypertext Transfer Protocol version 2 in C"

--- a/build/nghttp2/testsuite.log
+++ b/build/nghttp2/testsuite.log
@@ -5,7 +5,7 @@ Making check in src
 Making check in includes
 Making all in includes
 ============================================================================
-Testsuite summary for nghttp2 1.49.0
+Testsuite summary for nghttp2 1.50.0
 ============================================================================
 # TOTAL: 0
 # PASS:  0
@@ -23,7 +23,7 @@ Making check in testdata
 PASS: main
 PASS: failmalloc
 ============================================================================
-Testsuite summary for nghttp2 1.49.0
+Testsuite summary for nghttp2 1.50.0
 ============================================================================
 # TOTAL: 2
 # PASS:  2

--- a/build/python310/cryptography/build.sh
+++ b/build/python310/cryptography/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/cryptography-310
 PROG=cryptography
-VER=37.0.4
+VER=38.0.1
 SUMMARY="Cryptographic recipes and primitives"
 DESC="$SUMMARY"
 

--- a/build/python310/idna/build.sh
+++ b/build/python310/idna/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/build.sh
 
 PKG=library/python-3/idna-310
 PROG=idna
-VER=3.3
+VER=3.4
 SUMMARY="Internationalized Domain Names in Applications (IDNA)"
 DESC="Support for the Internationalised Domain Names in Applications (IDNA) "
 DESC+="protocol as specified in RFC 5891"

--- a/build/python310/jsonschema/build.sh
+++ b/build/python310/jsonschema/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/jsonschema-310
 PROG=jsonschema
-VER=4.14.0
+VER=4.16.0
 SUMMARY="An implementation of JSON Schema validation for Python"
 DESC="$SUMMARY"
 

--- a/build/python310/meson/build.sh
+++ b/build/python310/meson/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/meson-310
 PROG=meson
-VER=0.63.1
+VER=0.63.2
 SUMMARY="The Meson Build system"
 DESC="An open source build system meant to be both extremely fast, "
 DESC+="and, even more importantly, as user friendly as possible"

--- a/build/python310/meson/patches/compiler_def_static_linker.patch
+++ b/build/python310/meson/patches/compiler_def_static_linker.patch
@@ -1,7 +1,7 @@
 diff -wpruN '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild/compilers/compilers.py
 --- a~/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
 +++ a/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
-@@ -1039,7 +1039,7 @@ class Compiler(HoldableObject, metaclass
+@@ -1043,7 +1043,7 @@ class Compiler(HoldableObject, metaclass
  
      def get_largefile_args(self) -> T.List[str]:
          '''Enable transparent large-file-support for 32-bit UNIX systems'''

--- a/build/python310/orjson/build.sh
+++ b/build/python310/orjson/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/orjson-310
 PROG=orjson
-VER=3.7.12
+VER=3.8.0
 SUMMARY="orjson"
 DESC="A fast, correct JSON library for Python."
 

--- a/build/python310/setuptools-rust/build.sh
+++ b/build/python310/setuptools-rust/build.sh
@@ -18,7 +18,7 @@
 
 PKG=library/python-3/setuptools-rust-310
 PROG=setuptools-rust
-VER=1.5.1
+VER=1.5.2
 SUMMARY="Python setuptools rust extension plugin"
 DESC="Compile and distribute Python extensions written in rust as easily "
 DESC+="as if they were written in C."

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -45,7 +45,7 @@
 | library/libedit			| 20210910-3.1		| https://thrysoee.dk/editline/
 | library/libevent			| 2.1.12		| https://github.com/libevent/libevent/tags | Currently used solely by tmux
 | library/libidn			| 1.41			| http://git.savannah.gnu.org/cgit/libidn.git/refs/tags https://ftp.gnu.org/gnu/libidn/
-| library/libffi			| 3.4.2			| https://sourceware.org/libffi/
+| library/libffi			| 3.4.3			| https://sourceware.org/libffi/
 | library/libuv				| 1.44.2		| https://github.com/libuv/libuv/releases | Currently used solely by bind
 | library/libxml2			| 2.10.2		| https://github.com/GNOME/libxml2/tags http://xmlsoft.org/news.html
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -134,7 +134,7 @@
 | library/python-3/jsonrpclib-310	| 0.4.3.2		| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-310	| 4.16.0		| https://pypi.org/project/jsonschema
 | library/python-3/meson-310		| 0.63.2		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
-| library/python-3/orjson-310		| 3.7.12		| https://github.com/ijl/orjson/releases
+| library/python-3/orjson-310		| 3.8.0		| https://github.com/ijl/orjson/releases
 | library/python-3/pip-310		| 22.2.2		| https://pypi.org/project/pip
 | library/python-3/pycodestyle-310	| 2.9.1			| https://pypi.org/project/pycodestyle/
 | library/python-3/pycparser-310	| 2.21			| https://pypi.org/project/pycparser

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -35,7 +35,7 @@
 | file/gnu-coreutils			| 9.1			| https://ftp.gnu.org/gnu/coreutils/
 | file/gnu-findutils			| 4.9.0			| https://ftp.gnu.org/pub/gnu/findutils/
 | library/c++/sigcpp			| 3.2.0			| https://download.gnome.org/sources/libsigc++/cache.json https://github.com/libsigcplusplus/libsigcplusplus/blob/master/NEWS
-| library/expat				| 2.4.8			| https://github.com/libexpat/libexpat/releases
+| library/expat				| 2.4.9			| https://github.com/libexpat/libexpat/releases
 | library/estr				| 0.1.11		| https://github.com/rsyslog/libestr/tags | Currently used solely by rsyslog
 | library/fastjson			| 0.99.9		| https://github.com/rsyslog/libfastjson/tags | Currently used solely by rsyslog
 | library/gmp				| 6.2.1			| https://gmplib.org/download/gmp/ https://gmplib.org/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -51,7 +51,7 @@
 | library/libxslt			| 1.1.30		| http://xmlsoft.org/libxslt/news.html
 | library/lzlib				| 1.13			| https://download.savannah.gnu.org/releases/lzip/lzlib/
 | library/ncurses			| 6.3			| https://ftp.gnu.org/gnu/ncurses/
-| library/nghttp2			| 1.49.0		| https://github.com/nghttp2/nghttp2/releases
+| library/nghttp2			| 1.50.0		| https://github.com/nghttp2/nghttp2/releases
 | library/nss				| 3.82			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
 | library/nspr				| 4.34			| http://archive.mozilla.org/pub/nspr/releases/ | https://ftp.mozilla.org/pub/security/nss/releases/
 | library/pcre2				| 10.40			| https://github.com/PhilipHazel/pcre2/releases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -133,7 +133,7 @@
 | library/python-3/js-regex-310		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-310	| 0.4.3.2		| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-310	| 4.16.0		| https://pypi.org/project/jsonschema
-| library/python-3/meson-310		| 0.63.1		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
+| library/python-3/meson-310		| 0.63.2		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/orjson-310		| 3.7.12		| https://github.com/ijl/orjson/releases
 | library/python-3/pip-310		| 22.2.2		| https://pypi.org/project/pip
 | library/python-3/pycodestyle-310	| 2.9.1			| https://pypi.org/project/pycodestyle/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -132,7 +132,7 @@
 | library/python-3/idna-310		| 3.4			| https://pypi.org/project/idna
 | library/python-3/js-regex-310		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-310	| 0.4.3.2		| https://github.com/tcalmant/jsonrpclib/releases
-| library/python-3/jsonschema-310	| 4.14.0		| https://pypi.org/project/jsonschema
+| library/python-3/jsonschema-310	| 4.16.0		| https://pypi.org/project/jsonschema
 | library/python-3/meson-310		| 0.63.1		| https://github.com/mesonbuild/meson/releases https://mesonbuild.com/
 | library/python-3/orjson-310		| 3.7.12		| https://github.com/ijl/orjson/releases
 | library/python-3/pip-310		| 22.2.2		| https://pypi.org/project/pip

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -129,7 +129,7 @@
 | library/python-3/cffi-310		| 1.15.1		| https://pypi.org/project/cffi
 | library/python-3/coverage-310		| 6.4.4			| https://pypi.org/project/coverage
 | library/python-3/cryptography-310	| 38.0.1		| https://pypi.org/project/cryptography
-| library/python-3/idna-310		| 3.3			| https://pypi.org/project/idna
+| library/python-3/idna-310		| 3.4			| https://pypi.org/project/idna
 | library/python-3/js-regex-310		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-310	| 0.4.3.2		| https://github.com/tcalmant/jsonrpclib/releases
 | library/python-3/jsonschema-310	| 4.14.0		| https://pypi.org/project/jsonschema

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -128,7 +128,7 @@
 | library/python-3/attrs-310		| 22.1.0		| https://pypi.org/project/attrs
 | library/python-3/cffi-310		| 1.15.1		| https://pypi.org/project/cffi
 | library/python-3/coverage-310		| 6.4.4			| https://pypi.org/project/coverage
-| library/python-3/cryptography-310	| 37.0.4		| https://pypi.org/project/cryptography
+| library/python-3/cryptography-310	| 38.0.1		| https://pypi.org/project/cryptography
 | library/python-3/idna-310		| 3.3			| https://pypi.org/project/idna
 | library/python-3/js-regex-310		| 1.0.1			| https://pypi.org/project/js-regex
 | library/python-3/jsonrpclib-310	| 0.4.3.2		| https://github.com/tcalmant/jsonrpclib/releases

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -52,8 +52,8 @@
 | library/lzlib				| 1.13			| https://download.savannah.gnu.org/releases/lzip/lzlib/
 | library/ncurses			| 6.3			| https://ftp.gnu.org/gnu/ncurses/
 | library/nghttp2			| 1.50.0		| https://github.com/nghttp2/nghttp2/releases
-| library/nss				| 3.82			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
-| library/nspr				| 4.34			| http://archive.mozilla.org/pub/nspr/releases/ | https://ftp.mozilla.org/pub/security/nss/releases/
+| library/nss				| 3.83			| https://ftp.mozilla.org/pub/security/nss/releases/ https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases
+| library/nspr				| 4.34.1		| http://archive.mozilla.org/pub/nspr/releases/ | https://ftp.mozilla.org/pub/security/nss/releases/
 | library/pcre2				| 10.40			| https://github.com/PhilipHazel/pcre2/releases
 | library/perl-5/xml-parser		| 2.46			| https://metacpan.org/pod/XML::Parser
 | library/readline			| 8.1.2			| https://ftp.gnu.org/gnu/readline/

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -145,7 +145,7 @@
 | library/python-3/rapidjson-310	| 1.8			| https://pypi.org/project/python-rapidjson
 | library/python-3/semantic-version-310	| 2.10.0		| https://pypi.org/project/semantic-version
 | library/python-3/setuptools-310	| 65.3.0		| https://pypi.org/project/setuptools
-| library/python-3/setuptools-rust-310	| 1.5.1			| https://pypi.org/project/setuptools-rust
+| library/python-3/setuptools-rust-310	| 1.5.2			| https://pypi.org/project/setuptools-rust
 | library/python-3/six-310		| 1.16.0		| https://pypi.org/project/six
 | library/python-3/tomli-310		| 2.0.1			| https://pypi.org/project/tomli
 | library/python-3/typing-extensions-310| 4.3.0			| https://pypi.org/project/typing-extensions

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -67,7 +67,7 @@
 | library/zlib				| 1.2.12		| https://www.zlib.net/
 | meta/data/microcode/amd		| 20220810		| https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/amd-ucode
 | meta/data/microcode/intel		| 20220809		| https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases
-| network/dns/bind			| 9.18.6		| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/
+| network/dns/bind			| 9.18.7		| https://ftp.isc.org/isc/bind9/ https://www.isc.org/downloads/
 | network/openssh			| 9.0p1			| https://www.mirrorservice.org/pub/OpenBSD/OpenSSH/portable/
 | network/rsync				| 3.2.6			| https://rsync.samba.org/
 | network/service/isc-dhcp		| 4.4.3			| https://ftp.isc.org/isc/dhcp/ https://www.isc.org/downloads/


### PR DESCRIPTION
`expat` needs backporting to all releases.

Ran the IPS test suite and the results matched the baseline.