### PR TITLE
Sudo: update to 1.9.17p1

### DIFF
--- a/build/sudo/build.sh
+++ b/build/sudo/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=sudo
-VER=1.9.17
+VER=1.9.17p1
 PKG=security/sudo
 SUMMARY="Authority delegation tool"
 DESC="Provide limited super-user privileges to specific users"

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -83,7 +83,7 @@
 | runtime/python-311			| 3.11.12		| https://www.python.org/downloads/source/
 | runtime/python-312			| 3.12.10		| https://www.python.org/downloads/source/
 | runtime/python-313			| 3.13.5		| https://www.python.org/downloads/source/
-| security/sudo				| 1.9.17		| https://www.sudo.ws/
+| security/sudo				| 1.9.17p1		| https://www.sudo.ws/
 | service/network/chrony		| 4.7			| https://github.com/mlichvar/chrony/tags https://chrony-project.org/
 | service/network/ntpsec		| 1.2.4			| https://github.com/ntpsec/ntpsec/tags https://blog.ntpsec.org/
 | service/network/smtp/dma		| 0.14			| https://github.com/corecode/dma/tags


### PR DESCRIPTION
CVE: https://www.stratascale.com/vulnerability-alert-CVE-2025-32463-sudo-chroot

NOTE: I was unable to run a test-build, as:

```
szilard@build:~/projekt/omnios-build/build/sudo% ./build.sh -M /tmp
-- Will retrieve files from /tmp
--- Python3 mediator is set incorrectly (3.12)
An Error occured in the build. Do you wish to continue anyway? (y/n) y
===== User elected to continue after prompt. =====
===== Build started at Tue Jul  1 07:02:38 UTC 2025 =====
Package name: security/sudo
Selected flavor: None (use -f to specify a flavor)
Selected build arch: amd64
Extra dependency: None (use -d to specify a version)
Verifying dependencies
Checking for source directory
--- Source directory not found
Checking for sudo source archive
--- Found sudo-1.9.17p1.tar.gz
Extracting archive: sudo-1.9.17p1.tar.gz
--- Unable to extract archive.
An Error occured in the build. Do you wish to continue anyway? (y/n) git status
Do you wish to continue anyway? (y/n) n
===== Build aborted =====
Time: security/sudo - 0h0m13s
```