### PR TITLE
Update python versions

### DIFF
--- a/doc/packages.md
+++ b/doc/packages.md
@@ -78,9 +78,7 @@
 | runtime/java/openjdk21		| 21.0.2+13		| https://github.com/openjdk/jdk21u/tags
 | runtime/java/openjdk8			| 1.8.402-06		| https://github.com/openjdk/jdk8u/tags
 | runtime/perl				| 5.38.2		| https://www.cpan.org/src/README.html
-| runtime/python-39			| 3.9.18		| https://www.python.org/downloads/source/
-| runtime/python-310			| 3.10.13		| https://www.python.org/downloads/source/
-| runtime/python-311			| 3.11.7		| https://www.python.org/downloads/source/
+| runtime/python-311			| 3.11.9		| https://www.python.org/downloads/source/
 | runtime/python-312			| 3.12.3		| https://www.python.org/downloads/source/
 | security/sudo				| 1.9.15p5		| https://www.sudo.ws/
 | service/network/chrony		| 4.5			| https://download.tuxfamily.org/chrony/


### PR DESCRIPTION
Both r46 and r48 have 3.11, r50 has 3.12 so we can drop the old versions and update 3.11 to the version that was recently part of a weekly release.