### PR TITLE
Add aarch64 firmware package

### DIFF
--- a/build/aarch64-fw/build.sh
+++ b/build/aarch64-fw/build.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/bash
+
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+#
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+#
+
+. ../../lib/build.sh
+
+PROG=aarch64-fw
+PKG=system/firmware/aarch64
+VER=20250501
+SUMMARY="Firmware components for aarch64"
+DESC="Firmware blobs necessary for OmniOS aarch64"
+
+PKG_ARCH=aarch64
+# This is only built for aarch64
+if [ "$CLIBUILDARCH" != $PKG_ARCH ]; then
+   logmsg "$PKG is not built for this architecture"
+   exit 0
+fi
+
+# Respect environmental overrides for these to ease development.
+: ${KAYAK_SOURCE_REPO:=$OOCEGITHUB/kayak}
+: ${KAYAK_SOURCE_BRANCH:=r$RELVER}
+
+SKIP_LICENCES=Broadcom
+
+clone_source() {
+    clone_github_source kayak \
+        "$KAYAK_SOURCE_REPO" "$KAYAK_SOURCE_BRANCH" "$KAYAK_CLONE"
+
+    gdir=$TMPDIR/$BUILDDIR/kayak
+    VER=$REVSTAMP
+    VERHUMAN="${COMMIT:0:7} from $REVDATE"
+    ((EXTRACT_MODE)) && exit
+    append_builddir kayak
+}
+
+MAKE_ARGS=rpi-bins
+
+set_crossgcc() { false; }
+pre_configure() { false; }
+
+make_install() {
+    set -eE; trap 'logerr Installation failed at $BASH_LINENO' ERR
+
+    typeset fw=$DESTDIR/usr/share/firmware
+    typeset lic=$TMPDIR/licences
+
+    $RM -rf $lic/
+    $MKDIR -p $fw/ $lic/
+
+    logmsg "-- installing licences"
+    $CP bin/u-boot.licences/gpl-2.0.txt $lic/
+    $CP bin/bl31.licence $lic/
+    $CP bin/rpi-firmware/boot/COPYING.linux $lic/
+    $CP bin/rpi-firmware/boot/LICENCE.broadcom $lic/
+
+    logmsg "-- installing QEMU,virt firmware"
+    tgt=$fw/QEMU,virt
+    $MKDIR -p $tgt
+    $CP bin/u-boot.qemu_arm64_defconfig $tgt/u-boot.bin
+
+    logmsg "-- installing RaspberryPi,4 firmware"
+    tgt=$fw/RaspberryPi,4
+    $MKDIR -p $tgt/overlays
+    $CP bin/u-boot.rpi_4_defconfig $tgt/u-boot.bin
+    $CP bin/bl31.bin $tgt/
+    for f in \
+        bootcode.bin \
+        fixup4cd.dat \
+        start4cd.elf \
+        bcm2711-rpi-4-b.dtb \
+        bcm2712-rpi-5-b.dtb
+    do
+        $CP bin/rpi-firmware/boot/$f $tgt/
+    done
+    $CP bin/rpi-firmware/boot/overlays/* $tgt/overlays
+
+    set +eE; trap - ERR
+}
+
+init
+prep_build
+clone_source
+build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/aarch64-fw/local.mog
+++ b/build/aarch64-fw/local.mog
@@ -1,0 +1,18 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
+
+license ../licences/gpl-2.0.txt license=GPLv2
+license ../licences/bl31.licence license=MIT
+license ../licences/COPYING.linux license=GPLv2/rpifw
+license ../licences/LICENCE.broadcom license=Broadcom
+<transform file -> set mode 0444>
+

--- a/build/entire/entire-aarch64.pkg
+++ b/build/entire/entire-aarch64.pkg
@@ -217,6 +217,7 @@ system/data/hardware-registry
 system/extended-system-utilities			O
 system/file-system/autofs				O
 system/file-system/udfs					O
+system/firmware/aarch64					SZ
 system/flash/fwflash					OS
 system/fru-id
 system/fru-id/platform

--- a/build/gfx-drm/build.sh
+++ b/build/gfx-drm/build.sh
@@ -46,9 +46,6 @@ clone_source() {
     clone_github_source $PROG \
         "$GFX_DRM_SOURCE_REPO" "$GFX_DRM_SOURCE_BRANCH" "$GFX_DRM_CLONE"
 
-    GITREV=`$GIT -C $WORKDIR log -1  --format=format:%at`
-    COMMIT=`$GIT -C $WORKDIR log -1  --format=format:%h`
-    REVDATE=`echo $GITREV | gawk '{ print strftime("%c %Z",$1) }'`
     VERHUMAN="${COMMIT:0:7} from $REVDATE"
     ((EXTRACT_MODE)) && exit
 }

--- a/build/kayak-kernel/build.sh
+++ b/build/kayak-kernel/build.sh
@@ -71,11 +71,6 @@ fi
 clone_source() {
     clone_github_source kayak \
         "$KAYAK_SOURCE_REPO" "$KAYAK_SOURCE_BRANCH" "$KAYAK_CLONE"
-
-    gdir=$TMPDIR/$BUILDDIR/kayak
-    GITREV=`$GIT -C $gdir log -1  --format=format:%at`
-    COMMIT=`$GIT -C $gdir log -1  --format=format:%h`
-    REVDATE=`echo $GITREV | gawk '{ print strftime("%c %Z",$1) }'`
     VERHUMAN="${COMMIT:0:7} from $REVDATE"
     ((EXTRACT_MODE)) && exit
 }

--- a/build/kayak/build.sh
+++ b/build/kayak/build.sh
@@ -38,11 +38,6 @@ RUN_DEPENDS_IPS="
 clone_source() {
     clone_github_source kayak \
         "$KAYAK_SOURCE_REPO" "$KAYAK_SOURCE_BRANCH" "$KAYAK_CLONE"
-
-    gdir=$TMPDIR/$BUILDDIR/kayak
-    GITREV=`$GIT -C $gdir log -1  --format=format:%at`
-    COMMIT=`$GIT -C $gdir log -1  --format=format:%h`
-    REVDATE=`echo $GITREV | gawk '{ print strftime("%c %Z",$1) }'`
     VERHUMAN="${COMMIT:0:7} from $REVDATE"
     ((EXTRACT_MODE)) && exit
 }

--- a/doc/baseline.aarch64
+++ b/doc/baseline.aarch64
@@ -509,6 +509,7 @@ omnios system/file-system/smb
 omnios system/file-system/udfs
 omnios system/file-system/zfs
 omnios system/file-system/zfs/tests
+omnios system/firmware/aarch64
 omnios system/flash/fwflash
 omnios system/fru-id
 omnios system/fru-id/platform

--- a/doc/pkglist.aarch64
+++ b/doc/pkglist.aarch64
@@ -202,6 +202,7 @@ library/python-3/pyopenssl-313
 illumos-gate
 package/pkg
 entire
+aarch64-fw
 ###############################################################################
 .SYSROOT
 security/sudo

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1588,6 +1588,11 @@ clone_github_source() {
 
     ((EXTRACT_MODE == 1 && dependency == 0)) && exit
 
+    GITREV=`$GIT -C $prog log -1  --format=format:%at`
+    COMMIT=`$GIT -C $prog log -1  --format=format:%h`
+    REVSTAMP=`echo $GITREV | $AWK '{ print strftime("%Y%m%d",$1) }'`
+    REVDATE=`echo $GITREV | $AWK '{ print strftime("%c %Z",$1) }'`
+
     popd > /dev/null
 }
 
@@ -1994,6 +1999,7 @@ make_package_impl() {
         pkgmeta pkg.description     "$DESCSTR"
         pkgmeta publisher           "$PUBLISHER_EMAIL"
         pkgmeta pkg.human-version   "$VERHUMAN"
+        [ -n "$PKG_ARCH" ] && pkgmeta variant.arch $PKG_ARCH
         [ $legacy -eq 1 ] && pkgmeta pkg.legacy true
         if [[ $_ARC_SOURCE = *\ * ]]; then
             _asindex=0


### PR DESCRIPTION
This delivery firmware files to `/usr/share/firmare/<arch>` on aarch64 so that `bootadm` can keep them up-to-date in the boot partition.