### PR TITLE
Python 3.12 is incorrectly detecting platform triple

### DIFF
--- a/build/python311/local.mog
+++ b/build/python311/local.mog
@@ -8,7 +8,7 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 license LICENSE license=PSFv2
 
@@ -30,15 +30,16 @@ license LICENSE license=PSFv2
 # Prevent pkgdepend from reporting an error
 <transform file path=. -> set pkg.depend.bypass-generate .*>
 
-# Move /usr/lib/amd64/libpython3.so and replace with a symlink
-<transform file path=usr/lib/amd64/libpython3.so$ \
+# Move libpython3.so and replace with a symlink
+<transform file path=(usr/lib/(?:amd64/)?libpython3\.so)$ -> emit \
+    link path=%<1> target=libpython$(PYTHONVER)-stub.so >
+<transform file path=usr/lib/(?:amd64/)?libpython3\.so$ \
     -> edit path 3 $(PYTHONVER)-stub>
-link path=usr/lib/amd64/libpython3.so target=libpython$(PYTHONVER)-stub.so
 
 # Set mediators on links in shared directories
 
 <transform link path=usr/(bin|share) -> set mediator python3>
-<transform link path=usr/lib/amd64/.*3m?\.so -> set mediator python3>
+<transform link path=usr/lib/(?:amd64/)?.*3m?\.so -> set mediator python3>
 <transform link path=.*/pkgconfig/.+\.pc$ -> set mediator python3>
 
 <transform link mediator=python3 -> set mediator-version $(PYTHONVER)>

--- a/build/python312/build.sh
+++ b/build/python312/build.sh
@@ -60,7 +60,6 @@ CFLAGS+=" -msave-args"
 
 export CCSHARED="-fPIC"
 CPPFLAGS+=" -I/usr/include/ncurses"
-CPPFLAGS+=" `pkg-config --cflags libffi`"
 export DFLAGS=-64
 MAKE_ARGS="
     DFLAGS=-64
@@ -81,7 +80,7 @@ CONFIGURE_OPTS[amd64]+="
 "
 
 CONFIGURE_OPTS[aarch64]+="
-    --build=${TRIPLETS[amd64]}
+    --build=${TRIPLETS[amd64]%.*}
     --with-build-python=$PYTHON
     ac_cv_file__dev_ptmx=yes
     ac_cv_file__dev_ptc=no

--- a/build/python312/common.sh
+++ b/build/python312/common.sh
@@ -10,7 +10,7 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 set_python_version 3.12
 

--- a/build/python312/local.mog
+++ b/build/python312/local.mog
@@ -8,7 +8,7 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 license LICENSE license=PSFv2
 
@@ -30,15 +30,16 @@ license LICENSE license=PSFv2
 # Prevent pkgdepend from reporting an error
 <transform file path=. -> set pkg.depend.bypass-generate .*>
 
-# Move /usr/lib/amd64/libpython3.so and replace with a symlink
-<transform file path=usr/lib/amd64/libpython3.so$ \
+# Move libpython3.so and replace with a symlink that can be mediated. The
+# mediator is applied below
+<transform file path=(usr/lib/(?:amd64/)?libpython3\.so)$ -> emit \
+    link path=%<1> target=libpython$(PYTHONVER)-stub.so >
+<transform file path=usr/lib/(?:amd64/)?libpython3\.so$ \
     -> edit path 3 $(PYTHONVER)-stub>
-link path=usr/lib/amd64/libpython3.so target=libpython$(PYTHONVER)-stub.so
 
 # Set mediators on links in shared directories
-
 <transform link path=usr/(bin|share) -> set mediator python3>
-<transform link path=usr/lib/amd64/.*3m?\.so -> set mediator python3>
+<transform link path=usr/lib/(?:amd64/)?.*3\.so -> set mediator python3>
 <transform link path=.*/pkgconfig/.+\.pc$ -> set mediator python3>
 
 <transform link mediator=python3 -> set mediator-version $(PYTHONVER)>

--- a/build/python312/patches/illumos.patch
+++ b/build/python312/patches/illumos.patch
@@ -14,7 +14,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
  	    ac_sys_system=WASI
  	    ;;
 +	*-*-solaris*)
-+            ac_sys_system=SunOS
++	    ac_sys_system=SunOS
 +	    ac_sys_release=5.11
 +	    ;;
  	*)
@@ -42,3 +42,18 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
  	*)
  		# for now, limit cross builds to known configurations
  		MACHDEP="unknown"
+@@ -1102,6 +1115,14 @@ cat > conftest.c <<EOF
+ #  else
+ #    error unknown wasm64 platform
+ #  endif
++#elif defined(__illumos__)
++#  if defined(__x86_64__)
++	x86_64-pc-solaris2
++#  elif defined(__aarch64__)
++	aarch64-unknown-solaris2
++#  else
++#    error unknown illumos platform
++#  endif
+ #else
+ # error unknown platform triplet
+ #endif

--- a/build/python312/patches/posix_spawn-close_fds-support.patch
+++ b/build/python312/patches/posix_spawn-close_fds-support.patch
@@ -117,7 +117,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/Modules/posixmodule.c a/Modul
 diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
 --- a~/configure.ac	1970-01-01 00:00:00
 +++ a/configure.ac	1970-01-01 00:00:00
-@@ -4896,6 +4896,7 @@ AC_CHECK_FUNCS([ \
+@@ -4904,6 +4904,7 @@ AC_CHECK_FUNCS([ \
    lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \
    mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
    pipe2 plock poll posix_fadvise posix_fallocate posix_spawn posix_spawnp \

--- a/build/python312/patches/series
+++ b/build/python312/patches/series
@@ -1,9 +1,9 @@
+illumos.patch
 autoconf-macros.patch
 vendor-packages.patch
 dont-use-ccs.patch
 default-lib-path.patch
 disable_epoll.patch
-cross-aarch64.patch
 strxfrm-fix.patch
 encoding-alias.patch
 locale-encoding.patch


### PR DESCRIPTION
This mostly the updated `illumos.patch` file, but I also fixed some mog entries related to assumptions about where the libraries live, which can be just `usr/lib/` for cross builds.