### PR TITLE
groff - update from 1.22.4 to 1.23.0

### DIFF
--- a/build/groff/build.sh
+++ b/build/groff/build.sh
@@ -13,12 +13,12 @@
 # }}}
 
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=groff
-VER=1.22.4
+VER=1.23.0
 PKG=text/groff
 SUMMARY="GNU troff"
 DESC="GNU Troff typesetting package"
@@ -30,11 +30,13 @@ RUN_DEPENDS_IPS="
 set_arch 64
 CONFIGURE_OPTS="--without-x"
 
+PKGDIFF_HELPER="
+    s:$PROG/[0-9]\.[0-9][0-9]*\.[0-9][0-9]*:$PROG/VERSION:
+"
+
 init
 download_source $PROG $PROG $VER
 patch_source
-# Stop configure complaining about missing texinfo package
-touch $TMPDIR/$BUILDDIR/doc/groff.info
 prep_build
 build
 make_package

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -114,7 +114,7 @@
 | text/gnu-grep				| 3.11			| https://ftp.gnu.org/gnu/grep/
 | text/gnu-patch			| 2.7.6			| http://git.savannah.gnu.org/cgit/patch.git/refs/tags
 | text/gnu-sed				| 4.9			| https://ftp.gnu.org/gnu/sed/ https://savannah.gnu.org/news/?group=sed
-| text/groff				| 1.22.4		| https://ftp.gnu.org/gnu/groff/
+| text/groff				| 1.23.0		| https://ftp.gnu.org/gnu/groff/
 | text/less				| 633			| http://www.greenwoodsoftware.com/less/download.html
 | web/curl				| 8.1.2			| https://curl.haxx.se/download.html
 | web/wget				| 1.21.4		| https://ftp.gnu.org/gnu/wget/


### PR DESCRIPTION
Some binaries are missing in new version, but they never worked previously. The updated configure is just now checking for the ghostscript dependency.

```diff
-set name=info.source-url value=https://mirrors.omnios.org/groff/groff-1.22.4.tar.gz
+set name=info.source-url value=https://mirrors.omnios.org/groff/groff-1.23.0.tar.gz
-file path=usr/bin/groffer owner=root group=bin mode=0755
-file path=usr/bin/roff2dvi owner=root group=bin mode=0755
-file path=usr/bin/roff2html owner=root group=bin mode=0755
-file path=usr/bin/roff2pdf owner=root group=bin mode=0755
-file path=usr/bin/roff2ps owner=root group=bin mode=0755
-file path=usr/bin/roff2text owner=root group=bin mode=0755
-file path=usr/bin/roff2x owner=root group=bin mode=0755
...
```