### PR TITLE
When compiling python modules, always force rebuild and timestamp mode (r151048)

### DIFF
--- a/build/python311/build.sh
+++ b/build/python311/build.sh
@@ -123,6 +123,12 @@ post_configure() {
     restore_variable CC
 }
 
+post_install() {
+    python_compile \
+        -o0 -o1 -o2 \
+        -x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data'
+}
+
 TESTSUITE_SED="
     1,/tests* OK/ {
         /tests* OK/p

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2877,7 +2877,13 @@ python_vendor_relocate() {
 
 python_compile() {
     logmsg "Compiling python modules"
-    logcmd $PYTHON -m compileall $DESTDIR
+    logcmd $PYTHON \
+        -m compileall \
+        -j0 \
+        -f \
+        --invalidation-mode timestamp \
+        "$@" \
+        $DESTDIR
 }
 
 python_pep518() {


### PR DESCRIPTION
When compiling python modules, always force rebuild and timestamp mode (r151048)
