### PR TITLE
clear_archflags is a little over-zealous

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -635,10 +635,7 @@ reset_configure_opts() {
 }
 
 clear_archflags() {
-    CFLAGS=()
-    CPPFLAGS=()
-    CXXFLAGS=()
-    LDFLAGS=()
+    flatten_variables CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
 }
 
 set_standard() {


### PR DESCRIPTION

The `clear_archflags` function is removing the non-arch flags too, resulting
specifically in the gcc compilers being built without the usual flags,
including optimisation.

