### PR TITLE
gcc12: Add -fforce-omit-frame-pointer

### DIFF
--- a/build/gcc12/patches/0036-Add-fforce-omit-frame-pointer.patch
+++ b/build/gcc12/patches/0036-Add-fforce-omit-frame-pointer.patch
@@ -1,0 +1,43 @@
+From 5fe0e17fe65a491349bc5c76972212b2e77cccd3 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <illumos@fiddaman.net>
+Date: Wed, 26 Oct 2022 12:53:51 +0000
+Subject: Add -fforce-omit-frame-pointer
+
+---
+ gcc/common.opt                  | 4 ++++
+ gcc/config/i386/i386-options.cc | 7 +++++--
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/common.opt b/gcc/common.opt
+index 9dad568d6e6..4896e4ad644 100644
+--- a/gcc/common.opt
++++ b/gcc/common.opt
+@@ -2191,6 +2191,10 @@ fomit-frame-pointer
+ Common Var(flag_omit_frame_pointer) Optimization
+ When possible do not generate stack frames.
+ 
++fforce-omit-frame-pointer
++Common Var(flag_force_omit_frame_pointer) Optimization
++When possible, do not generate stack frames. Hinders debugging with mdb and dtrace.
++
+ fopt-info
+ Common Var(flag_opt_info) Optimization
+ Enable all optimization info dumps on stderr.
+diff --git a/gcc/config/i386/i386-options.cc b/gcc/config/i386/i386-options.cc
+index 0aa1b36fdf6..2c95200c39a 100644
+--- a/gcc/config/i386/i386-options.cc
++++ b/gcc/config/i386/i386-options.cc
+@@ -2922,8 +2922,11 @@ ix86_option_override_internal (bool main_args_p,
+    * questionable benefit anyway, even on i386.
+    */
+ 
+-  flag_omit_frame_pointer = 0;
+-  opts->x_flag_omit_frame_pointer = 0;
++  if (flag_force_omit_frame_pointer == 0)
++    {
++      flag_omit_frame_pointer = 0;
++      opts->x_flag_omit_frame_pointer = 0;
++    }
+ 
+   /* Save the initial options in case the user does function specific
+      options.  */

--- a/build/gcc12/patches/0037-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc12/patches/0037-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,4 +1,4 @@
-From 04ba6e2ac5314218047816a71a80b1700134f787 Mon Sep 17 00:00:00 2001
+From e46a4185619b6d812960fd8e5eacbdb365a74057 Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS

--- a/build/gcc12/patches/series
+++ b/build/gcc12/patches/series
@@ -32,4 +32,5 @@
 0033-Fix-cp-module.cc-build-use-posix_madvise.patch
 0034-Add-__illumos__-preprocessor-definition.patch
 0035-libstdc-must-use-thread-local-errno.patch
-0036-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+0036-Add-fforce-omit-frame-pointer.patch
+0037-OOCE-Adjust-default-library-paths-for-OmniOS.patch


### PR DESCRIPTION
```
bloody% gcc -o c c.c -fno-omit-frame-pointer
bloody% dis -F test c | sed -n 3,5p
test()
    test:      55                 pushq  %rbp
    test+0x1:  48 89 e5           movq   %rsp,%rbp

bloody% gcc -o c c.c -fomit-frame-pointer
bloody% dis -F test c | sed -n 3,5p
test()
    test:      55                 pushq  %rbp
    test+0x1:  48 89 e5           movq   %rsp,%rbp

bloody% gcc -o c c.c -fomit-frame-pointer -fforce-omit-frame-pointer
bloody% dis -F test c | sed -n 3,5p
test()
    test:      48 83 ec 08        subq   $0x8,%rsp
    test+0x4:  be 02 00 00 00     movl   $0x2,%esi
```