### PR TITLE
Build xz with XPG6

### DIFF
--- a/build/xz/build.sh
+++ b/build/xz/build.sh
@@ -26,6 +26,7 @@ DESC+="high compression ratio"
 SKIP_LICENCES=xz
 
 forgo_isaexec
+set_standard XPG6
 
 post_configure() {
     logcmd gmake -C $TMPDIR/$BUILDDIR/src/liblzma foo


### PR DESCRIPTION
The recent update to gettext has pulled in
https://github.com/autotools-mirror/gettext/commit/ec07a48b8fd1939b62d03
which rejects the illumos libc gettext implementation in favour of that
within libintl.so, which requires the post-SUSv3 iconv prototypes.
