### PR TITLE
coreutils - update from 9.4 to 9.5

### DIFF
--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -13,12 +13,12 @@
 # }}}
 
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=coreutils
-VER=9.4
+VER=9.5
 PKG=file/gnu-coreutils
 SUMMARY="coreutils - GNU core utilities"
 DESC="GNU core utilities"

--- a/build/coreutils/patches/set-permission.c.patch
+++ b/build/coreutils/patches/set-permission.c.patch
@@ -5,7 +5,7 @@ GNU Coreutils bug 21062 coreutils-8.24 - cp(1) check failures on tmpfs filesyste
 diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/set-permissions.c a/lib/set-permissions.c
 --- a~/lib/set-permissions.c	1970-01-01 00:00:00
 +++ a/lib/set-permissions.c	1970-01-01 00:00:00
-@@ -230,6 +230,7 @@ set_acls_from_mode (const char *name, in
+@@ -231,6 +231,7 @@ set_acls_from_mode (const char *name, in
          {
            if (errno == ENOSYS)
              {
@@ -13,7 +13,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/set-permissions.c a/lib/s
                *must_chmod = true;
                return 0;
              }
-@@ -264,6 +265,7 @@ set_acls_from_mode (const char *name, in
+@@ -265,6 +266,7 @@ set_acls_from_mode (const char *name, in
        {
          if (errno == ENOSYS || errno == EOPNOTSUPP)
            {
@@ -21,7 +21,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/set-permissions.c a/lib/s
              *must_chmod = true;
              return 0;
            }
-@@ -634,6 +636,7 @@ set_acls (struct permission_context *ctx
+@@ -635,6 +637,7 @@ set_acls (struct permission_context *ctx
            if ((errno == ENOSYS || errno == EOPNOTSUPP || errno == EINVAL)
                && acl_nontrivial (ctx->count, ctx->entries) == 0)
              ret = 0;
@@ -29,7 +29,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/set-permissions.c a/lib/s
          }
        else
          *acls_set = true;
-@@ -651,6 +654,7 @@ set_acls (struct permission_context *ctx
+@@ -652,6 +655,7 @@ set_acls (struct permission_context *ctx
            if ((errno == ENOSYS || errno == EINVAL || errno == ENOTSUP)
                && acl_ace_nontrivial (ctx->ace_count, ctx->ace_entries) == 0)
              ret = 0;

--- a/build/coreutils/patches/who.c.patch
+++ b/build/coreutils/patches/who.c.patch
@@ -1,7 +1,7 @@
 diff -wpruN --no-dereference '--exclude=*.orig' a~/src/who.c a/src/who.c
 --- a~/src/who.c	1970-01-01 00:00:00
 +++ a/src/who.c	1970-01-01 00:00:00
-@@ -516,8 +516,8 @@ print_runlevel (struct gl_utmp const *ut
+@@ -515,8 +515,8 @@ print_runlevel (struct gl_utmp const *ut
    unsigned char curr = utmp_ent->ut_pid % 256;
  
    if (!runlevline)

--- a/build/coreutils/testsuite.log
+++ b/build/coreutils/testsuite.log
@@ -91,6 +91,7 @@ SKIP: tests/seq/seq-long-double.sh
 PASS: tests/seq/seq-precision.sh
 PASS: tests/head/head.pl
 PASS: tests/head/head-elide-tail.pl
+SKIP: tests/tail/tail-sysfs.sh
 SKIP: tests/tail/tail-n0f.sh
 PASS: tests/ls/ls-misc.pl
 PASS: tests/date/date.pl
@@ -104,7 +105,6 @@ PASS: tests/od/od-endian.sh
 PASS: tests/od/od-float.sh
 PASS: tests/misc/mktemp.pl
 SKIP: tests/misc/arch.sh
-PASS: tests/misc/join.pl
 PASS: tests/pr/pr-tests.pl
 PASS: tests/pwd/pwd-option.sh
 PASS: tests/chcon/chcon-fail.sh
@@ -122,9 +122,9 @@ PASS: tests/cat/cat-E.sh
 SKIP: tests/cat/cat-proc.sh
 PASS: tests/cat/cat-buf.sh
 PASS: tests/cat/cat-self.sh
-PASS: tests/misc/base64.pl
 PASS: tests/misc/basename.pl
-PASS: tests/misc/basenc.pl
+PASS: tests/basenc/base64.pl
+PASS: tests/basenc/basenc.pl
 PASS: tests/misc/close-stdout.sh
 PASS: tests/chroot/chroot-fail.sh
 PASS: tests/cksum/cksum.sh
@@ -165,6 +165,8 @@ PASS: tests/cksum/md5sum.pl
 PASS: tests/cksum/md5sum-bsd.sh
 PASS: tests/cksum/md5sum-newline.pl
 PASS: tests/cksum/md5sum-parallel.sh
+PASS: tests/join/join.pl
+PASS: tests/join/join-utf8.sh
 PASS: tests/misc/mknod.sh
 PASS: tests/nice/nice.sh
 PASS: tests/nice/nice-fail.sh
@@ -173,7 +175,7 @@ PASS: tests/misc/nohup.sh
 PASS: tests/nproc/nproc-avail.sh
 PASS: tests/nproc/nproc-positive.sh
 PASS: tests/nproc/nproc-override.sh
-PASS: tests/misc/numfmt.pl
+FAIL: tests/misc/numfmt.pl
 PASS: tests/od/od-N.sh
 PASS: tests/od/od-j.sh
 PASS: tests/od/od-multiple-t.sh
@@ -307,6 +309,7 @@ PASS: tests/chmod/silent.sh
 PASS: tests/chmod/thru-dangling.sh
 PASS: tests/chmod/umask-x.sh
 PASS: tests/chmod/usage.sh
+PASS: tests/chmod/symlinks.sh
 PASS: tests/chown/deref.sh
 PASS: tests/chown/preserve-root.sh
 PASS: tests/chown/separator.sh
@@ -329,6 +332,7 @@ PASS: tests/cp/dir-vs-file.sh
 PASS: tests/cp/existing-perm-dir.sh
 SKIP: tests/cp/existing-perm-race.sh
 PASS: tests/cp/fail-perm.sh
+PASS: tests/cp/keep-directory-symlink.sh
 SKIP: tests/cp/sparse-extents.sh
 SKIP: tests/cp/copy-FMR.sh
 PASS: tests/cp/sparse-perf.sh
@@ -442,6 +446,7 @@ PASS: tests/ln/sf-1.sh
 PASS: tests/ln/slash-decorated-nonexistent-dest.sh
 PASS: tests/ln/target-1.sh
 PASS: tests/ls/a-option.sh
+SKIP: tests/ls/acl.sh
 PASS: tests/ls/abmon-align.sh
 PASS: tests/ls/birthtime.sh
 PASS: tests/ls/block-size.sh
@@ -468,6 +473,7 @@ PASS: tests/ls/no-arg.sh
 SKIP: tests/ls/no-cap.sh
 PASS: tests/ls/selinux-segfault.sh
 PASS: tests/ls/quote-align.sh
+PASS: tests/ls/size-align.sh
 PASS: tests/ls/readdir-mountpoint-inode.sh
 PASS: tests/ls/recursive.sh
 SKIP: tests/ls/removed-directory.sh
@@ -526,6 +532,7 @@ PASS: tests/mv/into-self-2.sh
 PASS: tests/mv/into-self-3.sh
 PASS: tests/mv/into-self-4.sh
 SKIP: tests/mv/leak-fd.sh
+PASS: tests/mv/mv-exchange.sh
 PASS: tests/mv/mv-n.sh
 PASS: tests/mv/mv-special-1.sh
 PASS: tests/mv/no-copy.sh
@@ -573,6 +580,7 @@ PASS: tests/touch/read-only.sh
 PASS: tests/touch/relative.sh
 PASS: tests/touch/trailing-slash.sh
 SKIP: tests/chown/basic.sh
+SKIP: tests/chgrp/from.sh
 SKIP: tests/cp/cp-a-selinux.sh
 SKIP: tests/cp/preserve-gid.sh
 SKIP: tests/cp/special-bits.sh
@@ -643,491 +651,358 @@ SKIP: tests/factor/t33.sh
 SKIP: tests/factor/t34.sh
 SKIP: tests/factor/t35.sh
 SKIP: tests/factor/t36.sh
-# TOTAL: 645
-# PASS:  496
-# SKIP:  149
+# TOTAL: 653
+# PASS:  500
+# SKIP:  152
 # XFAIL: 0
-# FAIL:  0
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0
-PASS: test-accept
-PASS: test-set-mode-acl.sh
-PASS: test-set-mode-acl-1.sh
-PASS: test-set-mode-acl-2.sh
-PASS: test-copy-acl.sh
-PASS: test-copy-acl-1.sh
-PASS: test-copy-acl-2.sh
-PASS: test-alignalloc
-PASS: test-alignasof
-PASS: test-alignof
-PASS: test-alloca-opt
-PASS: test-areadlink
-PASS: test-areadlink-with-size
-PASS: test-areadlinkat
-PASS: test-areadlinkat-with-size
-PASS: test-argmatch
-PASS: test-argv-iter
-PASS: test-arpa_inet
-PASS: test-array-mergesort
-PASS: test-assert
-PASS: test-base32
-PASS: test-base64
-PASS: test-binary-io.sh
-PASS: test-bind
-PASS: test-bitrotate
-PASS: test-btoc32-1.sh
-PASS: test-btoc32-2.sh
-PASS: test-btoc32-3.sh
-PASS: test-btowc-1.sh
-PASS: test-btowc-2.sh
-PASS: test-btowc-3.sh
-PASS: test-byteswap
-PASS: test-c-ctype
-PASS: test-c-strcase.sh
-PASS: test-c-strcasestr
-PASS: test-c32_apply_type_test
-PASS: test-c32_get_type_test
-PASS: test-c32isalnum.sh
-PASS: test-c32isalpha.sh
-PASS: test-c32isblank.sh
-PASS: test-c32iscntrl.sh
-PASS: test-c32isdigit.sh
-PASS: test-c32isgraph.sh
-PASS: test-c32islower.sh
-PASS: test-c32isprint.sh
-PASS: test-c32ispunct.sh
-PASS: test-c32isspace.sh
-PASS: test-c32isupper.sh
-PASS: test-c32isxdigit.sh
-PASS: test-c32rtomb.sh
-SKIP: test-c32rtomb-w32-2.sh
-SKIP: test-c32rtomb-w32-3.sh
-SKIP: test-c32rtomb-w32-4.sh
-SKIP: test-c32rtomb-w32-5.sh
-SKIP: test-c32rtomb-w32-6.sh
-SKIP: test-c32rtomb-w32-7.sh
-SKIP: test-c32rtomb-w32-8.sh
-PASS: test-c32tolower.sh
-PASS: test-c32width
-PASS: test-calloc-gnu
-PASS: test-canonicalize
-PASS: test-chdir
-PASS: test-chmod
-PASS: test-chown
-PASS: test-cloexec
-PASS: test-close
-PASS: test-closein.sh
-PASS: test-connect
-PASS: test-count-leading-zeros
-PASS: test-md5-buffer
-PASS: test-md5-stream
-PASS: test-sha1-buffer
-PASS: test-sha1-stream
-PASS: test-sha256-stream
-PASS: test-sha512-stream
-PASS: test-sm3-buffer
-PASS: test-ctype
-PASS: test-di-set
-PASS: test-dirent-safer
-PASS: test-dirent
-PASS: test-dirfd
-PASS: test-dirname
-PASS: test-dup
-PASS: test-dup2
-PASS: test-environ
-PASS: test-errno
-PASS: test-error.sh
-PASS: test-exclude1.sh
-PASS: test-exclude2.sh
-PASS: test-exclude3.sh
-PASS: test-exclude4.sh
-PASS: test-exclude5.sh
-PASS: test-exclude6.sh
-PASS: test-exclude7.sh
-PASS: test-exclude8.sh
-PASS: test-explicit_bzero
-PASS: test-faccessat
-PASS: test-fadvise
-PASS: test-fchdir
-PASS: test-fchmodat
-PASS: test-fchownat
-PASS: test-fclose
-PASS: test-fcntl-h
-PASS: test-fcntl-safer
-PASS: test-fcntl
-PASS: test-fdatasync
-PASS: test-fdopen
-PASS: test-fdopendir
-PASS: test-fdutimensat
-PASS: test-fflush
-PASS: test-fflush2.sh
-PASS: test-fgetc
-PASS: test-file-has-acl.sh
-PASS: test-file-has-acl-1.sh
-PASS: test-file-has-acl-2.sh
-PASS: test-filenamecat
-PASS: test-filevercmp
-PASS: test-float
-PASS: test-fnmatch-h
-PASS: test-fnmatch-1.sh
-PASS: test-fnmatch-2.sh
-PASS: test-fnmatch-3.sh
-SKIP: test-fnmatch-4.sh
-SKIP: test-fnmatch-5.sh
-SKIP: test-fnmatch-w32-2.sh
-SKIP: test-fnmatch-w32-3.sh
-SKIP: test-fnmatch-w32-4.sh
-SKIP: test-fnmatch-w32-5.sh
-SKIP: test-fnmatch-w32-6.sh
-SKIP: test-fnmatch-w32-7.sh
-SKIP: test-fnmatch-w32-8.sh
-PASS: test-fopen-gnu
-PASS: test-fopen-safer
-PASS: test-fopen
-PASS: test-fpending.sh
-PASS: test-fpurge
-PASS: test-fputc
-PASS: test-fread
-PASS: test-freadahead.sh
-PASS: test-freading
-PASS: test-freadptr.sh
-PASS: test-freadptr2.sh
-PASS: test-freadseek.sh
-PASS: test-free
-PASS: test-freopen-safer
-PASS: test-freopen
-PASS: test-frexp-nolibm
-PASS: test-frexpl-nolibm
-PASS: test-fseek.sh
-PASS: test-fseek2.sh
-PASS: test-fseeko.sh
-PASS: test-fseeko2.sh
-PASS: test-fseeko3.sh
-PASS: test-fseeko4.sh
-PASS: test-fseterr
-PASS: test-fstat
-PASS: test-fstatat
-PASS: test-fsync
-PASS: test-ftell.sh
-PASS: test-ftell2.sh
-PASS: test-ftell3
-PASS: test-ftello.sh
-PASS: test-ftello2.sh
-PASS: test-ftello3
-PASS: test-ftello4.sh
-PASS: test-ftruncate.sh
-PASS: test-futimens
-PASS: test-fwrite
-PASS: test-getaddrinfo
-PASS: test-getcwd-lgpl
-PASS: test-getcwd.sh
-PASS: test-getdelim
-PASS: test-getdtablesize
-PASS: test-getgroups
-PASS: test-gethostname
-PASS: test-getline
-PASS: test-getloadavg
-PASS: test-getlogin
-PASS: test-getndelim2
-PASS: test-getopt-gnu
-PASS: test-getopt-posix
-PASS: test-getprogname
-PASS: test-getrandom
-PASS: test-getrusage
-PASS: test-gettime-res
-PASS: test-gettimeofday
-PASS: test-dynarray
-PASS: test-scratch-buffer
-PASS: test-hard-locale
-PASS: test-hash
-PASS: test-i-ring
-PASS: test-iconv-h
-PASS: test-iconv
-PASS: test-ignore-value
-PASS: test-inet_ntop
-PASS: test-inet_pton
-PASS: test-ino-map
-PASS: test-intprops
-PASS: test-inttostr
-PASS: test-inttypes
-PASS: test-ioctl
-PASS: test-isatty
-PASS: test-isblank
-PASS: test-isnand-nolibm
-PASS: test-isnanf-nolibm
-PASS: test-isnanl-nolibm
-PASS: test-iswblank
-PASS: test-iswctype
-PASS: test-iswdigit.sh
-PASS: test-iswxdigit.sh
-PASS: test-langinfo
-PASS: test-largefile
-PASS: test-lchmod
-PASS: test-lchown
-PASS: test-libgmp
-PASS: test-limits-h
-PASS: test-link
-PASS: test-linkat
-PASS: test-listen
-PASS: test-locale
-PASS: test-localeconv
-PASS: test-localename
-PASS: test-rwlock1
-PASS: test-lock
-PASS: test-once1
-PASS: test-once2
-PASS: test-lseek.sh
-PASS: test-lstat
-PASS: test-malloc-gnu
-PASS: test-malloca
-PASS: test-math
-PASS: test-mbrlen-1.sh
-PASS: test-mbrlen-2.sh
-PASS: test-mbrlen-3.sh
-SKIP: test-mbrlen-4.sh
-SKIP: test-mbrlen-5.sh
-SKIP: test-mbrlen-w32-2.sh
-SKIP: test-mbrlen-w32-3.sh
-SKIP: test-mbrlen-w32-4.sh
-SKIP: test-mbrlen-w32-5.sh
-SKIP: test-mbrlen-w32-6.sh
-SKIP: test-mbrlen-w32-7.sh
-SKIP: test-mbrlen-w32-8.sh
-PASS: test-mbrtoc32-1.sh
-PASS: test-mbrtoc32-2.sh
-PASS: test-mbrtoc32-3.sh
-SKIP: test-mbrtoc32-4.sh
-SKIP: test-mbrtoc32-5.sh
-SKIP: test-mbrtoc32-w32-2.sh
-SKIP: test-mbrtoc32-w32-3.sh
-SKIP: test-mbrtoc32-w32-4.sh
-SKIP: test-mbrtoc32-w32-5.sh
-SKIP: test-mbrtoc32-w32-6.sh
-SKIP: test-mbrtoc32-w32-7.sh
-SKIP: test-mbrtoc32-w32-8.sh
-PASS: test-mbrtowc-1.sh
-PASS: test-mbrtowc-2.sh
-PASS: test-mbrtowc-3.sh
-SKIP: test-mbrtowc-4.sh
-SKIP: test-mbrtowc-5.sh
-SKIP: test-mbrtowc-w32-2.sh
-SKIP: test-mbrtowc-w32-3.sh
-SKIP: test-mbrtowc-w32-4.sh
-SKIP: test-mbrtowc-w32-5.sh
-SKIP: test-mbrtowc-w32-6.sh
-SKIP: test-mbrtowc-w32-7.sh
-SKIP: test-mbrtowc-w32-8.sh
-PASS: test-mbsalign
-SKIP: test-mbscasecmp.sh
-SKIP: test-mbschr.sh
-PASS: test-mbsinit.sh
-PASS: test-mbsrtoc32s-1.sh
-PASS: test-mbsrtoc32s-2.sh
-PASS: test-mbsrtoc32s-3.sh
-SKIP: test-mbsrtoc32s-4.sh
-SKIP: test-mbsrtoc32s-5.sh
-PASS: test-mbsrtowcs-1.sh
-PASS: test-mbsrtowcs-2.sh
-PASS: test-mbsrtowcs-3.sh
-SKIP: test-mbsrtowcs-4.sh
-SKIP: test-mbsrtowcs-5.sh
-PASS: test-memcasecmp
-PASS: test-memchr
-PASS: test-memchr2
-PASS: test-memcoll
-PASS: test-memrchr
-PASS: test-memset_explicit
-PASS: test-mkdir
-PASS: test-mkdirat
-PASS: test-mkfifo
-PASS: test-mkfifoat
-PASS: test-mknod
-PASS: test-nanosleep
-PASS: test-netdb
-PASS: test-netinet_in
-PASS: test-nl_langinfo1.sh
-PASS: test-nl_langinfo2.sh
-PASS: test-nl_langinfo-mt
-PASS: test-nstrftime
-PASS: test-nullptr
-PASS: test-open
-PASS: test-openat-safer
-PASS: test-openat
-PASS: test-parse-datetime
-PASS: test-pathmax
-PASS: test-perror.sh
-PASS: test-perror2
-PASS: test-physmem
-PASS: test-pipe
-PASS: test-pipe2
-PASS: test-posix_memalign
-PASS: test-posixtm
-PASS: test-printf-frexp
-PASS: test-printf-frexpl
-PASS: test-priv-set
-PASS: test-pselect
-PASS: test-pthread-cond
-PASS: test-pthread
-PASS: test-pthread-mutex
-PASS: test-pthread-thread
-PASS: test-pthread_sigmask1
-PASS: test-pthread_sigmask2
-PASS: test-quotearg-simple
-PASS: test-raise
-PASS: test-rand-isaac
-PASS: test-rawmemchr
-PASS: test-read-file
-PASS: test-read
-PASS: test-readlink
-PASS: test-readlinkat
-PASS: test-readtokens.sh
-PASS: test-readutmp
-PASS: test-realloc-gnu
-PASS: test-reallocarray
-PASS: test-regex
-PASS: test-remove
-PASS: test-rename
-PASS: test-renameat
-PASS: test-renameatu
-PASS: test-rmdir
-PASS: test-sched
-PASS: test-select
-PASS: test-select-in.sh
-PASS: test-select-out.sh
-PASS: test-setenv
-PASS: test-setlocale_null
-PASS: test-setlocale_null-mt-one
-PASS: test-setlocale_null-mt-all
-PASS: test-setlocale1.sh
-PASS: test-setlocale2.sh
-PASS: test-setsockopt
-PASS: test-sigaction
-PASS: test-signal-h
-PASS: test-signbit
-PASS: test-sigprocmask
-PASS: test-sleep
-PASS: test-snprintf
-PASS: test-sockets
-PASS: test-stat
-PASS: test-stat-time
-PASS: test-stdbool
-PASS: test-stdckdint
-PASS: test-stddef
-PASS: test-stdint
-PASS: test-stdio
-PASS: test-stdlib
-PASS: test-strerror
-PASS: test-strerror_r
-PASS: test-string
-PASS: test-strncat
-PASS: test-strnlen
-PASS: test-strsignal
-PASS: test-strtod
-PASS: test-strtod1.sh
-PASS: test-strtoimax
-PASS: test-strtold
-PASS: test-strtold1.sh
-PASS: test-strtoll
-PASS: test-strtoull
-PASS: test-strtoumax
-PASS: test-symlink
-PASS: test-symlinkat
-PASS: test-sys_ioctl
-PASS: test-sys_random
-PASS: test-sys_resource
-PASS: test-sys_select
-PASS: test-sys_socket
-PASS: test-sys_stat
-PASS: test-sys_time
-PASS: test-sys_types
-PASS: test-sys_uio
-PASS: test-sys_utsname
-PASS: test-sys_wait
-PASS: test-termios
-PASS: test-init.sh
-PASS: test-thread_self
-PASS: test-thread_create
-PASS: test-time-h
-PASS: test-time
-PASS: test-timespec
-PASS: test-tls
-PASS: test-u64
-PASS: test-uchar
-PASS: test-uname
-PASS: test-uc_tolower
-PASS: test-unicodeio1.sh
-PASS: test-unicodeio2.sh
-SKIP: test-unicodeio3.sh
-PASS: test-ctype_alnum
-PASS: test-ctype_alpha
-PASS: test-ctype_blank
-PASS: test-ctype_cntrl
-PASS: test-ctype_digit
-PASS: test-ctype_graph
-PASS: test-ctype_lower
-PASS: test-ctype_print
-PASS: test-ctype_punct
-PASS: test-ctype_space
-PASS: test-ctype_upper
-PASS: test-ctype_xdigit
-PASS: test-dup-safer
-PASS: test-unistd
-PASS: test-u32-chr
-PASS: test-u32-cpy
-PASS: test-u32-pcpy
-PASS: test-u32-set
-PASS: test-u32-strcat
-PASS: test-u32-strlen
-PASS: test-u8-mbtoucr
-PASS: test-u8-uctomb
-PASS: test-uc_width
-PASS: uniwidth/test-uc_width2.sh
-PASS: test-unlink
-PASS: test-unlinkat
-PASS: test-unsetenv
-PASS: test-update-copyright.sh
-PASS: test-userspec
-PASS: test-usleep
-PASS: test-utime-h
-PASS: test-utime
-PASS: test-utimens
-PASS: test-utimensat
-PASS: test-vasnprintf
-PASS: test-vasprintf-posix
-PASS: test-vasprintf
-PASS: test-vc-list-files-git.sh
-SKIP: test-vc-list-files-cvs.sh
-PASS: test-verify
-PASS: test-verify.sh
-PASS: test-verror.sh
-PASS: test-version-etc.sh
-PASS: test-vfprintf-posix.sh
-PASS: test-vprintf-posix.sh
-PASS: test-wchar
-PASS: test-wcrtomb.sh
-SKIP: test-wcrtomb-w32-2.sh
-SKIP: test-wcrtomb-w32-3.sh
-SKIP: test-wcrtomb-w32-4.sh
-SKIP: test-wcrtomb-w32-5.sh
-SKIP: test-wcrtomb-w32-6.sh
-SKIP: test-wcrtomb-w32-7.sh
-SKIP: test-wcrtomb-w32-8.sh
-PASS: test-wctype-h
-PASS: test-wctype
-PASS: test-wcwidth
-PASS: test-write
-PASS: test-xalloc-die.sh
-PASS: test-xprintf-posix.sh
-PASS: test-xstrtoimax.sh
-PASS: test-xstrtol.sh
-PASS: test-xstrtoumax.sh
-PASS: test-xvasprintf
-PASS: test-year2038
-PASS: test-yesno.sh
-# TOTAL: 474
-# PASS:  416
-# SKIP:  58
+SKIP: tests/tail/inotify-race
+SKIP tests/tail/inotify-race.sh (exit status: 77)
+SKIP: tests/tail/inotify-race2
+SKIP tests/tail/inotify-race2.sh (exit status: 77)
+SKIP: tests/rm/ext3-perf
+SKIP tests/rm/ext3-perf.sh (exit status: 77)
+SKIP: tests/cp/link-heap
+SKIP tests/cp/link-heap.sh (exit status: 77)
+SKIP: tests/cp/no-ctx
+SKIP tests/cp/no-ctx.sh (exit status: 77)
+SKIP: tests/tty/tty-eof
+SKIP tests/tty/tty-eof.pl (exit status: 77)
+SKIP: tests/tail/inotify-rotate
+SKIP tests/tail/inotify-rotate.sh (exit status: 77)
+SKIP: tests/tail/inotify-rotate-resources
+SKIP tests/tail/inotify-rotate-resources.sh (exit status: 77)
+SKIP: tests/tail/inotify-dir-recreate
+SKIP tests/tail/inotify-dir-recreate.sh (exit status: 77)
+SKIP: tests/tail/inotify-only-regular
+SKIP tests/tail/inotify-only-regular.sh (exit status: 77)
+SKIP: tests/chgrp/basic
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/basic.sh (exit status: 77)
+SKIP: tests/rm/hash
+SKIP tests/rm/hash.sh (exit status: 77)
+SKIP: tests/rm/r-root
+SKIP tests/rm/r-root.sh (exit status: 77)
+SKIP: tests/rm/many-dir-entries-vs-OOM
+SKIP tests/rm/many-dir-entries-vs-OOM.sh (exit status: 77)
+SKIP: tests/chgrp/default-no-deref
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/default-no-deref.sh (exit status: 77)
+SKIP: tests/chgrp/deref
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/deref.sh (exit status: 77)
+SKIP: tests/chgrp/no-x
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/no-x.sh (exit status: 77)
+SKIP: tests/chgrp/posix-H
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/posix-H.sh (exit status: 77)
+SKIP: tests/chgrp/recurse
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/chgrp/recurse.sh (exit status: 77)
+SKIP: tests/seq/seq-long-double
+SKIP tests/seq/seq-long-double.sh (exit status: 77)
+SKIP: tests/tail/tail-sysfs
+SKIP tests/tail/tail-sysfs.sh (exit status: 77)
+SKIP: tests/tail/tail-n0f
+SKIP tests/tail/tail-n0f.sh (exit status: 77)
+SKIP: tests/misc/arch
+SKIP tests/misc/arch.sh (exit status: 77)
+SKIP: tests/misc/coreutils
+SKIP tests/misc/coreutils.sh (exit status: 77)
+SKIP: tests/cat/cat-proc
+SKIP tests/cat/cat-proc.sh (exit status: 77)
+FAIL: tests/misc/numfmt
+FAIL tests/misc/numfmt.pl (exit status: 1)
+SKIP: tests/runcon/runcon-compute
+SKIP tests/runcon/runcon-compute.sh (exit status: 77)
+SKIP: tests/shuf/shuf-reservoir
+SKIP tests/shuf/shuf-reservoir.sh (exit status: 77)
+SKIP: tests/sort/sort-benchmark-random
+SKIP tests/sort/sort-benchmark-random.sh (exit status: 77)
+SKIP: tests/sort/sort-compress-hang
+SKIP tests/sort/sort-compress-hang.sh (exit status: 77)
+SKIP: tests/sort/sort-compress-proc
+SKIP tests/sort/sort-compress-proc.sh (exit status: 77)
+SKIP: tests/sort/sort-h-thousands-sep
+SKIP tests/sort/sort-h-thousands-sep.sh (exit status: 77)
+SKIP: tests/sort/sort-month
+SKIP tests/sort/sort-month.sh (exit status: 77)
+SKIP: tests/sort/sort-spinlock-abuse
+SKIP tests/sort/sort-spinlock-abuse.sh (exit status: 77)
+SKIP: tests/sort/sort-stale-thread-mem
+SKIP tests/sort/sort-stale-thread-mem.sh (exit status: 77)
+SKIP: tests/sort/sort-u-FMR
+SKIP tests/sort/sort-u-FMR.sh (exit status: 77)
+SKIP: tests/stty/stty
+SKIP tests/stty/stty.sh (exit status: 77)
+SKIP: tests/stty/stty-pairs
+SKIP tests/stty/stty-pairs.sh (exit status: 77)
+SKIP: tests/tac/tac-continue
+SKIP tests/tac/tac-continue.sh (exit status: 77)
+SKIP: tests/timeout/timeout-group
+SKIP tests/timeout/timeout-group.sh (exit status: 77)
+SKIP: tests/timeout/timeout-large-parameters
+SKIP tests/timeout/timeout-large-parameters.sh (exit status: 77)
+SKIP: tests/misc/xattr
+SKIP tests/misc/xattr.sh (exit status: 77)
+SKIP: tests/cp/acl
+SKIP tests/cp/acl.sh (exit status: 77)
+SKIP: tests/cp/existing-perm-race
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+COREUTILS_GROUPS set in your environment to the space-separated list
+SKIP tests/cp/existing-perm-race.sh (exit status: 77)
+SKIP: tests/cp/sparse-extents
+SKIP tests/cp/sparse-extents.sh (exit status: 77)
+SKIP: tests/cp/copy-FMR
+SKIP tests/cp/copy-FMR.sh (exit status: 77)
+SKIP: tests/cp/nfs-removal-race
+SKIP tests/cp/nfs-removal-race.sh (exit status: 77)
+SKIP: tests/cp/perm
+SKIP tests/cp/perm.sh (exit status: 77)
+SKIP: tests/cp/proc-short-read
+SKIP tests/cp/proc-short-read.sh (exit status: 77)
+SKIP: tests/df/df-symlink
+SKIP tests/df/df-symlink.sh (exit status: 77)
+SKIP: tests/df/no-mtab-status
+SKIP tests/df/no-mtab-status.sh (exit status: 77)
+SKIP: tests/df/skip-duplicates
+SKIP tests/df/skip-duplicates.sh (exit status: 77)
+SKIP: tests/df/skip-rootfs
+SKIP tests/df/skip-rootfs.sh (exit status: 77)
+SKIP: tests/dd/nocache_eof
+SKIP tests/dd/nocache_eof.sh (exit status: 77)
+SKIP: tests/du/2g
+SKIP tests/du/2g.sh (exit status: 77)
+SKIP: tests/du/bigtime
+SKIP tests/du/bigtime.sh (exit status: 77)
+SKIP: tests/du/fd-leak
+SKIP tests/du/fd-leak.sh (exit status: 77)
+SKIP: tests/du/move-dir-while-traversing
+SKIP tests/du/move-dir-while-traversing.sh (exit status: 77)
+SKIP: tests/du/threshold
+SKIP tests/du/threshold.sh (exit status: 77)
+SKIP: tests/id/gnu-zero-uids
+SKIP tests/id/gnu-zero-uids.sh (exit status: 77)
+SKIP: tests/id/no-context
+SKIP tests/id/no-context.sh (exit status: 77)
+SKIP: tests/id/context
+SKIP tests/id/context.sh (exit status: 77)
+SKIP: tests/id/smack
+SKIP tests/id/smack.sh (exit status: 77)
+SKIP: tests/install/install-C-selinux
+SKIP tests/install/install-C-selinux.sh (exit status: 77)
+SKIP: tests/install/install-Z-selinux
+SKIP tests/install/install-Z-selinux.sh (exit status: 77)
+SKIP: tests/ls/acl
+SKIP tests/ls/acl.sh (exit status: 77)
+SKIP: tests/ls/no-cap
+SKIP tests/ls/no-cap.sh (exit status: 77)
+SKIP: tests/ls/removed-directory
+SKIP tests/ls/removed-directory.sh (exit status: 77)
+SKIP: tests/ls/slink-acl
+SKIP tests/ls/slink-acl.sh (exit status: 77)
+SKIP: tests/ls/stat-dtype
+SKIP tests/ls/stat-dtype.sh (exit status: 77)
+SKIP: tests/ls/stat-free-color
+SKIP tests/ls/stat-free-color.sh (exit status: 77)
+SKIP: tests/ls/stat-free-symlinks
+SKIP tests/ls/stat-free-symlinks.sh (exit status: 77)
+SKIP: tests/mkdir/p-acl
+SKIP tests/mkdir/p-acl.sh (exit status: 77)
+SKIP: tests/mkdir/selinux
+SKIP tests/mkdir/selinux.sh (exit status: 77)
+SKIP: tests/mkdir/restorecon
+SKIP tests/mkdir/restorecon.sh (exit status: 77)
+SKIP: tests/mkdir/smack-no-root
+SKIP tests/mkdir/smack-no-root.sh (exit status: 77)
+SKIP: tests/mv/acl
+SKIP tests/mv/acl.sh (exit status: 77)
+SKIP: tests/mv/atomic
+SKIP tests/mv/atomic.sh (exit status: 77)
+SKIP: tests/mv/atomic2
+SKIP tests/mv/atomic2.sh (exit status: 77)
+SKIP: tests/mv/leak-fd
+SKIP tests/mv/leak-fd.sh (exit status: 77)
+SKIP: tests/mv/symlink-onto-hardlink-to-self
+SKIP tests/mv/symlink-onto-hardlink-to-self.sh (exit status: 77)
+SKIP: tests/tail/big-4gb
+SKIP tests/tail/big-4gb.sh (exit status: 77)
+SKIP: tests/chown/basic
+SKIP tests/chown/basic.sh (exit status: 77)
+SKIP: tests/chgrp/from
+SKIP tests/chgrp/from.sh (exit status: 77)
+SKIP: tests/cp/cp-a-selinux
+SKIP tests/cp/cp-a-selinux.sh (exit status: 77)
+SKIP: tests/cp/preserve-gid
+SKIP tests/cp/preserve-gid.sh (exit status: 77)
+SKIP: tests/cp/special-bits
+SKIP tests/cp/special-bits.sh (exit status: 77)
+SKIP: tests/cp/cp-mv-enotsup-xattr
+SKIP tests/cp/cp-mv-enotsup-xattr.sh (exit status: 77)
+SKIP: tests/cp/capability
+SKIP tests/cp/capability.sh (exit status: 77)
+SKIP: tests/cp/cross-dev-symlink
+SKIP tests/cp/cross-dev-symlink.sh (exit status: 77)
+SKIP: tests/dd/skip-seek-past-dev
+SKIP tests/dd/skip-seek-past-dev.sh (exit status: 77)
+SKIP: tests/df/problematic-chars
+SKIP tests/df/problematic-chars.sh (exit status: 77)
+SKIP: tests/df/over-mount-device
+SKIP tests/df/over-mount-device.sh (exit status: 77)
+SKIP: tests/du/bind-mount-dir-cycle
+SKIP tests/du/bind-mount-dir-cycle.sh (exit status: 77)
+SKIP: tests/du/bind-mount-dir-cycle-v2
+SKIP tests/du/bind-mount-dir-cycle-v2.sh (exit status: 77)
+SKIP: tests/id/setgid
+SKIP tests/id/setgid.sh (exit status: 77)
+SKIP: tests/install/install-C-root
+SKIP tests/install/install-C-root.sh (exit status: 77)
+SKIP: tests/ls/capability
+SKIP tests/ls/capability.sh (exit status: 77)
+SKIP: tests/ls/nameless-uid
+SKIP tests/ls/nameless-uid.sh (exit status: 77)
+SKIP: tests/chcon/chcon
+SKIP tests/chcon/chcon.sh (exit status: 77)
+SKIP: tests/chroot/chroot-credentials
+SKIP tests/chroot/chroot-credentials.sh (exit status: 77)
+SKIP: tests/misc/selinux
+SKIP tests/misc/selinux.sh (exit status: 77)
+SKIP: tests/truncate/truncate-owned-by-other
+SKIP tests/truncate/truncate-owned-by-other.sh (exit status: 77)
+SKIP: tests/mkdir/writable-under-readonly
+SKIP tests/mkdir/writable-under-readonly.sh (exit status: 77)
+SKIP: tests/mkdir/smack-root
+SKIP tests/mkdir/smack-root.sh (exit status: 77)
+SKIP: tests/mv/hardlink-case
+SKIP tests/mv/hardlink-case.sh (exit status: 77)
+SKIP: tests/mv/sticky-to-xpart
+SKIP tests/mv/sticky-to-xpart.sh (exit status: 77)
+SKIP: tests/rm/fail-2eperm
+SKIP tests/rm/fail-2eperm.sh (exit status: 77)
+SKIP: tests/rm/no-give-up
+SKIP tests/rm/no-give-up.sh (exit status: 77)
+SKIP: tests/rm/one-file-system
+SKIP tests/rm/one-file-system.sh (exit status: 77)
+SKIP: tests/rm/read-only
+SKIP tests/rm/read-only.sh (exit status: 77)
+SKIP: tests/rm/empty-immutable-skip
+SKIP tests/rm/empty-immutable-skip.sh (exit status: 77)
+SKIP: tests/split/l-chunk-root
+SKIP tests/split/l-chunk-root.sh (exit status: 77)
+SKIP: tests/tail/append-only
+SKIP tests/tail/append-only.sh (exit status: 77)
+SKIP: tests/tail/end-of-device
+SKIP tests/tail/end-of-device.sh (exit status: 77)
+SKIP: tests/touch/now-owned-by-other
+SKIP tests/touch/now-owned-by-other.sh (exit status: 77)
+SKIP: tests/factor/t00
+SKIP tests/factor/t00.sh (exit status: 77)
+SKIP: tests/factor/t01
+SKIP tests/factor/t01.sh (exit status: 77)
+SKIP: tests/factor/t02
+SKIP tests/factor/t02.sh (exit status: 77)
+SKIP: tests/factor/t03
+SKIP tests/factor/t03.sh (exit status: 77)
+SKIP: tests/factor/t04
+SKIP tests/factor/t04.sh (exit status: 77)
+SKIP: tests/factor/t05
+SKIP tests/factor/t05.sh (exit status: 77)
+SKIP: tests/factor/t06
+SKIP tests/factor/t06.sh (exit status: 77)
+SKIP: tests/factor/t07
+SKIP tests/factor/t07.sh (exit status: 77)
+SKIP: tests/factor/t08
+SKIP tests/factor/t08.sh (exit status: 77)
+SKIP: tests/factor/t09
+SKIP tests/factor/t09.sh (exit status: 77)
+SKIP: tests/factor/t10
+SKIP tests/factor/t10.sh (exit status: 77)
+SKIP: tests/factor/t11
+SKIP tests/factor/t11.sh (exit status: 77)
+SKIP: tests/factor/t12
+SKIP tests/factor/t12.sh (exit status: 77)
+SKIP: tests/factor/t13
+SKIP tests/factor/t13.sh (exit status: 77)
+SKIP: tests/factor/t14
+SKIP tests/factor/t14.sh (exit status: 77)
+SKIP: tests/factor/t15
+SKIP tests/factor/t15.sh (exit status: 77)
+SKIP: tests/factor/t16
+SKIP tests/factor/t16.sh (exit status: 77)
+SKIP: tests/factor/t17
+SKIP tests/factor/t17.sh (exit status: 77)
+SKIP: tests/factor/t18
+SKIP tests/factor/t18.sh (exit status: 77)
+SKIP: tests/factor/t19
+SKIP tests/factor/t19.sh (exit status: 77)
+SKIP: tests/factor/t20
+SKIP tests/factor/t20.sh (exit status: 77)
+SKIP: tests/factor/t21
+SKIP tests/factor/t21.sh (exit status: 77)
+SKIP: tests/factor/t22
+SKIP tests/factor/t22.sh (exit status: 77)
+SKIP: tests/factor/t23
+SKIP tests/factor/t23.sh (exit status: 77)
+SKIP: tests/factor/t24
+SKIP tests/factor/t24.sh (exit status: 77)
+SKIP: tests/factor/t25
+SKIP tests/factor/t25.sh (exit status: 77)
+SKIP: tests/factor/t26
+SKIP tests/factor/t26.sh (exit status: 77)
+SKIP: tests/factor/t27
+SKIP tests/factor/t27.sh (exit status: 77)
+SKIP: tests/factor/t28
+SKIP tests/factor/t28.sh (exit status: 77)
+SKIP: tests/factor/t29
+SKIP tests/factor/t29.sh (exit status: 77)
+SKIP: tests/factor/t30
+SKIP tests/factor/t30.sh (exit status: 77)
+SKIP: tests/factor/t31
+SKIP tests/factor/t31.sh (exit status: 77)
+SKIP: tests/factor/t32
+SKIP tests/factor/t32.sh (exit status: 77)
+SKIP: tests/factor/t33
+SKIP tests/factor/t33.sh (exit status: 77)
+SKIP: tests/factor/t34
+SKIP tests/factor/t34.sh (exit status: 77)
+SKIP: tests/factor/t35
+SKIP tests/factor/t35.sh (exit status: 77)
+SKIP: tests/factor/t36
+SKIP tests/factor/t36.sh (exit status: 77)
+# TOTAL: 653
+# PASS:  500
+# SKIP:  152
 # XFAIL: 0
-# FAIL:  0
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -32,7 +32,7 @@
 | developer/versioning/sccs		| 5.09			| https://sourceforge.net/projects/sccs/files/
 | driver/tuntap				| 1.3.3			| https://github.com/kaizawa/tuntap/tags
 | editor/vim				| 9.1			| http://ftp.vim.org/pub/vim/unix
-| file/gnu-coreutils			| 9.4			| https://ftp.gnu.org/gnu/coreutils/
+| file/gnu-coreutils			| 9.5			| https://ftp.gnu.org/gnu/coreutils/
 | file/gnu-findutils			| 4.9.0			| https://ftp.gnu.org/pub/gnu/findutils/
 | library/c++/sigcpp			| 3.6.0			| https://download.gnome.org/sources/libsigc++/cache.json https://github.com/libsigcplusplus/libsigcplusplus/blob/master/NEWS
 | library/expat				| 2.6.2			| https://github.com/libexpat/libexpat/releases


### PR DESCRIPTION
The biggest difference in the testsuite is that the gnulib tests are no longer run, which seems fine.

There is also a failing `numfmt` test which is that padding is lost when presenting a padded, delimited, number in the French locale. This seems to be a result of our `mbrtoc32()` function not recognising the delimiter being used.

Padding works fine in the C, and various other locales, and always works without delimiters so I think this is ok, unless we get any problem reports.