### PR TITLE
add dtc

### DIFF
--- a/build/dtc/build.sh
+++ b/build/dtc/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=dtc
+VER=1.7.2
+PKG=developer/dtc
+SUMMARY="Device Tree Compiler"
+DESC="$PROG - $SUMMARY"
+
+set_arch 64
+
+NO_SONAME_EXPECTED=1
+
+pre_configure() {
+    typeset arch=$1
+
+    # TODO: no debug info/SSP for shared library
+    MAKE_ARGS="
+        NO_YAML=1
+        NO_PYTHON=1
+        PREFIX=$PREFIX
+    "
+    MAKE_ARGS_WS="
+        EXTRA_CFLAGS=\"$CFLAGS ${CFLAGS[$arch]}\"
+        SHAREDLIB_LDFLAGS=\"-shared -Wl,-soname\"
+        LDFLAGS=\"-R$PREFIX/${LIBDIRS[$arch]}\"
+    "
+    MAKE_INSTALL_ARGS="
+        $MAKE_ARGS
+        LIBDIR=$PREFIX/${LIBDIRS[$arch]}/libfdt
+    "
+
+    # no configure
+    false
+}
+
+init
+download_source $PROG $PROG $VER
+patch_source
+prep_build
+build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/dtc/local.mog
+++ b/build/dtc/local.mog
@@ -1,0 +1,17 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+license GPL license=GPLv2
+
+# drop static lib
+<transform file path=.*\.a$ -> drop>
+

--- a/build/entire/entire-aarch64.pkg
+++ b/build/entire/entire-aarch64.pkg
@@ -25,6 +25,7 @@ compress/xz						O
 compress/zip						O
 compress/zstd						O
 developer/debug/mdb					O
+developer/dtc						O
 developer/dtrace					O
 developer/linker					O
 diagnostic/diskinfo					O

--- a/doc/baseline
+++ b/doc/baseline
@@ -41,6 +41,7 @@ omnios developer/debug/mdb
 omnios developer/debug/mdb/module/module-fibre-channel
 omnios developer/debug/mdb/module/module-qlc
 omnios developer/driver/ftsafe
+omnios developer/dtc
 omnios developer/dtrace
 omnios developer/dtrace/toolkit
 omnios developer/exuberant-ctags

--- a/doc/baseline.aarch64
+++ b/doc/baseline.aarch64
@@ -35,6 +35,7 @@ omnios developer/debug/ctf
 omnios developer/debug/mdb
 omnios developer/debug/mdb/module/module-fibre-channel
 omnios developer/driver/ftsafe
+omnios developer/dtc
 omnios developer/dtrace
 omnios developer/exuberant-ctags
 omnios developer/gcc14

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -17,6 +17,7 @@
 | developer/build/automake		| 1.17			| https://ftp.gnu.org/gnu/automake/
 | developer/build/gnu-make		| 4.4.1			| https://ftp.gnu.org/gnu/make/
 | developer/build/libtool		| 2.5.4			| https://www.gnu.org/software/libtool/
+| developer/dtc				| 1.7.2			| https://git.kernel.org/pub/scm/utils/dtc/dtc.git/refs/
 | developer/exuberant-ctags		| 5.8			| https://sourceforge.net/projects/ctags/files/ctags/ http://ctags.sourceforge.net/
 | developer/gcc10			| 10.5			| https://ftp.gnu.org/gnu/gcc/
 | developer/gcc13			| 13.3			| https://ftp.gnu.org/gnu/gcc/

--- a/doc/pkglist.aarch64
+++ b/doc/pkglist.aarch64
@@ -88,6 +88,7 @@ text/gnu-sed
 archiver/gnu-tar
 compress/7zip
 compress/gzip
+developer/dtc
 developer/swig
 library/glib2
 library/libxslt


### PR DESCRIPTION
We want `dtc` installed by default for `aarch64`. Moving it to `omnios-build`.

cc: @richlowe