### PR TITLE
gcc15: build objects with DWARF4

### DIFF
--- a/build/gcc15/build.sh
+++ b/build/gcc15/build.sh
@@ -119,12 +119,15 @@ CONFIGURE_OPTS="
 "
 CONFIGURE_OPTS[WS]="
     --with-boot-ldflags=\"-R$OPT/lib\"
-    --with-boot-cflags=\"-O2\"
     --with-pkgversion=\"$DISTRO $RELVER/$VER-$ILVER\"
     --with-bugurl=$HOMEURL/about/contact
 "
 LDFLAGS="-R$OPT/lib"
 CPPFLAGS+=" -D_TS_ERRNO"
+MAKE_ARGS_WS="
+    BOOT_CFLAGS=\"$CTF_CFLAGS\"
+    CFLAGS_FOR_TARGET=\"$CTF_CFLAGS\"
+"
 
 # gcc uses posix_fallocate() to extend temporary files on disk.
 # Although OmniOS has the posix_fallocate() function, ZFS does not support it.


### PR DESCRIPTION
Without this some supporting objects such as libgcc_s end up with DWARFv5 and our CTF tools cannot deal with it