### PR TITLE
sudo: disable secure_path in /etc/sudoers by default

### DIFF
--- a/build/sudo/build.sh
+++ b/build/sudo/build.sh
@@ -40,6 +40,7 @@ CONFIGURE_OPTS="
     --enable-python
     --enable-log-client
     --disable-log-server
+    --with-secure-path-value=no
 "
 CONFIGURE_OPTS[amd64]+="
     --libexecdir=/usr/lib/$PROG/amd64

--- a/build/sudo/files/_omnios_corefiles
+++ b/build/sudo/files/_omnios_corefiles
@@ -1,0 +1,7 @@
+# Lowering the core dump limit in the child environment became the default
+# when resource limits were introduced in sudo 1.9.9.
+# We preserve the default limits on OmniOS to retain old behaviour, and to have
+# something useful for post-mortem debugging.
+
+Defaults rlimit_core=default
+

--- a/build/sudo/files/_omnios_nopty
+++ b/build/sudo/files/_omnios_nopty
@@ -1,4 +1,3 @@
-
 # Using a PTY, which became the default in sudo 1.9.14, does not yet work
 # properly. This restores the previous default.
 

--- a/build/sudo/local.mog
+++ b/build/sudo/local.mog
@@ -30,6 +30,8 @@
 
 file files/_omnios_nopty path=etc/sudoers.d/_omnios_nopty \
     owner=root group=root mode=0440 preserve=true
+file files/_omnios_corefiles path=etc/sudoers.d/_omnios_corefiles \
+    owner=root group=root mode=0440 preserve=true
 
 license LICENSE.md license=Various
 

--- a/build/sudo/patches/securepath.patch
+++ b/build/sudo/patches/securepath.patch
@@ -1,0 +1,59 @@
+Submitted upstream as: https://github.com/sudo-project/sudo/pull/409
+
+commit 68175fe0f4ca339085483c2039f2dd9b0864df1f
+Author: Andy Fiddaman <illumos@fiddaman.net>
+Date:   Tue Sep 17 12:49:13 2024 +0000
+
+    Allow --secure-path-value=no
+
+    This adds support for --with-secure-path-value=no to allow packagers
+    to ship the sudoers configuration file with the secure path
+    line commented out if required.
+
+diff --git a/configure.ac b/configure.ac
+index e547f7941..4c3def4bf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -177,6 +177,7 @@ AC_SUBST([sssd_lib])
+ AC_SUBST([nsswitch_conf])
+ AC_SUBST([netsvc_conf])
+ AC_SUBST([secure_path])
++AC_SUBST([secure_path_config])
+ AC_SUBST([secure_path_status])
+ AC_SUBST([editor])
+ AC_SUBST([pam_session])
+@@ -230,6 +231,7 @@ sesh_file="$libexecdir/sudo/sesh"
+ visudo="$sbindir/visudo"
+ nsswitch_conf=/etc/nsswitch.conf
+ secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
++secure_path_config=
+ secure_path_status="disabled"
+ pam_session=on
+ pam_login_service=sudo
+@@ -1068,9 +1070,11 @@ AC_ARG_WITH(ldap-secret-file, [AS_HELP_STRING([--with-ldap-secret-file], [path t
+ test -n "$with_ldap_secret_file" && ldap_secret="$with_ldap_secret_file"
+ SUDO_DEFINE_UNQUOTED(_PATH_LDAP_SECRET, "$ldap_secret", [Path to the ldap.secret file])
+ 
+-AC_ARG_WITH(secure-path-value, [AS_HELP_STRING([--with-secure-path-value], [value of secure_path in the default sudoers file])],
++AC_ARG_WITH(secure-path-value, [AS_HELP_STRING([--with-secure-path-value], [value of secure_path in the default sudoers file, or "no" to comment out by default])],
+ [case $with_secure_path_value in
+-    yes|no)	AC_MSG_ERROR([must give --secure-path-value an argument.])
++    yes)	AC_MSG_ERROR([must give --with-secure-path-value an argument.])
++		;;
++    no)		secure_path_config="# "
+ 		;;
+     *)		secure_path="$with_secure_path_value"
+ 		;;
+diff --git a/plugins/sudoers/sudoers.in b/plugins/sudoers/sudoers.in
+index 8368c5e95..9e7621fde 100644
+--- a/plugins/sudoers/sudoers.in
++++ b/plugins/sudoers/sudoers.in
+@@ -48,7 +48,7 @@ Defaults!@visudo@ env_keep += "SUDO_EDITOR EDITOR VISUAL"
+ ## Use a hard-coded PATH instead of the user's to find commands.
+ ## This also helps prevent poorly written scripts from running
+ ## artbitrary commands under sudo.
+-Defaults secure_path="@secure_path@"
++@secure_path_config@Defaults secure_path="@secure_path@"
+ ##
+ ## You may wish to keep some of the following environment variables
+ ## when running commands via sudo.

--- a/build/sudo/patches/series
+++ b/build/sudo/patches/series
@@ -2,3 +2,4 @@ audit-event.patch
 Makefile.in.patch
 mansections.patch
 pam-illumos.patch
+securepath.patch


### PR DESCRIPTION
We have always shipped `/etc/sudoers` this way but sudo 1.9.16 changes things on upgrade if the user has never modified the default file. This change allows us to continue shipping without this setting being enabled, for least surprise/breakage.