### PR TITLE
Use separate python module requirements for aarch64

### DIFF
--- a/build/pkg/build-arch-aarch64.sh
+++ b/build/pkg/build-arch-aarch64.sh
@@ -49,7 +49,10 @@ build() {
     logmsg "--- build"
     logcmd python setup.py install
     logmsg "--- modules"
-    logcmd make -e MACH=$ARCH TARGET=install modules/$PYTHON3VER
+    logcmd make -e \
+        MACH=$ARCH \
+        REQUIREMENTS=requirements-aarch64.txt \
+        TARGET=install modules/$PYTHON3VER
     popd > /dev/null
 }
 


### PR DESCRIPTION
The build side of https://github.com/omniosorg/pkg5/pull/446
