### PR TITLE
Use DWARFv4 by default

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -251,10 +251,7 @@ CW=$ONBLDBIN/i386/cw
 GENOFFSETS=$ONBLDBIN/genoffsets
 CTF_FLAGS=
 typeset -A CTFCFLAGS
-CTFCFLAGS[_]="-gdwarf-2"
-CTFCFLAGS[10]="-gstrict-dwarf"
-CTFCFLAGS[13]="-gstrict-dwarf"
-CTFCFLAGS[14]="-gstrict-dwarf"
+CTFCFLAGS[_]="-gdwarf-4 -gstrict-dwarf"
 GENOFFSETS_CFLAGS="
     ${CTFCFLAGS[_]}
     -_gcc=-fno-eliminate-unused-debug-symbols


### PR DESCRIPTION
Following "17091 Use DWARFv4 by default" in gate, let us do the same in userland