### PR TITLE
Detect and fix more gcc14 fallout

### DIFF
--- a/build/bash/build.sh
+++ b/build/bash/build.sh
@@ -40,6 +40,7 @@ BUILD_DEPENDS_IPS="library/readline"
 RUN_DEPENDS_IPS="system/prerequisite/gnu system/library"
 
 set_arch 64
+set_standard XPG6
 
 XFORM_ARGS+="
     -DBCVER=$BCVER

--- a/build/bison/build.sh
+++ b/build/bison/build.sh
@@ -25,6 +25,7 @@ DESC="A general-purpose parser generator that converts an annotated "
 DESC+="context-free grammar into a deterministic or generalised parser"
 
 set_arch 64
+set_standard XPG6
 
 CONFIGURE_OPTS="--disable-yacc"
 export M4=/usr/bin/gm4

--- a/build/chrony/build.sh
+++ b/build/chrony/build.sh
@@ -33,7 +33,7 @@ XFORM_ARGS="
 "
 
 init
-prep_build
+prep_build autoconf -autoreconf
 
 #########################################################################
 # Download and build a static version of nettle
@@ -56,6 +56,7 @@ note -n "-- Building $PROG"
 pre_build() {
     typeset arch=$1
 
+    unset RUN_AUTORECONF
     CPPFLAGS[$arch]="-I$DEPROOT$PREFIX/include"
     LDFLAGS[$arch]+=" -L$DEPROOT$PREFIX/${LIBDIRS[$arch]}"
     addpath PKG_CONFIG_PATH[$arch] \

--- a/build/chrony/patches-nettle/openssl.patch
+++ b/build/chrony/patches-nettle/openssl.patch
@@ -1,0 +1,12 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -1183,7 +1183,7 @@ if test x$enable_openssl = xyes ; then
+ #include <openssl/ec.h>
+ #include <openssl/rsa.h>
+ ], [
+-EVP_MD_CTX *cipher_ctx = EVP_CIPHER_CTX_new();
++EVP_CIPHER_CTX *cipher_ctx = EVP_CIPHER_CTX_new();
+ EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
+ EVP_PKEY *rsa_key = EVP_RSA_gen(2048);
+ EVP_PKEY *ec_key = EVP_EC_gen("P-256");

--- a/build/chrony/patches-nettle/series
+++ b/build/chrony/patches-nettle/series
@@ -1,0 +1,1 @@
+openssl.patch

--- a/build/coreutils/build.sh
+++ b/build/coreutils/build.sh
@@ -33,6 +33,8 @@ PREFIX=/usr/gnu
 # work with 32-bit binaries.
 forgo_isaexec
 
+set_standard XPG6 CFLAGS
+
 # hardlinks are defined in local.mog
 SKIP_HARDLINK=1
 

--- a/build/coreutils/patches/gcc14.patch
+++ b/build/coreutils/patches/gcc14.patch
@@ -1,0 +1,19 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/m4/printf.m4 a/m4/printf.m4
+--- a~/m4/printf.m4	1970-01-01 00:00:00
++++ a/m4/printf.m4	1970-01-01 00:00:00
+@@ -894,6 +894,7 @@ AC_DEFUN([gl_PRINTF_DIRECTIVE_N],
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ #ifdef _MSC_VER
+ #include <inttypes.h>
+ /* See page about "Parameter Validation" on msdn.microsoft.com.
+@@ -1708,6 +1709,7 @@ AC_DEFUN([gl_SNPRINTF_DIRECTIVE_N],
+ #include <signal.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <unistd.h>
+ #if HAVE_SNPRINTF
+ # define my_snprintf snprintf
+ #else

--- a/build/coreutils/patches/series
+++ b/build/coreutils/patches/series
@@ -7,3 +7,4 @@ who.c.patch
 tests_df_no-mtab-status.sh.patch
 set-permission.c.patch
 stdbuf.c.patch
+gcc14.patch

--- a/build/dbus/patches/gcc14.patch
+++ b/build/dbus/patches/gcc14.patch
@@ -1,0 +1,24 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure a/configure
+--- a~/configure	1970-01-01 00:00:00
++++ a/configure	1970-01-01 00:00:00
+@@ -22622,7 +22622,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_
+ /* end confdefs.h.  */
+ 
+ #include <bsm/adt.h>
+-adt_user_context = ADT_USER;
++int adt_user_context = ADT_USER;
+ 
+ int
+ main (void)
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -1042,7 +1042,7 @@ AC_SUBST([SELINUX_LIBS])
+ AC_MSG_CHECKING(for ADT API)
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <bsm/adt.h>
+-adt_user_context = ADT_USER;
++int adt_user_context = ADT_USER;
+ ]], [[]])], [ check_adt_audit=yes ], [ check_adt_audit=no ])
+ 
+ if test ${check_adt_audit} = yes

--- a/build/dbus/patches/series
+++ b/build/dbus/patches/series
@@ -1,1 +1,2 @@
 inline.patch
+gcc14.patch

--- a/build/diffutils/build.sh
+++ b/build/diffutils/build.sh
@@ -34,6 +34,7 @@ DESC="$SUMMARY"
 RUN_DEPENDS_IPS="system/prerequisite/gnu"
 
 set_arch 64
+set_standard XPG6
 CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'

--- a/build/gettext/build.sh
+++ b/build/gettext/build.sh
@@ -24,6 +24,7 @@ SUMMARY="gettext - GNU gettext utility"
 DESC="GNU gettext - GNU gettext utility"
 
 set_arch 64
+set_standard XPG6
 
 RUN_DEPENDS_IPS="system/prerequisite/gnu developer/macro/gnu-m4"
 

--- a/build/gettext/patches/gcc14.patch
+++ b/build/gettext/patches/gcc14.patch
@@ -1,0 +1,30 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/gettext-runtime/intl/configure a/gettext-runtime/intl/configure
+--- a~/gettext-runtime/intl/configure	1970-01-01 00:00:00
++++ a/gettext-runtime/intl/configure	1970-01-01 00:00:00
+@@ -30647,6 +30647,7 @@ else case e in #(
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ #ifdef _MSC_VER
+ #include <inttypes.h>
+ /* See page about "Parameter Validation" on msdn.microsoft.com.
+diff -wpruN --no-dereference '--exclude=*.orig' a~/libtextstyle/configure a/libtextstyle/configure
+--- a~/libtextstyle/configure	1970-01-01 00:00:00
++++ a/libtextstyle/configure	1970-01-01 00:00:00
+@@ -30457,6 +30457,7 @@ else case e in #(
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ #ifdef _MSC_VER
+ #include <inttypes.h>
+ /* See page about "Parameter Validation" on msdn.microsoft.com.
+@@ -31406,6 +31407,7 @@ else case e in #(
+ #include <signal.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <unistd.h>
+ #if HAVE_SNPRINTF
+ # define my_snprintf snprintf
+ #else

--- a/build/gettext/patches/series
+++ b/build/gettext/patches/series
@@ -1,0 +1,1 @@
+gcc14.patch

--- a/build/grep/build.sh
+++ b/build/grep/build.sh
@@ -26,6 +26,7 @@ DESC="GNU grep utilities"
 DEPENDS_IPS="system/prerequisite/gnu library/pcre"
 
 set_arch 64
+set_standard XPG6
 CONFIGURE_OPTS="--program-prefix=g"
 
 TESTSUITE_FILTER='^[A-Z#][A-Z ]'

--- a/build/gtar/build.sh
+++ b/build/gtar/build.sh
@@ -33,6 +33,7 @@ RUN_DEPENDS_IPS="
 "
 
 set_arch 64
+set_standard XPG6
 
 CONFIGURE_OPTS="
     --program-prefix=g

--- a/build/libidn/build.sh
+++ b/build/libidn/build.sh
@@ -32,6 +32,8 @@ CONFIGURE_OPTS="--disable-static"
 MAKE_ARGS="MAKEINFO=/usr/bin/true"
 MAKE_INSTALL_ARGS="$MAKE_ARGS"
 
+set_standard XPG6
+
 init
 prep_build
 

--- a/build/libpsl/build.sh
+++ b/build/libpsl/build.sh
@@ -29,6 +29,7 @@ CONFIGURE_OPTS+="
 "
 
 forgo_isaexec
+set_standard XPG6
 
 export MAKE
 

--- a/build/m4/build.sh
+++ b/build/m4/build.sh
@@ -33,6 +33,7 @@ DESC="GNU m4 - A macro processor (gm4)"
 
 PREFIX=/usr/gnu
 set_arch 64
+set_standard XPG6
 
 CONFIGURE_OPTS="--infodir=/usr/share/info"
 

--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -47,6 +47,7 @@ CONFIGURE_OPTS_COMMON="
     --prefix=$GPREFIX
     --with-terminfo-dirs=$GPREFIX/share/terminfo
     --with-default-terminfo-dir=$GPREFIX/share/terminfo
+    cf_cv_struct_dirent64=no
 "
 CONFIGURE_OPTS_ABI6="$CONFIGURE_OPTS_COMMON"
 CONFIGURE_OPTS_ABI5="$CONFIGURE_OPTS_COMMON --with-abi-version=5"

--- a/build/net-snmp/patches/fdset.patch
+++ b/build/net-snmp/patches/fdset.patch
@@ -1,0 +1,12 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure a/configure
+--- a~/configure	1970-01-01 00:00:00
++++ a/configure	1970-01-01 00:00:00
+@@ -31638,7 +31638,7 @@ CFLAGS="$CFLAGS -Werror"
+ 
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the type of fd_set::fds_bits" >&5
+ printf %s "checking for the type of fd_set::fds_bits... " >&6; }
+-for type in __fd_mask __int32_t unknown; do
++for type in __int32_t __fd_mask unknown; do
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 

--- a/build/net-snmp/patches/series
+++ b/build/net-snmp/patches/series
@@ -23,3 +23,4 @@
 067.1.kernel_sunos5.patch
 068.configure.patch
 closefrom.patch
+fdset.patch

--- a/build/openssh/patches/configure-ed25519.patch
+++ b/build/openssh/patches/configure-ed25519.patch
@@ -1,0 +1,24 @@
+From 8d0e46c1ddb5b7f0992591b0dc5d8aaa77cc9dba Mon Sep 17 00:00:00 2001
+From: Alkaid <zgf574564920@gmail.com>
+Date: Tue, 12 Mar 2024 03:59:12 -0700
+Subject: [PATCH] Fix OpenSSL ED25519 support detection
+
+Wrong function signature in configure.ac prevents openssh from enabling
+the recently new support for ED25519 priv keys in PEM PKCS8 format.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 82e8bb7c141..081e2bc75bd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3184,7 +3184,7 @@ if test "x$openssl" = "xyes" ; then
+ 		]], [[
+ 		unsigned char buf[64];
+ 		memset(buf, 0, sizeof(buf));
+-		exit(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519,
++		exit(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL,
+ 		    buf, sizeof(buf)) == NULL);
+ 		]])],
+ 		[

--- a/build/openssh/patches/series
+++ b/build/openssh/patches/series
@@ -20,3 +20,4 @@ sshd_config.patch
 0029-Accept-LANG-and-LC_-environment-variables-from-clien.patch
 0031-Restore-tcpwrappers-libwrap-support.patch
 test.patch
+configure-ed25519.patch

--- a/build/python312/patches/gethostbyname.patch
+++ b/build/python312/patches/gethostbyname.patch
@@ -1,0 +1,42 @@
+Attempting to detect whether we have a gethostbyname_r() with 6 arguments
+is fatal with gcc14. We jump straight to the 5 argument check which is
+correct when building with XPG6.
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -5564,26 +5564,6 @@ AH_TEMPLATE([HAVE_GETHOSTBYNAME_R],
+ 
+ AC_CHECK_FUNC([gethostbyname_r],
+   [AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+-  AC_MSG_CHECKING([gethostbyname_r with 6 args])
+-  OLD_CFLAGS=$CFLAGS
+-  CFLAGS="$CFLAGS $MY_CPPFLAGS $MY_THREAD_CPPFLAGS $MY_CFLAGS"
+-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+-#   include <netdb.h>
+-  ]], [[
+-    char *name;
+-    struct hostent *he, *res;
+-    char buffer[2048];
+-    int buflen = 2048;
+-    int h_errnop;
+-
+-    (void) gethostbyname_r(name, he, buffer, buflen, &res, &h_errnop)
+-  ]])],[
+-    AC_DEFINE([HAVE_GETHOSTBYNAME_R])
+-    AC_DEFINE([HAVE_GETHOSTBYNAME_R_6_ARG], [1],
+-    [Define this if you have the 6-arg version of gethostbyname_r().])
+-    AC_MSG_RESULT([yes])
+-  ],[
+-    AC_MSG_RESULT([no])
+     AC_MSG_CHECKING([gethostbyname_r with 5 args])
+     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #       include <netdb.h>
+@@ -5622,7 +5602,6 @@ AC_CHECK_FUNC([gethostbyname_r],
+            AC_MSG_RESULT([no])
+         ])
+     ])
+-  ])
+   CFLAGS=$OLD_CFLAGS
+ ], [
+   AC_CHECK_FUNCS([gethostbyname])

--- a/build/python312/patches/series
+++ b/build/python312/patches/series
@@ -40,3 +40,4 @@ revert-makedirs.patch
 #
 # Do not add ustack.patch to this file, it is used to build the debug
 # variant of python, see build.sh
+gethostbyname.patch

--- a/build/tcsh/build.sh
+++ b/build/tcsh/build.sh
@@ -27,6 +27,7 @@ UCPROG=${PROG^^}
 UVER=${VER//./_}
 
 set_builddir "$PROG-$UCPROG$UVER"
+set_standard XPG6
 set_arch 64
 
 build_init() {

--- a/build/wget/build.sh
+++ b/build/wget/build.sh
@@ -37,6 +37,7 @@ TEST_DEPENDS_PERLMOD="
 "
 
 set_arch 64
+set_standard XPG6
 
 CONFIGURE_OPTS="
     --with-ssl=openssl

--- a/build/wget2/build.sh
+++ b/build/wget2/build.sh
@@ -52,6 +52,7 @@ fi
 note -n "-- Building $PROG"
 
 forgo_isaexec
+set_standard XPG6
 
 CONFIGURE_OPTS="
     --with-ssl=openssl

--- a/build/zsh/patches/gcc14.patch
+++ b/build/zsh/patches/gcc14.patch
@@ -167,6 +167,40 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
  {
      char buf[4096];
      int r1 = tgetent(buf, "!@#$%^&*");
+@@ -1761,27 +1761,27 @@ if test x$zsh_cv_path_term_header != xno
+   fi
+ 
+   AC_MSG_CHECKING(if boolcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = boolcodes; puts(*test);]])],[AC_DEFINE(HAVE_BOOLCODES) boolcodes=yes],[boolcodes=no])
+   AC_MSG_RESULT($boolcodes)
+ 
+   AC_MSG_CHECKING(if numcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = numcodes; puts(*test);]])],[AC_DEFINE(HAVE_NUMCODES) numcodes=yes],[numcodes=no])
+   AC_MSG_RESULT($numcodes)
+ 
+   AC_MSG_CHECKING(if strcodes is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = strcodes; puts(*test);]])],[AC_DEFINE(HAVE_STRCODES) strcodes=yes],[strcodes=no])
+   AC_MSG_RESULT($strcodes)
+ 
+   AC_MSG_CHECKING(if boolnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = boolnames; puts(*test);]])],[AC_DEFINE(HAVE_BOOLNAMES) boolnames=yes],[boolnames=no])
+   AC_MSG_RESULT($boolnames)
+ 
+   AC_MSG_CHECKING(if numnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = numnames; puts(*test);]])],[AC_DEFINE(HAVE_NUMNAMES) numnames=yes],[numnames=no])
+   AC_MSG_RESULT($numnames)
+ 
+   AC_MSG_CHECKING(if strnames is available)
+-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[char **test = strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[$term_includes]], [[const char **test = strnames; puts(*test);]])],[AC_DEFINE(HAVE_STRNAMES) strnames=yes],[strnames=no])
+   AC_MSG_RESULT($strnames)
+ 
+   dnl There are apparently defective terminal library headers on some
 @@ -1862,7 +1862,7 @@ zsh_cv_rlim_t_is_longer,
  #endif
  #include <sys/resource.h>

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -2658,7 +2658,7 @@ configure_arch() {
     # Check for configuration tests that have failed as a result of a
     # main function being present without a declared return type.
     $RIPGREP --no-messages --no-ignore \
-        "error: (return type defaults|implicit declaration.*'(exit|strcmp)')" \
+        'error:.*(-W(incompatible-pointer-types|implicit-int)|(exit|strcmp).*-Wimplicit-function-declaration)' \
         -g config.log && logerr 'Found broken tests in configure'
 }
 


### PR DESCRIPTION
Following on from #3610, there is probably more breakage lurking from the switch to gcc14. This improves the way we try and detect this after a configure run and fixes up the problems it found.