### PR TITLE
meson-311: update to 1.5.1 (r151046)

### DIFF
--- a/build/python311/meson/build.sh
+++ b/build/python311/meson/build.sh
@@ -12,13 +12,13 @@
 # http://www.illumos.org/license/CDDL.
 # }}}
 #
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../../lib/build.sh
 
 PKG=library/python-3/meson-311
 PROG=meson
-VER=1.0.1
+VER=1.5.1
 SUMMARY="The Meson Build system"
 DESC="An open source build system meant to be both extremely fast, "
 DESC+="and, even more importantly, as user friendly as possible"

--- a/build/python311/meson/local.mog
+++ b/build/python311/meson/local.mog
@@ -8,12 +8,15 @@
 # source. A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 license COPYING license=Apache2
 
 <transform file path=usr/bin -> set pkg.depend.bypass-generate .* >
-<transform file path=$(PYTHONLIB)/vendor-packages/mesonbuild/rewriter.py$ \
+<transform file path=$(PYTHONLIB)/vendor-packages/mesonbuild/rewriter\.py$ \
+    -> set pkg.depend.bypass-generate .* >
+<transform file \
+    path=$(PYTHONLIB)/vendor-packages/mesonbuild/scripts/python_info\.py$ \
     -> set pkg.depend.bypass-generate .* >
 <transform file path=usr/bin \
     -> edit path usr/bin usr/lib/python$(PYTHONVER)/bin>

--- a/build/python311/meson/patches/compiler_def_static_linker.patch
+++ b/build/python311/meson/patches/compiler_def_static_linker.patch
@@ -1,7 +1,7 @@
-diff -wpruN '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild/compilers/compilers.py
+diff -wpruN --no-dereference '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild/compilers/compilers.py
 --- a~/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
 +++ a/mesonbuild/compilers/compilers.py	1970-01-01 00:00:00
-@@ -1067,7 +1067,7 @@ class Compiler(HoldableObject, metaclass
+@@ -1113,7 +1113,7 @@ class Compiler(HoldableObject, metaclass
  
      def get_largefile_args(self) -> T.List[str]:
          '''Enable transparent large-file-support for 32-bit UNIX systems'''
@@ -10,10 +10,10 @@ diff -wpruN '--exclude=*.orig' a~/mesonbuild/compilers/compilers.py a/mesonbuild
              # Enable large-file support unconditionally on all platforms other
              # than macOS and MSVC. macOS is now 64-bit-only so it doesn't
              # need anything special, and MSVC doesn't have automatic LFS.
-diff -wpruN '--exclude=*.orig' a~/mesonbuild/linkers/detect.py a/mesonbuild/linkers/detect.py
+diff -wpruN --no-dereference '--exclude=*.orig' a~/mesonbuild/linkers/detect.py a/mesonbuild/linkers/detect.py
 --- a~/mesonbuild/linkers/detect.py	1970-01-01 00:00:00
 +++ a/mesonbuild/linkers/detect.py	1970-01-01 00:00:00
-@@ -45,7 +45,7 @@ if T.TYPE_CHECKING:
+@@ -20,7 +20,7 @@ if T.TYPE_CHECKING:
      from ..mesonlib import MachineChoice
  
  defaults: T.Dict[str, T.List[str]] = {}


### PR DESCRIPTION
more recent `cairo` requires more recent `meson`.