### PR TITLE
Update gcc7 illumos version tag

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -13,14 +13,14 @@
 # }}}
 #
 # Copyright 2014 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PKG=developer/gcc7
 PROG=gcc
 VER=7.5.0
-ILVER=il-1
+ILVER=il-2
 SUMMARY="gcc $VER-$ILVER"
 DESC="The GNU Compiler Collection"
 


### PR DESCRIPTION

The upstream https://github.com/illumos/gcc/releases/tag/gcc-7.5.0-il-2
tag has just been created. OmniOS already has the patches that are in
the new tag so this just bumps the reported illumos tag version.

