### PR TITLE
python39 - update from 3.9.14 to 3.9.15 (r151038)

### DIFF
--- a/build/python39/build.sh
+++ b/build/python39/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/functions.sh
 
 PROG=Python
-VER=3.9.14
+VER=3.9.15
 PKG=runtime/python-39
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"

--- a/build/python39/patches/mod-posix-sched_priority.patch
+++ b/build/python39/patches/mod-posix-sched_priority.patch
@@ -7,7 +7,7 @@ However, -1 alongside EINVAL represents an error.
 diff -wpruN '--exclude=*.orig' a~/Modules/posixmodule.c a/Modules/posixmodule.c
 --- a~/Modules/posixmodule.c	1970-01-01 00:00:00
 +++ a/Modules/posixmodule.c	1970-01-01 00:00:00
-@@ -6723,7 +6723,11 @@ os_sched_get_priority_max_impl(PyObject
+@@ -6727,7 +6727,11 @@ os_sched_get_priority_max_impl(PyObject
      int max;
  
      max = sched_get_priority_max(policy);
@@ -19,7 +19,7 @@ diff -wpruN '--exclude=*.orig' a~/Modules/posixmodule.c a/Modules/posixmodule.c
          return posix_error();
      return PyLong_FromLong(max);
  }
-@@ -6742,7 +6746,11 @@ os_sched_get_priority_min_impl(PyObject
+@@ -6746,7 +6750,11 @@ os_sched_get_priority_min_impl(PyObject
  /*[clinic end generated code: output=7595c1138cc47a6d input=21bc8fa0d70983bf]*/
  {
      int min = sched_get_priority_min(policy);

--- a/build/python39/patches/module-py_db.patch
+++ b/build/python39/patches/module-py_db.patch
@@ -29,7 +29,7 @@ diff -wpruN '--exclude=*.orig' a~/Makefile.pre.in a/Makefile.pre.in
  
  Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) $(EXPORTSYMS)
  	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
-@@ -1248,7 +1257,7 @@ multisslcompile: build_all
+@@ -1249,7 +1258,7 @@ multisslcompile: build_all
  multissltest: build_all
  	$(RUNSHARED) ./$(BUILDPYTHON) Tools/ssl/multissltests.py
  


### PR DESCRIPTION
python39 - update from 3.9.14 to 3.9.15 (r151038)
