### PR TITLE
python 3.11 depends on latest expat library

### DIFF
--- a/build/python311/build.sh
+++ b/build/python311/build.sh
@@ -31,7 +31,7 @@ BUILD_DEPENDS_IPS="
 RUN_DEPENDS_IPS="
     compress/bzip2
     database/sqlite-3
-    library/expat
+    library/expat@`pkg_ver expat`
     library/libffi
     library/libxml2
     library/ncurses


### PR DESCRIPTION
Fixes https://github.com/omniosorg/omnios-build/issues/3770