### PR TITLE
chrony: bump bundled nettle to 3.9.1 (r151046)

### DIFF
--- a/build/chrony/build.sh
+++ b/build/chrony/build.sh
@@ -12,16 +12,17 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=chrony
 VER=4.3
+DASHREV=1
 PKG=service/network/chrony
 SUMMARY="Network time services"
 DESC="A versatile implementation of the Network Time Protocol (NTP)"
-NETTLEVER=3.8.1
+NETTLEVER=3.9.1
 
 set_arch 64
 


### PR DESCRIPTION
chrony: bump bundled nettle to 3.9.1 (r151046)
