### PR TITLE
Simplify compiler link specs.

### DIFF
--- a/build/gcc10/patches/0038-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc10/patches/0038-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,35 +1,33 @@
-From bf476fb8c150ecae72cc4b98404bf2aff0fed4ca Mon Sep 17 00:00:00 2001
+From b1e8a5c361a97625976663dfc42e7851121f163f Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS
 
 ---
- gcc/config/sol2.h | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ gcc/config/sol2.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/gcc/config/sol2.h b/gcc/config/sol2.h
-index a945e96d4a2..f494e72bc0c 100644
+index a945e96d4a2..8770553f123 100644
 --- a/gcc/config/sol2.h
 +++ b/gcc/config/sol2.h
-@@ -308,8 +308,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -308,8 +308,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH32_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 -	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/10/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/10/lib -L %R/usr/gcc/10/lib} \
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/10/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/10/lib -L %R/usr/gcc/10/lib}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/10/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/10/lib}"
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -320,8 +320,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -320,8 +319,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH64_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 -	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/10/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/10/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/10/lib/" ARCH64_SUBDIR "}	\
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/10/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/10/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/10/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/10/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/10/lib/" ARCH64_SUBDIR "}"
  
  #undef LINK_ARCH64_SPEC
  #ifndef USE_GLD

--- a/build/gcc11/patches/0036-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc11/patches/0036-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,35 +1,33 @@
-From 21265237072389e57e6fd935f99ac2473d174e53 Mon Sep 17 00:00:00 2001
+From f7de1f85db896f0b2d67328aae22a2ceb166a8dd Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS
 
 ---
- gcc/config/sol2.h | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ gcc/config/sol2.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/gcc/config/sol2.h b/gcc/config/sol2.h
-index 98c35aa4dcb..b20c92956ba 100644
+index 98c35aa4dcb..3871eab88e2 100644
 --- a/gcc/config/sol2.h
 +++ b/gcc/config/sol2.h
-@@ -308,8 +308,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -308,8 +308,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH32_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 -	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/11/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/11/lib -L %R/usr/gcc/11/lib} \
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/11/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/11/lib -L %R/usr/gcc/11/lib}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/11/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/11/lib}"
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -320,8 +320,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -320,8 +319,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH64_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 -	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/11/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/11/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/11/lib/" ARCH64_SUBDIR "}	\
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/11/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/11/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/11/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/11/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/11/lib/" ARCH64_SUBDIR "}"
  
  #undef LINK_ARCH64_SPEC
  #ifndef USE_GLD

--- a/build/gcc12/patches/0038-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc12/patches/0038-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,35 +1,33 @@
-From 355b7e51cb41436713ad3ff83cabc662f0666460 Mon Sep 17 00:00:00 2001
+From 047c3fb06300e92da668272512097d3f94b42aee Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS
 
 ---
- gcc/config/sol2.h | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ gcc/config/sol2.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/gcc/config/sol2.h b/gcc/config/sol2.h
-index 7cb9dfe3312..915423cd6a6 100644
+index 7cb9dfe3312..4c8366c12e0 100644
 --- a/gcc/config/sol2.h
 +++ b/gcc/config/sol2.h
-@@ -308,8 +308,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -308,8 +308,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH32_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 -	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/12/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/12/lib -L %R/usr/gcc/12/lib} \
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/12/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/12/lib -L %R/usr/gcc/12/lib}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/12/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/12/lib}"
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -320,8 +320,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -320,8 +319,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH64_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 -	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/12/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/12/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/12/lib/" ARCH64_SUBDIR "}	\
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/12/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/12/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/12/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/12/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/12/lib/" ARCH64_SUBDIR "}"
  
  #undef LINK_ARCH64_SPEC
  #ifndef USE_GLD

--- a/build/gcc7/patches/0033-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc7/patches/0033-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,35 +1,33 @@
-From 5c4c0a3c9a95dddcedaa3cee2b5b9ad8a2897cac Mon Sep 17 00:00:00 2001
+From d940a78fc509cab26f822a3a03ca74dac2750dec Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS
 
 ---
- gcc/config/sol2.h | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ gcc/config/sol2.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/gcc/config/sol2.h b/gcc/config/sol2.h
-index 74e429619b2..ca10373a773 100644
+index 74e429619b2..bbd985ced08 100644
 --- a/gcc/config/sol2.h
 +++ b/gcc/config/sol2.h
-@@ -246,8 +246,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -246,8 +246,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH32_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 -	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/7/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/7/lib -L %R/usr/gcc/7/lib} \
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/7/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/7/lib -L %R/usr/gcc/7/lib}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/7/lib:%R/lib:%R/usr/lib -R %R/usr/gcc/7/lib}"
  
  #undef LINK_ARCH32_SPEC
  #define LINK_ARCH32_SPEC LINK_ARCH32_SPEC_BASE
-@@ -258,8 +258,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -258,8 +257,7 @@ along with GCC; see the file COPYING3.  If not see
  #define LINK_ARCH64_SPEC_BASE \
    "%{YP,*} \
     %{R*} \
 -   %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 -	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
-+   %{!YP,*:%{p|pg:-Y P,%R/usr/gcc/7/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/7/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/7/lib/" ARCH64_SUBDIR "}	\
-+	   %{!p:%{!pg:-Y P,%R/usr/gcc/7/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/7/lib/" ARCH64_SUBDIR " -L %R/usr/gcc/7/lib/" ARCH64_SUBDIR "}}}"
++   %{!YP,*:-Y P,%R/usr/gcc/7/lib/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR " -R %R/usr/gcc/7/lib/" ARCH64_SUBDIR "}"
  
  #undef LINK_ARCH64_SPEC
  #ifndef USE_GLD


### PR DESCRIPTION
The modifications that have been traditionally made to the compiler link
specs are more complicated than they need to be, duplicating flags for the
profiling and non-profiling cases, and passing a redundant -L alongside
a perfectly good -Y P,