### PR TITLE
perl: Link XS modules through the gcc driver

### DIFF
--- a/build/perl/build.sh
+++ b/build/perl/build.sh
@@ -76,7 +76,7 @@ configure_amd64() {
         -Dcf_by=$DISTRO_LC-builder \
         -Dcf_email=$PUBLISHER_EMAIL \
         -Dcc=gcc \
-        -Dld=/usr/ccs/bin/ld \
+        -Dld=gcc \
         -Doptimize="-O3 $CTF_CFLAGS" \
         -Dprefix=${PREFIX} \
         -Dvendorprefix=${PREFIX} \


### PR DESCRIPTION
Link XS modules through the gcc driver rather than calling the illumos linker
directly. gcc still drives /usr/bin/ld underneath, but it also adds libgcc to
the link in the correct position. Without this, any libgcc helper a module
references (e.g. __udivti3) is left as an undefined symbol that cannot be
resolved at runtime. The aarch64 configuration already links modules with gcc
for the same reason.
