### PR TITLE
openssl - update from 3.6.2 to 3.6.3 (r151058)

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.6.2
+VER=3.6.3
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "


### PR DESCRIPTION
openssl - update from 3.6.2 to 3.6.3 (r151058)
