### PR TITLE
Chrony startup timeout is excessive

### DIFF
--- a/build/chrony/files/chrony.xml
+++ b/build/chrony/files/chrony.xml
@@ -76,7 +76,7 @@
         <exec_method type="method"
                      name="start"
                      exec="/usr/sbin/chronyd"
-                     timeout_seconds="600">
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
                 <method_credential user="root"
                                    group="root"


### PR DESCRIPTION
This was likely copied from ntpsec which does a one-off time
step before starting the daemon and therefore needs more
time. Chrony should never take this long to start.