### PR TITLE
xz: improve reproducibility by running autogen.sh ourselves

### DIFF
--- a/build/xz/build.sh
+++ b/build/xz/build.sh
@@ -34,7 +34,7 @@ post_configure() {
 TESTSUITE_SED="/libtool/d"
 
 init
-download_source $PROG $PROG $VER
+download_source $PROG v$VER
 patch_source
 prep_build autoconf -autoreconf
 build


### PR DESCRIPTION
Rather than use the release tarball for 5.6.1, switch to the
github-generated one which does not include the autoconf files
and allow the build framework to generate them for us.