### PR TITLE
libxml2: re-enable HTTP/libz/lzma support

### DIFF
--- a/build/libxml2/build.sh
+++ b/build/libxml2/build.sh
@@ -34,6 +34,9 @@ CONFIGURE_OPTS+="
     --disable-static
     --without-python
     --with-legacy
+    --with-lzma
+    --with-zlib
+    --with-http
 "
 
 TESTSUITE_FILTER="^(Total|[Tt]esting|Ran)"


### PR DESCRIPTION
These were on by default in earlier versions of libxml2