### PR TITLE
open-vm-tools: fix ip address reporting

### DIFF
--- a/build/open-vm-tools/patches/nicInfo.patch
+++ b/build/open-vm-tools/patches/nicInfo.patch
@@ -1,6 +1,5 @@
-diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/lib/nicInfo/nicInfoPosix.c
---- a~/lib/nicInfo/nicInfoPosix.c	1970-01-01 00:00:00
-+++ a/lib/nicInfo/nicInfoPosix.c	1970-01-01 00:00:00
+--- a~/lib/nicInfo/nicInfoPosix.c.orig	Tue Aug  6 20:09:09 2024
++++ a/lib/nicInfo/nicInfoPosix.c	Tue Aug  6 20:09:16 2024
 @@ -35,11 +35,8 @@
  #include <sys/stat.h>
  #include <errno.h>
@@ -13,7 +12,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/
  #ifndef NO_DNET
  # ifdef DNET_IS_DUMBNET
  #  include <dumbnet.h>
-@@ -195,7 +192,7 @@ GuestInfoGetFqdn(int outBufLen,    // IN
+@@ -195,7 +192,7 @@
  }
  
  
@@ -22,7 +21,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/
  /*
   ******************************************************************************
   * CountNetmaskBits --                                                   */ /**
-@@ -234,7 +231,7 @@ CountNetmaskBitsV4(struct sockaddr *netm
+@@ -234,7 +231,7 @@
  }
  #endif
  
@@ -31,7 +30,57 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/
  static unsigned
  CountNetmaskBitsV6(struct sockaddr *netmask)
  {
-@@ -452,7 +449,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
+@@ -306,7 +303,11 @@
+     * records are intermingled with AF_INET and AF_INET6 records.
+     */
+    for (pkt = ifaddrs; pkt != NULL; pkt = pkt->ifa_next) {
++#ifdef sun
++      struct sockaddr_dl *sdl;
++#else
+       struct sockaddr_ll *sll = (struct sockaddr_ll *)pkt->ifa_addr;
++#endif
+ 
+       if (GuestInfo_IfaceGetPriority(pkt->ifa_name) != priority ||
+           GuestInfo_IfaceIsExcluded(pkt->ifa_name)) {
+@@ -313,7 +314,15 @@
+          continue;
+       }
+ 
++#ifdef sun
++      if (pkt->ifa_addr->sa_family == AF_LINK) {
++         uint8_t *mac;
++
++         sdl = (struct sockaddr_dl *)pkt->ifa_addr;
++         mac = LLADDR(sdl);
++#else
+       if (sll != NULL && sll->sll_family == AF_PACKET) {
++#endif
+          char macAddress[NICINFO_MAC_LEN];
+          GuestNicV3 *nic;
+          struct ifaddrs *ip;
+@@ -324,7 +333,7 @@
+           * and its ifa_flags is reported as 0. No AF_PACKET family ifaddrs
+           * is reported for loopback interface.
+           */
+-#if !defined(USERWORLD)
++#if !defined(USERWORLD) && !defined(sun)
+          /*
+           * Ignore loopback and downed devices.
+           */
+@@ -335,8 +344,12 @@
+ 
+          Str_Sprintf(macAddress, sizeof macAddress,
+                      "%02x:%02x:%02x:%02x:%02x:%02x",
++#ifdef sun
++                     mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
++#else
+                      sll->sll_addr[0], sll->sll_addr[1], sll->sll_addr[2],
+                      sll->sll_addr[3], sll->sll_addr[4], sll->sll_addr[5]);
++#endif
+          nic = GuestInfoAddNicEntry(nicInfo, macAddress, NULL, NULL,
+                                     maxNicsError);
+          if (nic == NULL) {
+@@ -452,7 +465,7 @@
     }
  
     return TRUE;
@@ -40,7 +89,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/lib/nicInfo/nicInfoPosix.c a/
     struct ifaddrs *ifaddrs = NULL;
  
     if (getifaddrs(&ifaddrs) == 0 && ifaddrs != NULL) {
-@@ -501,6 +498,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4
+@@ -501,6 +514,7 @@
   */
  #if defined(__FreeBSD__) || \
      defined(__APPLE__) || \


### PR DESCRIPTION
getifaddrs() on illumos does not seem to return AF_PACKET interfaces at all, so vmtoolsd does not report any ip addresses to the hypervisor. Fix this by processing AF_LINK interfaces instead.

While here, fix the build error likely coming from recent pam changes (?) by disabling the warning (will remove if deemed completely unrelated).