### PR TITLE
Services that start as root should start in /

### DIFF
--- a/build/chrony/files/chrony.xml
+++ b/build/chrony/files/chrony.xml
@@ -77,7 +77,7 @@
                      name="start"
                      exec="/usr/sbin/chronyd"
                      timeout_seconds="60">
-            <method_context security_flags="aslr">
+            <method_context security_flags="aslr" working_directory="/">
                 <method_credential user="root"
                                    group="root"
                                    privileges="basic,!file_link_any,!proc_info,!proc_session,file_chown_self,file_dac_search,file_dac_write,net_privaddr,proc_lock_memory,proc_priocntl,proc_setid,sys_time" />

--- a/build/chrony/files/chrony.xml
+++ b/build/chrony/files/chrony.xml
@@ -55,7 +55,6 @@
                     type="path">
             <service_fmri value="file://localhost/etc/inet/chrony.conf" />
         </dependency>
-
         <!-- ntpsec/vmtoolsd also adjust the system time. Prevent chrony running
              at the same time. -->
 
@@ -77,7 +76,8 @@
                      name="start"
                      exec="/usr/sbin/chronyd"
                      timeout_seconds="60">
-            <method_context security_flags="aslr" working_directory="/">
+            <method_context security_flags="aslr"
+                            working_directory="/">
                 <method_credential user="root"
                                    group="root"
                                    privileges="basic,!file_link_any,!proc_info,!proc_session,file_chown_self,file_dac_search,file_dac_write,net_privaddr,proc_lock_memory,proc_priocntl,proc_setid,sys_time" />

--- a/build/dbus/files/dbus.xml
+++ b/build/dbus/files/dbus.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-	Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
-	Use is subject to license terms.
+        Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
+        Use is subject to license terms.
 
  CDDL HEADER START
 
@@ -24,66 +24,64 @@
 
  CDDL HEADER END
 
-	ident	"@(#)dbus.xml	1.1	06/04/24 SMI"
+        ident   "@(#)dbus.xml   1.1     06/04/24 SMI"
 
-	NOTE:  This service manifest is not editable; its contents will
-	be overwritten by package or patch operations, including
-	operating system upgrade.  Make customizations in a different
-	file.
+        NOTE:  This service manifest is not editable; its contents will
+        be overwritten by package or patch operations, including
+        operating system upgrade.  Make customizations in a different
+        file.
 
-	Service manifest for dbus.
+        Service manifest for dbus.
 -->
+<service_bundle type="manifest"
+                name="SUNWdbusr:dbus">
 
-<service_bundle type='manifest' name='SUNWdbusr:dbus'>
+    <service name="system/dbus"
+             type="service"
+             version="1">
 
-<service
-	name='system/dbus'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="true" />
 
-	<create_default_instance enabled='true' />
+        <single_instance />
 
-	<single_instance />
+        <dependency name="usr"
+                    type="service"
+                    grouping="require_all"
+                    restart_on="none">
+            <service_fmri value="svc:/system/filesystem/minimal" />
+        </dependency>
 
-	<dependency name='usr'
-		type='service'
-		grouping='require_all'
-		restart_on='none'>
-		<service_fmri value='svc:/system/filesystem/minimal' />
-	</dependency>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/svc-dbus start"
+                     timeout_seconds="30"></exec_method>
 
-	<exec_method
-		type='method'
-		name='start'
-		exec='/lib/svc/method/svc-dbus start'
-		timeout_seconds='30'>
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="30" />
 
-	<exec_method
-		type='method'
-		name='stop'
-		exec=':kill'
-		timeout_seconds='30' />
+        <property_group name="startd"
+                        type="framework">
+            <!-- sub-process core dumps should not restart session -->
+            <propval name="ignore_error"
+                     type="astring"
+                     value="core,signal" />
+        </property_group>
 
-	<property_group name='startd' type='framework'>
-		<!-- sub-process core dumps shouldn't restart session -->
-		<propval name='ignore_error' type='astring'
-		    value='core,signal' />
-	</property_group>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">D-BUS message bus</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="dbus-daemon"
+                         section="1"
+                         manpath="/usr/man" />
+            </documentation>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			D-BUS message bus
-			</loctext>
-		</common_name>
-		<documentation>
-			<manpage title='dbus-daemon' section='1' manpath='/usr/man' />
-		</documentation>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/dbus/files/dbus.xml
+++ b/build/dbus/files/dbus.xml
@@ -57,9 +57,6 @@
 		name='start'
 		exec='/lib/svc/method/svc-dbus start'
 		timeout_seconds='30'>
-		<method_context>
-			<method_credential user='root' group='root' />
-		</method_context>
 	</exec_method>
 
 	<exec_method

--- a/build/ipmitool/files/ipmievd.xml
+++ b/build/ipmitool/files/ipmievd.xml
@@ -19,91 +19,87 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 -->
-
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
     Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
     Use is subject to license terms.
 
-    ident	"@(#)ipmievd.xml	1.1	07/01/11 SMI"
+    ident       "@(#)ipmievd.xml        1.1     07/01/11 SMI"
 -->
+<service_bundle type="manifest"
+                name="SUNWipmi:ipmievd">
 
-<service_bundle type='manifest' name='SUNWipmi:ipmievd'>
+    <service name="network/ipmievd"
+             type="service"
+             version="1">
+        <!--
+          Configure a default instance for the service since it does not
+          require additional configuration intervention before it starts.
+        -->
 
-<service name='network/ipmievd' type='service' version='1'>
+        <create_default_instance enabled="false" />
+        <!--
+          Wait for all usr filesystem to be mounted. ipmievd is
+          located in /usr/lib.
+        -->
 
-	<!--
-	  Configure a default instance for the service since it doesn't
-	  require additional configuration intervention before it starts.
-	-->
-	<create_default_instance enabled='false' />
+        <dependency name="filesystem-usr"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/usr:default" />
+        </dependency>
+        <!--
+          Wait for syslog to be started in order to write system
+          messages from the kernel.
+        -->
 
-	<!--
-	  Wait for all usr filesystem to be mounted. ipmievd is
-	  located in /usr/lib.
-	-->
-	<dependency
-	    name='filesystem-usr'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-	    <service_fmri
-		value='svc:/system/filesystem/usr:default'/>
-	</dependency>
+        <dependency name="syslog"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/system-log" />
+        </dependency>
+        <!--
+          The ipmievd start/stop methods.
+        -->
 
-	<!--
-	  Wait for syslog to be started in order to write system
-	  messages from the kernel.
-	-->
-	<dependency
-	    name='syslog'
-	    grouping='require_all'
-	    restart_on='none'
-	    type='service'>
-	    <service_fmri
-		value='svc:/system/system-log'/>
-	</dependency>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/svc-ipmievd %m"
+                     timeout_seconds="60" />
 
-	<!--
-	  The ipmievd start/stop methods.
-	-->
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-		type='method'
-		name='start'
-		exec='/lib/svc/method/svc-ipmievd %m'
-		timeout_seconds='60'/>
+        <property_group name="startd"
+                        type="framework">
+            <!--
+                  Sub-process core dumps and external kill signals are not
+                  considered errors, so the service should be restarted.
+                -->
+            <propval name="ignore_error"
+                     type="astring"
+                     value="core,signal" />
+        </property_group>
 
-	<exec_method
-		type='method'
-		name='stop'
-		exec=':kill'
-		timeout_seconds='60' />
+        <stability value="Unstable" />
 
-	<property_group name='startd' type='framework'>
-		<!--
-		  Sub-process core dumps and external kill signals are not
-		  considered errors, so the service should be restarted.
-	        -->
-		<propval name='ignore_error' type='astring'
-			 value='core,signal' />
-	</property_group>
+        <template>
+            <common_name>
+                <loctext xml:lang="C">IPMI event daemon</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="ipmievd"
+                         section="8"
+                         manpath="/usr/share/man" />
+                <doc_link name="sourceforge.net"
+                          uri="http://sourceforge.net/projects/ipmitool" />
+            </documentation>
+        </template>
 
-	<stability value='Unstable' />
-
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				IPMI event daemon
-			</loctext>
-		</common_name>
-		<documentation>
-			<manpage title='ipmievd' section='8'
-				manpath='/usr/share/man' />
-			<doc_link name='sourceforge.net'
-				uri='http://sourceforge.net/projects/ipmitool' />
-		</documentation>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/isc-dhcp/files/isc-dhcp.xml
+++ b/build/isc-dhcp/files/isc-dhcp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
  CDDL HEADER START
@@ -24,209 +24,295 @@
     Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
     Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 -->
-<service_bundle type='manifest' name='isc-dhcp:server'>
+<service_bundle type="manifest"
+                name="isc-dhcp:server">
 
-<service name='network/service/dhcp' type='service' version='1'>
+    <service name="network/service/dhcp"
+             type="service"
+             version="1">
 
-	<dependency name='multi-user'
-		grouping='require_all'
-		restart_on='refresh'
-		type='service'>
-		<service_fmri value='svc:/milestone/multi-user'/>
-	</dependency>
+        <dependency name="multi-user"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependency>
 
-	<exec_method type='method' name='start'
-		exec='/lib/svc/method/isc-dhcp' timeout_seconds='60'>
-		<method_context>
-			<method_credential
-				user='dhcpserv' group='netadm'
-				privileges='basic,net_rawaccess,net_icmpaccess,net_privaddr,sys_ip_config'
-			/>
-		</method_context>
-	</exec_method>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/isc-dhcp"
+                     timeout_seconds="60">
+            <method_context>
+                <method_credential user="dhcpserv"
+                                   group="netadm"
+                                   privileges="basic,net_rawaccess,net_icmpaccess,net_privaddr,sys_ip_config" />
+            </method_context>
+        </exec_method>
 
-	<exec_method type='method' name='stop' exec=':kill'
-		timeout_seconds='60'/>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method type='method' name='refresh' exec=':true'
-		timeout_seconds='60'/>
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":true"
+                     timeout_seconds="60" />
 
-	<property_group name='firewall_context' type='com.sun,fw_definition'>
-		<propval name='name' type='astring' value='bootps'/>
-	</property_group>
-
-	<property_group name='firewall_config' type='com.sun,fw_configuration'>
-		<propval name='policy' type='astring' value='use_global'/>
-		<propval name='apply_to' type='astring' value=''/>
-		<propval name='exceptions' type='astring' value=''/>
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.value.firewall.config'/>
-	</property_group>
-
-	<property_group name='general' type='framework'>
-		<!-- to start stop dhcp services -->
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.dhcp' />
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.manage.dhcp' />
-	</property_group>
-
-	<instance name='ipv4' enabled='false'>
-		<property_group name='config' type='application'>
-			<propval name='debug' type='boolean' value='false'/>
-			<propval name='omapi_conn_limit' type='integer'
-				value='200'/>
-			<propval name='config_file' type='astring'
-				value='/etc/dhcpd.conf'/>
-			<propval name='lease_file' type='astring'
-				value='/var/db/dhcpd.leases'/>
-			<property name='listen_ifnames' type='astring' >
-				<astring_list>
-					<value_node value='' />
-				</astring_list>
-			</property>
-			<propval name='value_authorization' type='astring'
-				value='solaris.smf.value.dhcp' />
-		</property_group>
-	</instance>
-
-	<instance name='ipv6' enabled='false'>
-		<property_group name='config' type='application'>
-			<propval name='debug' type='boolean' value='false'/>
-			<propval name='omapi_conn_limit' type='integer'
-				value='200'/>
-			<propval name='config_file' type='astring'
-				value='/etc/dhcpd6.conf'/>
-			<propval name='lease_file' type='astring'
-				value='/var/db/dhcpd6.leases'/>
-			<property name='listen_ifnames' type='astring'>
-				<astring_list>
-					<value_node value='' />
-				</astring_list>
-			</property>
-			<propval name='value_authorization' type='astring'
-				value='solaris.smf.value.dhcp' />
-		</property_group>
-	</instance>
-
-	<stability value='Unstable'/>
-
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				ISC DHCP Server
-			</loctext>
-		</common_name>
-		<description>
-			<loctext xml:lang='C'>
-ISC DHCP server provides DHCP and BOOTP protocol services to network clients.
-			</loctext>
-		</description>
-		<documentation>
-			<manpage title='dhcpd' section='8'
-				manpath='/usr/share/man'/>
-		</documentation>
-	</template>
-</service>
-
-<service name='network/service/dhcrelay' type='service' version='1'>
-	<dependency name='multi-user'
-		grouping='require_all'
-		restart_on='refresh'
-		type='service'>
-		<service_fmri value='svc:/milestone/multi-user'/>
-	</dependency>
-
-	<exec_method type='method' name='start'
-		exec='/lib/svc/method/isc-dhcp' timeout_seconds='60'>
-		<method_context>
-			<method_credential user='dhcpserv' group='netadm'
-		privileges='basic,net_rawaccess,net_icmpaccess,net_privaddr,sys_ip_config'/>
-		</method_context>
-	</exec_method>
-
-	<exec_method type='method' name='stop' exec=':kill'
-		timeout_seconds='60'/>
-
-	<exec_method type='method' name='refresh' exec=':true'
-		timeout_seconds='60'/>
-
-	<property_group name='firewall_context' type='com.sun,fw_definition'>
-		<propval name='name' type='astring' value='bootps'/>
-	</property_group>
-
-	<property_group name='firewall_config' type='com.sun,fw_configuration'>
-		<propval name='policy' type='astring' value='use_global'/>
-		<propval name='apply_to' type='astring' value=''/>
-		<propval name='exceptions' type='astring' value=''/>
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.value.firewall.config'/>
-	</property_group>
-
-	<property_group name='general' type='framework'>
-		<!-- to start stop dhcp services -->
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.dhcp' />
-		<propval name='value_authorization' type='astring'
-                        value='solaris.smf.manage.dhcp' />
+        <property_group name="firewall_context"
+                        type="com.sun,fw_definition">
+            <propval name="name"
+                     type="astring"
+                     value="bootps" />
         </property_group>
 
-	<instance name='ipv4' enabled='false'>
-		<property_group name='config' type='application'>
-			<propval name='debug' type='boolean' value='false'/>
-			<propval name='append_agent_option' type='boolean'
-			    value='false'/>
-			<property name='servers' type='astring'>
-				<astring_list>
-					<value_node value=''/>
-				</astring_list>
-			</property>
-			<property name='listen_ifnames' type='astring' >
-				<astring_list>
-					<value_node value=''/>
-				</astring_list>
-			</property>
-			<propval name='value_authorization' type='astring'
-				value='solaris.smf.value.dhcp' />
-		</property_group>
-	</instance>
+        <property_group name="firewall_config"
+                        type="com.sun,fw_configuration">
+            <propval name="policy"
+                     type="astring"
+                     value="use_global" />
+            <propval name="apply_to"
+                     type="astring"
+                     value="" />
+            <propval name="exceptions"
+                     type="astring"
+                     value="" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.value.firewall.config" />
+        </property_group>
 
-	<instance name='ipv6' enabled='false'>
-		<property_group name='config' type='application'>
-			<propval name='debug' type='boolean' value='false'/>
-			<property name='receive_query_links' type='astring'>
-				<astring_list>
-					<value_node value=''/>
-				</astring_list>
-			</property>
-			<property name='forward_query_links' type='astring'>
-				<astring_list>
-					<value_node value=''/>
-				</astring_list>
-			</property>
-			<propval name='value_authorization' type='astring'
-                                value='solaris.smf.value.dhcp' />
-		</property_group>
-	</instance>
+        <property_group name="general"
+                        type="framework">
+            <!-- to start stop dhcp services -->
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.dhcp" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.dhcp" />
+        </property_group>
 
-	<stability value='Unstable'/>
+        <instance name="ipv4"
+                  enabled="false">
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-				ISC DHCP Relay
-			</loctext>
-		</common_name>
-		<description>
-			<loctext xml:lang='C'>
-ISC DHCP Relay service relays DHCP and BOOTP requests from one subnet with no DHCP server to another subnet with a DHCP server.
-			</loctext>
-		</description>
-		<documentation>
-			<manpage title='dhcrelay' section='8'
-				manpath='/usr/share/man'/>
-		</documentation>
-	</template>
-</service>
+            <property_group name="config"
+                            type="application">
+                <propval name="debug"
+                         type="boolean"
+                         value="false" />
+                <propval name="omapi_conn_limit"
+                         type="integer"
+                         value="200" />
+                <propval name="config_file"
+                         type="astring"
+                         value="/etc/dhcpd.conf" />
+                <propval name="lease_file"
+                         type="astring"
+                         value="/var/db/dhcpd.leases" />
+                <property name="listen_ifnames"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.dhcp" />
+            </property_group>
+
+        </instance>
+
+        <instance name="ipv6"
+                  enabled="false">
+
+            <property_group name="config"
+                            type="application">
+                <propval name="debug"
+                         type="boolean"
+                         value="false" />
+                <propval name="omapi_conn_limit"
+                         type="integer"
+                         value="200" />
+                <propval name="config_file"
+                         type="astring"
+                         value="/etc/dhcpd6.conf" />
+                <propval name="lease_file"
+                         type="astring"
+                         value="/var/db/dhcpd6.leases" />
+                <property name="listen_ifnames"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.dhcp" />
+            </property_group>
+
+        </instance>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">ISC DHCP Server</loctext>
+            </common_name>
+            <description>
+                <loctext xml:lang="C">ISC DHCP server provides DHCP and BOOTP
+                protocol services to network clients.</loctext>
+            </description>
+            <documentation>
+                <manpage title="dhcpd"
+                         section="8"
+                         manpath="/usr/share/man" />
+            </documentation>
+        </template>
+
+    </service>
+
+    <service name="network/service/dhcrelay"
+             type="service"
+             version="1">
+
+        <dependency name="multi-user"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependency>
+
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/isc-dhcp"
+                     timeout_seconds="60">
+            <method_context>
+                <method_credential user="dhcpserv"
+                                   group="netadm"
+                                   privileges="basic,net_rawaccess,net_icmpaccess,net_privaddr,sys_ip_config" />
+            </method_context>
+        </exec_method>
+
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
+
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":true"
+                     timeout_seconds="60" />
+
+        <property_group name="firewall_context"
+                        type="com.sun,fw_definition">
+            <propval name="name"
+                     type="astring"
+                     value="bootps" />
+        </property_group>
+
+        <property_group name="firewall_config"
+                        type="com.sun,fw_configuration">
+            <propval name="policy"
+                     type="astring"
+                     value="use_global" />
+            <propval name="apply_to"
+                     type="astring"
+                     value="" />
+            <propval name="exceptions"
+                     type="astring"
+                     value="" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.value.firewall.config" />
+        </property_group>
+
+        <property_group name="general"
+                        type="framework">
+            <!-- to start stop dhcp services -->
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.dhcp" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.dhcp" />
+        </property_group>
+
+        <instance name="ipv4"
+                  enabled="false">
+
+            <property_group name="config"
+                            type="application">
+                <propval name="debug"
+                         type="boolean"
+                         value="false" />
+                <propval name="append_agent_option"
+                         type="boolean"
+                         value="false" />
+                <property name="servers"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <property name="listen_ifnames"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.dhcp" />
+            </property_group>
+
+        </instance>
+
+        <instance name="ipv6"
+                  enabled="false">
+
+            <property_group name="config"
+                            type="application">
+                <propval name="debug"
+                         type="boolean"
+                         value="false" />
+                <property name="receive_query_links"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <property name="forward_query_links"
+                          type="astring">
+                    <astring_list>
+                        <value_node value="" />
+                    </astring_list>
+                </property>
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.dhcp" />
+            </property_group>
+
+        </instance>
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">ISC DHCP Relay</loctext>
+            </common_name>
+            <description>
+                <loctext xml:lang="C">ISC DHCP Relay service relays DHCP and
+                BOOTP requests from one subnet with no DHCP server to another
+                subnet with a DHCP server.</loctext>
+            </description>
+            <documentation>
+                <manpage title="dhcrelay"
+                         section="8"
+                         manpath="/usr/share/man" />
+            </documentation>
+        </template>
+
+    </service>
 
 </service_bundle>

--- a/build/net-snmp/files/net-snmp.xml
+++ b/build/net-snmp/files/net-snmp.xml
@@ -29,130 +29,118 @@
 
     Service manifest for the net-snmp daemon
 -->
+<service_bundle type="manifest"
+                name="SUNWnet-snmp-core:net-snmp">
 
-<service_bundle type='manifest' name='SUNWnet-snmp-core:net-snmp'>
+    <service name="application/management/net-snmp"
+             type="service"
+             version="1">
 
-<service
-	name='application/management/net-snmp'
-	type='service'
-	version='1'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <single_instance />
 
-	<single_instance />
+        <dependency name="multi-user"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependency>
+        <!-- Need / & /usr filesystems mounted, /var mounted read/write -->
 
-	<dependency
-		name='multi-user'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependency>
+        <dependency name="fs-local"
+                    type="service"
+                    grouping="require_all"
+                    restart_on="none">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
 
-	<!-- Need / & /usr filesystems mounted, /var mounted read/write -->
-	<dependency
-		name='fs-local'
-		type='service'
-		grouping='require_all'
-		restart_on='none'>
-			<service_fmri value='svc:/system/filesystem/local' />
-	</dependency>
+        <dependency name="name-services"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/name-services" />
+        </dependency>
 
-	<dependency
-		name='name-services'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/milestone/name-services' />
-	</dependency>
+        <dependency name="system-log"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/system-log" />
+        </dependency>
 
-	<dependency
-		name='system-log'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/system-log' />
-	</dependency>
+        <dependency name="rstat"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/rpc/rstat" />
+        </dependency>
 
-	<dependency
-		name='rstat'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/network/rpc/rstat' />
-	</dependency>
+        <dependency name="cryptosvc"
+                    grouping="require_all"
+                    restart_on="restart"
+                    type="service">
+            <service_fmri value="svc:/system/cryptosvc" />
+        </dependency>
 
-	<dependency name='cryptosvc'
-		grouping='require_all'
-		restart_on='restart'
-		type='service'>
-			<service_fmri value='svc:/system/cryptosvc' />
-	</dependency>
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="restart"
+                    type="service">
+            <service_fmri value="svc:/milestone/network" />
+        </dependency>
 
-	<dependency
-		name='network'
-		grouping='require_all'
-		restart_on='restart'
-		type='service'>
-			<service_fmri value='svc:/milestone/network' />
-	</dependency>
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/net-snmp/snmp/snmpd.conf" />
+        </dependency>
 
-	<dependency
-		name='config-file'
-		grouping='require_all'
-		restart_on='refresh'
-		type='path'>
-			<service_fmri
-			   value='file://localhost/etc/net-snmp/snmp/snmpd.conf' />
-	</dependency>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/svc-net-snmp"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr" />
+        </exec_method>
 
-	<exec_method
-        	type='method'
-		name='start'
-		exec='/lib/svc/method/svc-net-snmp'
-		timeout_seconds='60'>
-		<method_context security_flags='aslr' />
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-       type='method'
-	   name='stop'
-	   exec=':kill'
-	   timeout_seconds='60'>
-	</exec_method>
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60"></exec_method>
 
-	<exec_method
-	   type='method'
-	   name='refresh'
-	   exec=':kill -HUP'
-	   timeout_seconds='60'>
-	</exec_method>
+        <property_group name="general"
+                        type="framework">
+            <!-- to start/stop net-snmp -->
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.net-snmp" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.net-snmp" />
+            <propval name="arch_type"
+                     type="integer"
+                     value="0" />
+        </property_group>
 
-	<property_group name='general' type='framework'>
-		<!-- to start/stop net-snmp -->
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.net-snmp' />
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.manage.net-snmp' />
-		<propval name='arch_type' type='integer' value='0' />
-	</property_group>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">net-snmp SNMP daemon</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="snmpd"
+                         section="8"
+                         manpath="/usr/share/man/" />
+            </documentation>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			net-snmp SNMP daemon
-			</loctext>
-		</common_name>
-
-		<documentation>
-			<manpage title='snmpd' section='8'
-			    manpath='/usr/share/man/' />
-		</documentation>
-
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/ntpsec/files/ntpsec.xml
+++ b/build/ntpsec/files/ntpsec.xml
@@ -29,187 +29,164 @@
  operating system upgrade.  Make customizations in a different
  file.
 -->
+<service_bundle type="manifest"
+                name="SUNWntpr:ntp">
 
-<service_bundle type='manifest' name='SUNWntpr:ntp'>
+    <service name="network/ntp"
+             type="service"
+             version="1">
 
-<service
-	name='network/ntp'
-	type='service'
-	version='1'>
-	<single_instance />
-	<dependency
-		name='network'
-		grouping='require_any'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/service' />
-	</dependency>
+        <single_instance />
 
-	<dependency
-		name='filesystem'
-		grouping='require_all'
-		restart_on='error'
-		type='service'>
-		    <service_fmri value='svc:/system/filesystem/minimal' />
-	</dependency>
+        <dependency name="network"
+                    grouping="require_any"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/service" />
+        </dependency>
 
-	<dependency
-		name='name-services'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/milestone/name-services' />
-	</dependency>
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/minimal" />
+        </dependency>
 
-	<dependency
-		name='routing-setup'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/network/routing-setup' />
-	</dependency>
+        <dependency name="name-services"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/name-services" />
+        </dependency>
 
-	<dependency
-		name='config-file'
-		grouping='require_all'
-		restart_on='refresh'
-		type='path'>
-		<service_fmri value='file://localhost/etc/inet/ntp.conf' />
-	</dependency>
+        <dependency name="routing-setup"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/routing-setup" />
+        </dependency>
 
-	<!-- chrony/vmtoolsd also adjust the system time. Prevent ntp running
-	     at the same time. -->
-	<dependency
-		name='open-vm-tools'
-		grouping='exclude_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri
-		    value='svc:/system/virtualization/open-vm-tools:default' />
-	</dependency>
+        <dependency name="config-file"
+                    grouping="require_all"
+                    restart_on="refresh"
+                    type="path">
+            <service_fmri value="file://localhost/etc/inet/ntp.conf" />
+        </dependency>
+        <!-- chrony/vmtoolsd also adjust the system time. Prevent ntp running
+             at the same time. -->
 
-	<dependency
-		name='chrony'
-		grouping='exclude_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri
-		    value='svc:/network/chrony:default' />
-	</dependency>
+        <dependency name="open-vm-tools"
+                    grouping="exclude_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/virtualization/open-vm-tools:default" />
+        </dependency>
 
-	<exec_method
-	    type='method'
-    	    name='start'
-    	    exec='/lib/svc/method/ntpsec %m'
-    	    timeout_seconds='600'>
-		<method_context security_flags='aslr' working_directory='/'>
-			<method_credential
-			    user='root'
-			    group='root'
-			    privileges='basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time'
-			/>
-		</method_context>
-	</exec_method>
+        <dependency name="chrony"
+                    grouping="exclude_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/chrony:default" />
+        </dependency>
 
-	<exec_method
-	    type='method'
-    	    name='restart'
-    	    exec='/lib/svc/method/ntpsec %m'
-    	    timeout_seconds='1800'>
-		<method_context security_flags='aslr' working_directory='/'>
-			<method_credential
-			    user='root'
-			    group='root'
-			    privileges='basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time'
-			/>
-		</method_context>
-	</exec_method>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/ntpsec %m"
+                     timeout_seconds="600">
+            <method_context security_flags="aslr"
+                            working_directory="/">
+                <method_credential user="root"
+                                   group="root"
+                                   privileges="basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time" />
+            </method_context>
+        </exec_method>
 
-	<exec_method
-    	    type='method'
-    	    name='stop'
-    	    exec=':kill'
-    	    timeout_seconds='60' />
+        <exec_method type="method"
+                     name="restart"
+                     exec="/lib/svc/method/ntpsec %m"
+                     timeout_seconds="1800">
+            <method_context security_flags="aslr"
+                            working_directory="/">
+                <method_credential user="root"
+                                   group="root"
+                                   privileges="basic,!file_link_any,!proc_info,!proc_session,net_privaddr,proc_lock_memory,proc_priocntl,sys_time" />
+            </method_context>
+        </exec_method>
 
-	<property_group name='general' type='framework'>
-		<!-- to start stop ntpd -->
-		<propval name='action_authorization' type='astring'
-		value='solaris.smf.manage.ntp' />
-		<propval name='value_authorization' type='astring'
-		value='solaris.smf.value.ntp' />
-	</property_group>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<instance name="default" enabled="false">
-		<property_group name='config' type='application' >
-			<!-- default property settings for ntpd(8). -->
+        <property_group name="general"
+                        type="framework">
+            <!-- to start stop ntpd -->
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.ntp" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.value.ntp" />
+        </property_group>
 
-			<propval
-			    name='wait_for_sync'
-			    type='boolean'
-			    value='false' />
+        <instance name="default"
+                  enabled="false">
 
-			<propval
-			    name='wait_for_sync_tries'
-			    type='integer'
-			    value='500' />
+            <property_group name="config"
+                            type="application">
+                <!-- default property settings for ntpd(8). -->
+                <propval name="wait_for_sync"
+                         type="boolean"
+                         value="false" />
+                <propval name="wait_for_sync_tries"
+                         type="integer"
+                         value="500" />
+                <propval name="wait_for_sync_sleep"
+                         type="integer"
+                         value="3" />
+                <propval name="verbose_logging"
+                         type="boolean"
+                         value="false" />
+                <propval name="slew_always"
+                         type="boolean"
+                         value="false" />
+                <propval name="always_allow_large_step"
+                         type="boolean"
+                         value="true" />
+                <propval name="logfile"
+                         type="astring"
+                         value="/var/ntp/ntp.log" />
+                <propval name="debuglevel"
+                         type="integer"
+                         value="0" />
+                <propval name="mdnsregister"
+                         type="boolean"
+                         value="false" />
+                <!-- to change properties -->
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.ntp" />
+            </property_group>
 
-			<propval
-			    name='wait_for_sync_sleep'
-			    type='integer'
-			    value='3' />
+        </instance>
 
-			<propval
-			    name='verbose_logging'
-			    type='boolean'
-			    value='false' />
+        <stability value="Unstable" />
 
-			<propval
-			    name='slew_always'
-			    type='boolean'
-			    value='false' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Network Time Protocol (NTP) Version
+                4</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="ntpd"
+                         section="8" />
+                <manpage title="ntp.conf"
+                         section="5" />
+                <manpage title="ntpq"
+                         section="8" />
+            </documentation>
+        </template>
 
-			<propval
-			    name='always_allow_large_step'
-			    type='boolean'
-			    value='true' />
-
-			<propval
-			    name='logfile'
-			    type='astring'
-			    value='/var/ntp/ntp.log' />
-
-			<propval
-			    name='debuglevel'
-			    type='integer'
-			    value='0' />
-
-			<propval
-			    name='mdnsregister'
-			    type='boolean'
-			    value='false' />
-
-			<!-- to change properties -->
-			<propval
-			    name='value_authorization'
-			    type='astring'
-			    value='solaris.smf.value.ntp' />
-
-		</property_group>
-	</instance>
-	<stability value='Unstable' />
-
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			Network Time Protocol (NTP) Version 4
-			</loctext>
-		</common_name>
-		<documentation>
-			<manpage title='ntpd' section='8' />
-			<manpage title='ntp.conf' section='5' />
-			<manpage title='ntpq' section='8' />
-		</documentation>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/ntpsec/files/ntpsec.xml
+++ b/build/ntpsec/files/ntpsec.xml
@@ -102,7 +102,7 @@
     	    name='start'
     	    exec='/lib/svc/method/ntpsec %m'
     	    timeout_seconds='600'>
-		<method_context security_flags='aslr'>
+		<method_context security_flags='aslr' working_directory='/'>
 			<method_credential
 			    user='root'
 			    group='root'
@@ -116,7 +116,7 @@
     	    name='restart'
     	    exec='/lib/svc/method/ntpsec %m'
     	    timeout_seconds='1800'>
-		<method_context security_flags='aslr'>
+		<method_context security_flags='aslr' working_directory='/'>
 			<method_credential
 			    user='root'
 			    group='root'

--- a/build/open-vm-tools/files/open-vm-tools.xml
+++ b/build/open-vm-tools/files/open-vm-tools.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" ?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
     CDDL HEADER START
 
@@ -24,74 +24,67 @@
     All rights reserved.
     Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
 -->
+<service_bundle type="manifest"
+                name="system/virtualization/open-vm-tools">
 
-<service_bundle type="manifest" name="system/virtualization/open-vm-tools">
+    <service name="system/virtualization/open-vm-tools"
+             type="service"
+             version="1">
 
-<service
-	name="system/virtualization/open-vm-tools"
-	type="service"
-	version="1">
+        <create_default_instance enabled="true" />
 
-	<create_default_instance enabled="true" />
+        <dependency name="multi_user_dependency"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/multi-user" />
+        </dependency>
+        <!-- vmtoolsd adjusts the system time. Prevent ntp and chrony running
+             at the same time. -->
 
-	<dependency
-		name="multi_user_dependency"
-		grouping="require_all"
-		restart_on="none"
-		type="service">
-		<service_fmri value="svc:/milestone/multi-user"/>
-	</dependency>
+        <dependency name="ntpd"
+                    grouping="exclude_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/ntp:default" />
+        </dependency>
 
-	<!-- vmtoolsd adjusts the system time. Prevent ntp and chrony running
-	     at the same time. -->
-	<dependency
-		name='ntpd'
-		grouping='exclude_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri
-		    value='svc:/network/ntp:default' />
-	</dependency>
+        <dependency name="chrony"
+                    grouping="exclude_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/chrony:default" />
+        </dependency>
 
-	<dependency
-		name='chrony'
-		grouping='exclude_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri
-		    value='svc:/network/chrony:default' />
-	</dependency>
+        <exec_method type="method"
+                     name="start"
+                     exec="/usr/bin/vmtoolsd &amp;"
+                     timeout_seconds="60" />
 
-	<exec_method
-		type="method"
-		name="start"
-		exec="/usr/bin/vmtoolsd &amp;"
-		timeout_seconds="60" />
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-		type="method"
-		name="stop"
-		exec=":kill"
-		timeout_seconds="60" />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -1"
+                     timeout_seconds="60" />
+        <!-- SIGHUP -->
 
-	<exec_method
-		type="method"
-		name="refresh"
-		exec=":kill -1"
-		timeout_seconds="60" /> <!-- SIGHUP -->
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Open Virtual Machine Tools</loctext>
+            </common_name>
+            <description>
+                <loctext xml:lang="C">The Open Virtual Machine Tools project
+                aims to provide a suite of open source virtualization utilities
+                and drivers to improve the functionality and user experience of
+                virtualization. The project currently runs in guest operating
+                systems under VMware hypervisor.</loctext>
+            </description>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang="C">
-			Open Virtual Machine Tools
-			</loctext>
-		</common_name>
-		<description>
-			<loctext xml:lang="C">
-			The Open Virtual Machine Tools project aims to provide a suite of open source virtualization utilities and drivers to improve the functionality and user experience of virtualization. The project currently runs in guest operating systems under VMware hypervisor.
-			</loctext>
-		</description>
-	</template>
-</service>
+    </service>
 
 </service_bundle>

--- a/build/openlldp/files/lldpd.xml
+++ b/build/openlldp/files/lldpd.xml
@@ -54,7 +54,7 @@
 		name='start'
 		exec='/usr/lib/inet/in.lldpd'
 		timeout_seconds='60'>
-		<method_context security_flags='aslr'>
+		<method_context security_flags='aslr' working_directory='/'>
 			<method_credential
 			    user='root'
 			    group='root'

--- a/build/openlldp/files/lldpd.xml
+++ b/build/openlldp/files/lldpd.xml
@@ -25,61 +25,59 @@
  operating system upgrade.  Make customizations in a different
  file.
 -->
+<service_bundle type="manifest"
+                name="lldpd">
 
-<service_bundle type='manifest' name='lldpd'>
+    <service name="network/lldp"
+             type="service"
+             version="1">
 
-<service
-	name='network/lldp'
-	type='service'
-	version='1'>
-	<single_instance />
-	<dependency
-		name='network'
-		grouping='require_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/physical' />
-	</dependency>
+        <single_instance />
 
-	<dependency
-		name='dladm'
-		grouping='require_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/datalink-management' />
-	</dependency>
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/physical" />
+        </dependency>
 
-	<exec_method
-		type='method'
-		name='start'
-		exec='/usr/lib/inet/in.lldpd'
-		timeout_seconds='60'>
-		<method_context security_flags='aslr' working_directory='/'>
-			<method_credential
-			    user='root'
-			    group='root'
-			    privileges='basic,!file_link_any,!proc_info,!proc_session,net_rawaccess'
-			/>
-		</method_context>
-	</exec_method>
+        <dependency name="dladm"
+                    grouping="require_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/datalink-management" />
+        </dependency>
 
-	<exec_method
-		type='method'
-		name='stop'
-		exec=':kill'
-		timeout_seconds='60' />
+        <exec_method type="method"
+                     name="start"
+                     exec="/usr/lib/inet/in.lldpd"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr"
+                            working_directory="/">
+                <method_credential user="root"
+                                   group="root"
+                                   privileges="basic,!file_link_any,!proc_info,!proc_session,net_rawaccess" />
+            </method_context>
+        </exec_method>
 
-	<instance name="default" enabled="true" />
-	<stability value='Unstable' />
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			Link-layer Discovery Protocol Server
-			</loctext>
-		</common_name>
-		<documentation />
-	</template>
-</service>
+        <instance name="default"
+                  enabled="true" />
+
+        <stability value="Unstable" />
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">Link-layer Discovery Protocol
+                Server</loctext>
+            </common_name>
+            <documentation />
+        </template>
+
+    </service>
 
 </service_bundle>

--- a/build/openssh/files/ssh.xml
+++ b/build/openssh/files/ssh.xml
@@ -1,179 +1,195 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-	CDDL HEADER START
+        CDDL HEADER START
 
-	The contents of this file are subject to the terms of the
-	Common Development and Distribution License (the "License").
-	You may not use this file except in compliance with the License.
+        The contents of this file are subject to the terms of the
+        Common Development and Distribution License (the "License").
+        You may not use this file except in compliance with the License.
 
-	You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-	or http://www.opensolaris.org/os/licensing.
-	See the License for the specific language governing permissions
-	and limitations under the License.
+        You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+        or http://www.opensolaris.org/os/licensing.
+        See the License for the specific language governing permissions
+        and limitations under the License.
 
-	When distributing Covered Code, include this CDDL HEADER in each
-	file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-	If applicable, add the following below this CDDL HEADER, with the
-	fields enclosed by brackets "[]" replaced with your own identifying
-	information: Portions Copyright [yyyy] [name of copyright owner]
+        When distributing Covered Code, include this CDDL HEADER in each
+        file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+        If applicable, add the following below this CDDL HEADER, with the
+        fields enclosed by brackets "[]" replaced with your own identifying
+        information: Portions Copyright [yyyy] [name of copyright owner]
 
-	CDDL HEADER END
+        CDDL HEADER END
 
-	Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
-	Use is subject to license terms.
+        Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+        Use is subject to license terms.
 
-	Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+        Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 
-	NOTE:  This service manifest is not editable; its contents will
-	be overwritten by package or patch operations, including
-	operating system upgrade.  Make customizations in a different
-	file.
+        NOTE:  This service manifest is not editable; its contents will
+        be overwritten by package or patch operations, including
+        operating system upgrade.  Make customizations in a different
+        file.
 -->
+<service_bundle type="manifest"
+                name="SUNWsshdr:ssh">
 
-<service_bundle type='manifest' name='SUNWsshdr:ssh'>
+    <service name="network/ssh"
+             type="service"
+             version="2">
 
-<service
-	name='network/ssh'
-	type='service'
-	version='2'>
+        <create_default_instance enabled="false" />
 
-	<create_default_instance enabled='false' />
+        <single_instance />
 
-	<single_instance />
+        <dependency name="fs-minimal"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/minimal" />
+        </dependency>
 
-	<dependency name='fs-minimal'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri
-			value='svc:/system/filesystem/minimal' />
-	</dependency>
+        <dependency name="fs-autofs"
+                    grouping="optional_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/autofs" />
+        </dependency>
 
-	<dependency name='fs-autofs'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/filesystem/autofs' />
-	</dependency>
+        <dependency name="net-loopback"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/loopback" />
+        </dependency>
 
-	<dependency name='net-loopback'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/network/loopback' />
-	</dependency>
+        <dependency name="net-physical"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/network/physical" />
+        </dependency>
 
-	<dependency name='net-physical'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/network/physical' />
-	</dependency>
+        <dependency name="cryptosvc"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/cryptosvc" />
+        </dependency>
 
-	<dependency name='cryptosvc'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/cryptosvc' />
-	</dependency>
+        <dependency name="utmp"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/utmp" />
+        </dependency>
 
-	<dependency name='utmp'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/utmp' />
-	</dependency>
+        <dependency name="network_ipfilter"
+                    grouping="optional_all"
+                    restart_on="error"
+                    type="service">
+            <service_fmri value="svc:/network/ipfilter:default" />
+        </dependency>
 
-	<dependency name='network_ipfilter'
-		grouping='optional_all'
-		restart_on='error'
-		type='service'>
-		<service_fmri value='svc:/network/ipfilter:default' />
-	</dependency>
+        <dependency name="config_data"
+                    grouping="require_all"
+                    restart_on="restart"
+                    type="path">
+            <service_fmri value="file://localhost/etc/ssh/sshd_config" />
+        </dependency>
 
-	<dependency name='config_data'
-		grouping='require_all'
-		restart_on='restart'
-		type='path'>
-		<service_fmri
-		    value='file://localhost/etc/ssh/sshd_config' />
-	</dependency>
+        <dependent name="ssh_multi-user-server"
+                   grouping="optional_all"
+                   restart_on="none">
+            <service_fmri value="svc:/milestone/multi-user-server" />
+        </dependent>
 
-	<dependent
-		name='ssh_multi-user-server'
-		grouping='optional_all'
-		restart_on='none'>
-			<service_fmri
-			    value='svc:/milestone/multi-user-server' />
-	</dependent>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/sshd start"
+                     timeout_seconds="60">
+            <method_context security_flags="aslr" />
+        </exec_method>
 
-	<exec_method
-		type='method'
-		name='start'
-		exec='/lib/svc/method/sshd start'
-		timeout_seconds='60'>
-		<method_context security_flags='aslr' />
-	</exec_method>
+        <exec_method type="method"
+                     name="stop"
+                     exec=":kill"
+                     timeout_seconds="60" />
 
-	<exec_method
-		type='method'
-		name='stop'
-		exec=':kill'
-		timeout_seconds='60' />
+        <exec_method type="method"
+                     name="refresh"
+                     exec=":kill -HUP"
+                     timeout_seconds="60" />
 
-	<exec_method
-		type='method'
-		name='refresh'
-		exec=':kill -HUP'
-		timeout_seconds='60' />
+        <property_group name="startd"
+                        type="framework">
+            <!-- sub-process core dumps should not restart session -->
+            <propval name="ignore_error"
+                     type="astring"
+                     value="core,signal" />
+        </property_group>
 
-	<property_group name='startd'
-		type='framework'>
-		<!-- sub-process core dumps shouldn't restart session -->
-		<propval name='ignore_error'
-			type='astring' value='core,signal' />
-	</property_group>
+        <property_group name="general"
+                        type="framework">
+            <!-- to start stop sshd -->
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.ssh" />
+        </property_group>
 
-	<property_group name='general' type='framework'>
-		<!-- to start stop sshd -->
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.ssh' />
-	</property_group>
+        <property_group name="firewall_context"
+                        type="com.sun,fw_definition">
+            <propval name="name"
+                     type="astring"
+                     value="ssh" />
+            <propval name="ipf_method"
+                     type="astring"
+                     value="/lib/svc/method/sshd ipfilter" />
+        </property_group>
 
-	<property_group name='firewall_context' type='com.sun,fw_definition'>
-		<propval name='name' type='astring' value='ssh' />
-		<propval name='ipf_method' type='astring'
-		    value='/lib/svc/method/sshd ipfilter' />
-	</property_group>
+        <property_group name="firewall_config"
+                        type="com.sun,fw_configuration">
+            <propval name="policy"
+                     type="astring"
+                     value="use_global" />
+            <propval name="block_policy"
+                     type="astring"
+                     value="use_global" />
+            <propval name="apply_to"
+                     type="astring"
+                     value="" />
+            <propval name="apply_to_6"
+                     type="astring"
+                     value="" />
+            <propval name="exceptions"
+                     type="astring"
+                     value="" />
+            <propval name="exceptions_6"
+                     type="astring"
+                     value="" />
+            <propval name="target"
+                     type="astring"
+                     value="" />
+            <propval name="target_6"
+                     type="astring"
+                     value="" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.value.firewall.config" />
+        </property_group>
 
-	<property_group name='firewall_config' type='com.sun,fw_configuration'>
-		<propval name='policy' type='astring' value='use_global' />
-		<propval name='block_policy' type='astring'
-			value='use_global' />
-		<propval name='apply_to' type='astring' value='' />
-		<propval name='apply_to_6' type='astring' value='' />
-		<propval name='exceptions' type='astring' value='' />
-		<propval name='exceptions_6' type='astring' value='' />
-		<propval name='target' type='astring' value='' />
-		<propval name='target_6' type='astring' value='' />
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.value.firewall.config' />
-	</property_group>
+        <stability value="Unstable" />
 
-	<stability value='Unstable' />
+        <template>
+            <common_name>
+                <loctext xml:lang="C">SSH server</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="sshd"
+                         section="8"
+                         manpath="/usr/share/man" />
+            </documentation>
+        </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'>
-			SSH server
-			</loctext>
-		</common_name>
-		<documentation>
-			<manpage title='sshd' section='8' manpath='/usr/share/man' />
-		</documentation>
-	</template>
-
-</service>
+    </service>
 
 </service_bundle>

--- a/build/rsyslog/files/rsyslog.xml
+++ b/build/rsyslog/files/rsyslog.xml
@@ -26,120 +26,137 @@
     Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
     Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 -->
+<service_bundle type="manifest"
+                name="core:rsyslog">
 
-<service_bundle type='manifest' name='core:rsyslog'>
-<service name='system/system-log' type='service' version='1'>
+    <service name="system/system-log"
+             type="service"
+             version="1">
 
-<instance name='rsyslog' enabled='false'>
+        <instance name="rsyslog"
+                  enabled="false">
 
-	<dependency
-		name='milestone'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/milestone/sysconfig' />
-	</dependency>
+            <dependency name="milestone"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/milestone/sysconfig" />
+            </dependency>
 
-	<dependency
-		name='filesystem'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/filesystem/local' />
-	</dependency>
+            <dependency name="filesystem"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/local" />
+            </dependency>
 
-	<dependency
-		name='autofs'
-		grouping='optional_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/filesystem/autofs' />
-	</dependency>
+            <dependency name="autofs"
+                        grouping="optional_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/filesystem/autofs" />
+            </dependency>
 
-	<dependency
-		name='name-services'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/milestone/name-services' />
-	</dependency>
+            <dependency name="name-services"
+                        grouping="require_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/milestone/name-services" />
+            </dependency>
+            <!-- Do not allow rsyslog to run concurrently with syslog -->
 
-	<!-- Do not allow rsyslog to run concurrently with syslog -->
-	<dependency
-		name='rsyslog-exclusion'
-		grouping='exclude_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/system-log:default' />
-	</dependency>
+            <dependency name="rsyslog-exclusion"
+                        grouping="exclude_all"
+                        restart_on="none"
+                        type="service">
+                <service_fmri value="svc:/system/system-log:default" />
+            </dependency>
 
+            <dependent name="rsyslog_multi-user"
+                       grouping="optional_all"
+                       restart_on="none">
+                <service_fmri value="svc:/milestone/multi-user" />
+            </dependent>
+            <!--
+                The system-log start method includes a "savecore -m".
+                Use an appropriately long timeout value.
+        -->
 
-	<dependent
-		name='rsyslog_multi-user'
-		grouping='optional_all'
-		restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
+            <exec_method type="method"
+                         name="start"
+                         exec="/lib/svc/method/rsyslog %m"
+                         timeout_seconds="600" />
 
-	<!--
-		The system-log start method includes a "savecore -m".
-		Use an appropriately long timeout value.
-	-->
-	<exec_method
-		type='method'
-		name='start'
-		exec='/lib/svc/method/rsyslog %m'
-		timeout_seconds='600' />
+            <exec_method type="method"
+                         name="stop"
+                         exec=":kill"
+                         timeout_seconds="60" />
 
-	<exec_method
-		type='method'
-		name='stop'
-		exec=':kill'
-		timeout_seconds='60' />
+            <exec_method type="method"
+                         name="refresh"
+                         exec=":true"
+                         timeout_seconds="60" />
 
-	<exec_method
-		type='method'
-		name='refresh'
-		exec=':true'
-		timeout_seconds='60' />
+            <property_group name="general"
+                            type="framework">
+                <propval name="action_authorization"
+                         type="astring"
+                         value="solaris.smf.manage.system-log" />
+            </property_group>
 
-	<property_group name='general' type='framework'>
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.system-log' />
-	</property_group>
+            <property_group name="firewall_context"
+                            type="com.sun,fw_definition">
+                <propval name="name"
+                         type="astring"
+                         value="rsyslog" />
+            </property_group>
 
-	<property_group name='firewall_context' type='com.sun,fw_definition'>
-		<propval name='name' type='astring' value='rsyslog' />
-	</property_group>
+            <property_group name="firewall_config"
+                            type="com.sun,fw_configuration">
+                <propval name="policy"
+                         type="astring"
+                         value="use_global" />
+                <propval name="block_policy"
+                         type="astring"
+                         value="use_global" />
+                <propval name="apply_to"
+                         type="astring"
+                         value="" />
+                <propval name="apply_to_6"
+                         type="astring"
+                         value="" />
+                <propval name="exceptions"
+                         type="astring"
+                         value="" />
+                <propval name="exceptions_6"
+                         type="astring"
+                         value="" />
+                <propval name="target"
+                         type="astring"
+                         value="" />
+                <propval name="target_6"
+                         type="astring"
+                         value="" />
+                <propval name="value_authorization"
+                         type="astring"
+                         value="solaris.smf.value.firewall.config" />
+            </property_group>
 
-	<property_group name='firewall_config' type='com.sun,fw_configuration'>
-		<propval name='policy' type='astring' value='use_global' />
-		<propval name='block_policy' type='astring'
-			value='use_global' />
-		<propval name='apply_to' type='astring' value='' />
-		<propval name='apply_to_6' type='astring' value='' />
-		<propval name='exceptions' type='astring' value='' />
-		<propval name='exceptions_6' type='astring' value='' />
-		<propval name='target' type='astring' value='' />
-		<propval name='target_6' type='astring' value='' />
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.value.firewall.config' />
-	</property_group>
+            <template>
+                <common_name>
+                    <loctext xml:lang="C">rsyslog daemon</loctext>
+                </common_name>
+                <documentation>
+                    <manpage title="rsyslogd"
+                             section="8"
+                             manpath="/usr/share/man" />
+                </documentation>
+            </template>
 
-	<template>
-		<common_name>
-			<loctext xml:lang='C'> rsyslog daemon </loctext>
-		</common_name>
-		<documentation>
-			<manpage title='rsyslogd' section='8'
-				manpath='/usr/share/man' />
-		</documentation>
-	</template>
+        </instance>
 
-</instance>
+        <stability value="Unstable" />
 
-<stability value='Unstable' />
+    </service>
 
-</service>
 </service_bundle>
-

--- a/build/trousers/files/tcsd.xml
+++ b/build/trousers/files/tcsd.xml
@@ -25,82 +25,78 @@
  Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 -->
+<service_bundle type="manifest"
+                name="tcsd">
 
-<service_bundle type='manifest' name='tcsd'>
+    <service name="application/security/tcsd"
+             type="service"
+             version="1">
 
-<service
-        name='application/security/tcsd'
-        type='service'
-        version='1'>
+        <create_default_instance enabled="false" />
+        <!-- Wait for network interfaces to be initialized. -->
 
-	<create_default_instance enabled='false' />
-
-	<!-- Wait for network interfaces to be initialized. -->
-        <dependency
-                name='network'
-                grouping='require_all'
-                restart_on='none'
-                type='service'>
-                <service_fmri value='svc:/milestone/network:default' />
+        <dependency name="network"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/milestone/network:default" />
         </dependency>
+        <!-- Need / & /usr filesystems mounted, /var mounted read/write -->
 
-	<!-- Need / & /usr filesystems mounted, /var mounted read/write -->
-	<dependency
-		name='filesystem'
-		grouping='require_all'
-		restart_on='none'
-		type='service'>
-		<service_fmri value='svc:/system/filesystem/minimal' />
-	</dependency>
+        <dependency name="filesystem"
+                    grouping="require_all"
+                    restart_on="none"
+                    type="service">
+            <service_fmri value="svc:/system/filesystem/minimal" />
+        </dependency>
+        <method_context security_flags="aslr"
+                        working_directory="/">
+            <method_credential user="root"
+                               group="sys" />
+        </method_context>
 
-	<method_context security_flags='aslr' working_directory='/'>
-		<method_credential user='root' group='sys' />
-	</method_context>
+        <exec_method type="method"
+                     name="stop"
+                     exec="/lib/svc/method/tcsd stop"
+                     timeout_seconds="60"></exec_method>
 
-        <exec_method
-                type='method'
-                name='stop'
-                exec='/lib/svc/method/tcsd stop'
-                timeout_seconds='60'>
-	</exec_method>
+        <exec_method type="method"
+                     name="start"
+                     exec="/lib/svc/method/tcsd start"
+                     timeout_seconds="60"></exec_method>
 
-        <exec_method
-                type='method'
-                name='start'
-                exec='/lib/svc/method/tcsd start'
-                timeout_seconds='60'>
-	</exec_method>
-
-	<property_group name='general' type='framework'>
-		<propval name='action_authorization' type='astring'
-			value='solaris.smf.manage.tcsd' />
-		<propval name='value_authorization' type='astring'
-			value='solaris.smf.manage.tcsd' />
+        <property_group name="general"
+                        type="framework">
+            <propval name="action_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.tcsd" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.manage.tcsd" />
         </property_group>
 
+        <property_group name="config"
+                        type="application">
+            <propval name="local_only"
+                     type="boolean"
+                     value="true" />
+            <propval name="value_authorization"
+                     type="astring"
+                     value="solaris.smf.value.tcsd" />
+        </property_group>
 
-	<property_group name='config' type='application'>
-		<propval
-			name='local_only'
-			type='boolean'
-			value='true' />
-		<propval
-			name='value_authorization'
-			type='astring'
-			value='solaris.smf.value.tcsd' />
-	</property_group>
-
-        <stability value='Unstable' />
+        <stability value="Unstable" />
 
         <template>
-                <common_name>
-                        <loctext xml:lang='C'>
-                                TCS Daemon
-                        </loctext>
-                </common_name>
-                <documentation>
-                        <manpage title='tcsd' section='8' />
-                </documentation>
+            <common_name>
+                <loctext xml:lang="C">TCS Daemon</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="tcsd"
+                         section="8" />
+            </documentation>
         </template>
-</service>
+
+    </service>
+
 </service_bundle>

--- a/build/trousers/files/tcsd.xml
+++ b/build/trousers/files/tcsd.xml
@@ -53,7 +53,7 @@
 		<service_fmri value='svc:/system/filesystem/minimal' />
 	</dependency>
 
-	<method_context security_flags="aslr">
+	<method_context security_flags='aslr' working_directory='/'>
 		<method_credential user='root' group='sys' />
 	</method_context>
 

--- a/doc/tidy.conf
+++ b/doc/tidy.conf
@@ -1,0 +1,7 @@
+indent: yes
+indent-spaces: 4
+indent-attributes: yes
+wrap: 80
+wrap-attributes: yes
+output-xml: yes
+input-xml: yes

--- a/tools/tidy-manifests
+++ b/tools/tidy-manifests
@@ -1,0 +1,75 @@
+#!/bin/ksh
+
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+# This script reformats SMF manifests to a consistent style. It's not
+# necessarily anyone's preferred style, but it is consistent!
+
+PATH=/usr/bin:/usr/sbin
+
+typeset -r TIDY=/opt/ooce/bin/tidy
+typeset -r __SCRIPTDIR="${0%/*}"
+typeset -r CFG="$__SCRIPTDIR/../doc/tidy.conf"
+typeset -a ELEMENTS=(
+        '<service '
+        '<create_default_instance'
+        '<single_instance'
+        '<instance'
+        '<dependency'
+        '<dependent'
+        '<exec_method'
+        '<property_group'
+        '<template'
+        '<stability'
+        '<\/service'
+        '<\/instance'
+)
+
+function fatal {
+	print "$*" >&2
+	exit 1
+}
+
+[ -n "$1" ] || fatal "Syntax: $0 <manifest file>,..."
+[ -r "$CFG" ] || fatal "Cannot read config file $CFG"
+
+for mfst in "$@"; do
+	print "PROCESSING: $mfst"
+
+	# Tidy manifest according to doc/tidy.conf
+	$TIDY -q -config $CFG -m "$mfst" \
+	    || fatal "An error occurred processing $mfst"
+
+	# Use only double quotes in manifest
+	sed -i 's/'"'"'/"/g' "$mfst"
+
+	# Check for nested quotes
+	sed 's/[^"]//g' "$mfst" | awk '
+		length % 2 != 0 {
+			print "WARNING: line", FNR, "contains nested quotes"
+		}'
+
+	# Introduce spacing for readability between elements
+	for i in "${ELEMENTS[@]}"; do
+	    gsed -i "/$i/s/^/\n/" "$mfst" \
+	        || fatal "An error occurred processing $mfst"
+	done
+
+	# Produce de-tokenised version of the manifest suitable for validation
+	typeset tf=`mktemp`
+	sed 's/\$(\([a-zA-Z]*\))/\1/g' < "$mfst" > "$tf"
+	svccfg validate "$tf"
+	typeset -i rc=$?
+	rm -f $tf
+	((rc == 0)) || fatal "$mfst is corrupt"
+done
+


### PR DESCRIPTION
Split into three commits to make it easier to review, I have updated services that were previously starting in `/root` so that they start in `/`. We also need [illumos 16806](https://www.illumos.org/issues/16806) for a complete solution.

The last commit is the result of running `tidy-manifests` on all SMF manifests (which also checks they're still valid using `svccfg validate`). That should all just be whitespace/quote style changes.