### PR TITLE
aarch64: build gdb as part of binutils

### DIFF
--- a/build/binutils/build-arch-aarch64.sh
+++ b/build/binutils/build-arch-aarch64.sh
@@ -48,7 +48,7 @@ export AS_FOR_BUILD=/opt/cross/$ARCH/bin/$TRIPLET-as
 export AR_FOR_BUILD=/opt/cross/$ARCH/bin/$TRIPLET-ar
 export LD_FOR_TARGET=/bin/ld
 export CFLAGS_FOR_TARGET="-mno-outline-atomics -mtls-dialect=trad"
-export CXXFLAGS_FOR_TARGET="-mno-outline-atomics -mtls-dialect=trad"
+export CXXFLAGS_FOR_TARGET="$CFLAGS_FOR_TARGET"
 export STRIP="/usr/bin/strip -x"
 export STRIP_FOR_TARGET="$STRIP"
 
@@ -74,9 +74,8 @@ CONFIGURE_OPTS="
     --with-system-zlib
 "
 
-# gdb doesn't currently build for aarch64 due to an issue in the bison
-# generated code that narrows int to char, which is unsigned.
-CONFIGURE_OPTS+=" --disable-gdb"
+CFLAGS+=" $CFLAGS_FOR_TARGET"
+CXXFLAGS+=" $CFLAGS_FOR_TARGET"
 
 build_init() {
     typeset d=${SYSROOT[$ARCH]}/usr

--- a/build/binutils/local.mog
+++ b/build/binutils/local.mog
@@ -21,5 +21,7 @@ dir group=bin mode=0755 owner=root path=usr/sfw/bin
 <transform file path=usr/bin/g(.*)$ -> emit \
     link path=usr/gnu/bin/%<1> target=../../bin/g%<1> >
 
+$(aarch64_ONLY)link path=usr/bin/gdb target=ggdb
+
 <transform file path=.*\.a$ -> drop>
 


### PR DESCRIPTION

This depends on https://github.com/richlowe/illumos-gate/pull/41 to
build correctly.

