### PR TITLE
openjdk21 - Fix IPv6 (#3871)

### DIFF
--- a/build/openjdk21/patches/fix-ipv6.patch
+++ b/build/openjdk21/patches/fix-ipv6.patch
@@ -1,0 +1,12 @@
+--- jdk21u-jdk-21.0.6-7/src/java.base/unix/native/libnet/net_util_md.c.orig	2025-03-09 12:46:00.190813687 +0100
++++ jdk21u-jdk-21.0.6-7/src/java.base/unix/native/libnet/net_util_md.c	2025-03-09 13:04:33.720866346 +0100
+@@ -233,7 +233,9 @@
+          */
+         return JNI_FALSE;
+     }
++#ifndef __solaris__
+     close(fd);
++#endif
+ 
+     /**
+      * Linux - check if any interface has an IPv6 address.

--- a/build/openjdk21/patches/series
+++ b/build/openjdk21/patches/series
@@ -37,3 +37,4 @@ tribblix-flags-ldflags3.patch -p0
 xattrs.patch
 omnios-headless.patch
 fontpath.patch
+fix-ipv6.patch


### PR DESCRIPTION
IPv6_supported() would always return false because a file descriptor was closed too soon.