### PR TITLE
socat fails to restore tty mode on exit

### DIFF
--- a/build/socat/patches/fix-socat-tcsetattr.patch
+++ b/build/socat/patches/fix-socat-tcsetattr.patch
@@ -1,0 +1,27 @@
+
+Zero is not necessarily a valid 2nd param for tcsetattr.
+
+diff -wpruN '--exclude=*.orig' a~/xioclose.c a/xioclose.c
+--- a~/xioclose.c	1970-01-01 00:00:00
++++ a/xioclose.c	1970-01-01 00:00:00
+@@ -44,7 +44,7 @@ int xioclose1(struct single *pipe) {
+ #endif /* WITH_OPENSSL */
+ #if WITH_TERMIOS
+    if (pipe->ttyvalid) {
+-      if (Tcsetattr(pipe->fd, 0, &pipe->savetty) < 0) {
++      if (Tcsetattr(pipe->fd, TCSANOW, &pipe->savetty) < 0) {
+ 	 Warn2("cannot restore terminal settings on fd %d: %s",
+ 	       pipe->fd, strerror(errno));
+       }
+diff -wpruN '--exclude=*.orig' a~/xioshutdown.c a/xioshutdown.c
+--- a~/xioshutdown.c	1970-01-01 00:00:00
++++ a/xioshutdown.c	1970-01-01 00:00:00
+@@ -164,7 +164,7 @@ int xioshutdown(xiofile_t *sock, int how
+    }
+ #if WITH_TERMIOS
+    if (sock->stream.ttyvalid) {
+-      if (Tcsetattr(sock->stream.fd, 0, &sock->stream.savetty) < 0) {
++      if (Tcsetattr(sock->stream.fd, TCSANOW, &sock->stream.savetty) < 0) {
+ 	 Warn2("cannot restore terminal settings on fd %d: %s",
+ 	       sock->stream.fd, strerror(errno));
+       }

--- a/build/socat/patches/series
+++ b/build/socat/patches/series
@@ -1,0 +1,1 @@
+fix-socat-tcsetattr.patch


### PR DESCRIPTION
Fixes #3094