### PR TITLE
Stop building OpenSSL 3 against API 1.1.1

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -43,8 +43,6 @@ LDFLAGS[base]="-shared -Wl,-z,text,-z,aslr,-z,ignore"
 declare -A OPENSSL_CONFIG_OPTS
 OPENSSL_CONFIG_OPTS="shared threads zlib"
 OPENSSL_CONFIG_OPTS+=" --prefix=$PREFIX"
-# Build with support for the previous 1.1.1 API
-OPENSSL_CONFIG_OPTS+=" --api=1.1.1"
 
 # Configure options specific to a particular arch.
 OPENSSL_CONFIG_OPTS[i386]="--libdir=$PREFIX/lib"


### PR DESCRIPTION
It's about time we stopped building OpenSSL 3 with support for the legacy
1.1.1 API enabled by default.

`16911 illumos-gate should select OpenSSL 1.x API where needed`
in gate has made this possible.

It's still possible for individual applications to opt in to the old API via
```
	CPPFLAGS+=" -DOPENSSL_API_COMPAT=10101"
```

but there are no packages in omnios-build that require this.

